### PR TITLE
Labor Admin Overload Visibility #issue306

### DIFF
--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -41,12 +41,12 @@ def allPendingForms(formType):
         pageTitle = ""
         approvalTarget = ""
         completedOverloadFormCounter = 0
-        laborStatusFormCounter = FormHistory.select().where((FormHistory.status == 'Pending') & (FormHistory.historyType == 'Labor Status Form')).count()
+        laborStatusFormCounter = FormHistory.select().where(((FormHistory.status == "Pending")|(FormHistory.status == 'Pre-Student Approval')) & (FormHistory.historyType == 'Labor Status Form')).count()
         adjustedFormCounter = FormHistory.select().where((FormHistory.status == 'Pending') & (FormHistory.historyType == 'Labor Adjustment Form')).count()
         releaseFormCounter = FormHistory.select().where((FormHistory.status == 'Pending') & (FormHistory.historyType == 'Labor Release Form')).count()
 
         if currentUser.isLaborAdmin:
-            overloadFormCounter = FormHistory.select().where((FormHistory.status == 'Pending') & (FormHistory.historyType == 'Labor Overload Form')).count()
+            overloadFormCounter = FormHistory.select().where(((FormHistory.status == 'Pending')|(FormHistory.status == 'Pre-Student Approval')) & (FormHistory.historyType == 'Labor Overload Form')).count()
         elif currentUser.isFinancialAidAdmin:
             overloadFormCounter = FormHistory.select().join_from(FormHistory, OverloadForm)\
                                              .where((FormHistory.status == 'Pending') & (FormHistory.historyType == 'Labor Overload Form'))\
@@ -92,7 +92,7 @@ def allPendingForms(formType):
         if currentUser.isFinancialAidAdmin:
             if formType == "pendingOverload":
                 formList = FormHistory.select().join_from(FormHistory, OverloadForm)\
-                                      .where(FormHistory.status == 'Pending')\
+                                      .where((FormHistory.status == 'Pending'))\
                                       .where(FormHistory.historyType == "Labor Overload Form")\
                                       .where((FormHistory.overloadForm.financialAidApproved == 'Pending') | (FormHistory.overloadForm.financialAidApproved == None))\
                                       .order_by(-FormHistory.createdDate).distinct()
@@ -116,14 +116,14 @@ def allPendingForms(formType):
                                       .order_by(-FormHistory.createdDate).distinct()
 
         if currentUser.isLaborAdmin:
-            formList = FormHistory.select().where(FormHistory.status == "Pending").where(FormHistory.historyType == historyType).order_by(-FormHistory.createdDate).distinct()
+            formList = FormHistory.select().where((FormHistory.status == "Pending")|(FormHistory.status == 'Pre-Student Approval')).where(FormHistory.historyType == historyType).order_by(-FormHistory.createdDate).distinct()
         # only if a form is adjusted
         pendingOverloadFormPairs = {}
         # or allForms.adjustedForm.fieldAdjusted == "Weekly Hours":
         for allForms in formList:
             if allForms.historyType.historyTypeName == "Labor Status Form" or (allForms.historyType.historyTypeName == "Labor Adjustment Form" and allForms.adjustedForm.fieldAdjusted == "weeklyHours"):
                 try:
-                    overloadForm = FormHistory.select().where((FormHistory.formID == allForms.formID) & (FormHistory.historyType == "Labor Overload Form") & (FormHistory.status == "Pending")).get()
+                    overloadForm = FormHistory.select().where((FormHistory.formID == allForms.formID) & (FormHistory.historyType == "Labor Overload Form") & ((FormHistory.status == "Pending") | (FormHistory.status == "Pre-Student Approval"))).get()
                     if overloadForm:
                         pendingOverloadFormPairs[allForms.formHistoryID] = overloadForm.formHistoryID
                 except DoesNotExist:
@@ -425,10 +425,11 @@ def getOverloadModalData(formHistoryID):
             SAASApprover = None
 
         try:
-            currentPendingForm = FormHistory.select().where((FormHistory.formID == historyForm[0].formID) & (FormHistory.status == "Pending")).get()
+            currentPendingForm = FormHistory.select().where((FormHistory.formID == historyForm[0].formID) & ((FormHistory.status == "Pending") | (FormHistory.status == "Pre-Student Approval"))).get()
             if currentPendingForm:
                 pendingForm = True
                 pendingFormType = currentPendingForm.historyType.historyTypeName
+                status = currentPendingForm.status.statusName
         except (AttributeError, IndexError):
             pendingForm = False
             pendingFormType = False
@@ -450,7 +451,8 @@ def getOverloadModalData(formHistoryID):
                                             noteTotal = noteTotal,
                                             pendingForm = pendingForm,
                                             pendingFormType = pendingFormType,
-                                            formType = globalFormType
+                                            formType = globalFormType,
+                                            status = status
                                             )
     except Exception as e:
         print("Error Populating Overload Modal:", e)
@@ -649,7 +651,7 @@ def modalFormUpdate():
 @admin.route('/admin/sendVerificationEmail', methods=['POST'])
 def sendEmail():
     """
-    This method will send an email to either SAAS or Financial Aid
+    This method will send an email to either SAAS, Financial Aid or Student
     """
     try:
         rsp = eval(request.data.decode("utf-8"))
@@ -657,22 +659,28 @@ def sendEmail():
             historyForm = FormHistory.get(FormHistory.formHistoryID == rsp['formHistoryID'])
             overloadForm = OverloadForm.get(OverloadForm.overloadFormID == historyForm.overloadForm)
             status = Status.get(Status.statusName == 'Pending')
-            if rsp['emailRecipient'] == 'SAASEmail':
-                recipient = 'SAAS'
-                overloadForm.SAASApproved = status.statusName
-                overloadForm.save()
-            elif rsp['emailRecipient'] == 'financialAidEmail':
-                recipient = 'Financial Aid'
-                overloadForm.financialAidApproved = status.statusName
-                overloadForm.save()
-            link = 'http://{0}/'.format(request.host) + 'admin/financialAidOverloadApproval/' + str(rsp['formHistoryID'])
-            email = emailHandler(historyForm.formHistoryID)
-            email.overloadVerification(recipient, link)
+            if rsp['emailRecipient'] == 'studentEmail':
+                recipient ="Student"
+                email = emailHandler(historyForm.formHistoryID)
+                email.laborOverloadFormStudentReminder("http://{0}/".format(request.host) + "studentOverloadApp/" + str(rsp['formHistoryID']))
+
+            else:
+                if rsp['emailRecipient'] == 'SAASEmail':
+                    recipient = 'SAAS'
+                    overloadForm.SAASApproved = status.statusName
+                    overloadForm.save()
+                elif rsp['emailRecipient'] == 'financialAidEmail':
+                    recipient = 'Financial Aid'
+                    overloadForm.financialAidApproved = status.statusName
+                    overloadForm.save()
+                link = 'http://{0}/'.format(request.host) + 'admin/financialAidOverloadApproval/' + str(rsp['formHistoryID'])
+                email = emailHandler(historyForm.formHistoryID)
+                email.overloadVerification(recipient, link)
             currentDate = datetime.now().strftime('%m/%d/%y')
             newEmailInformation = {'recipient': recipient,
                                     'emailDate': currentDate,
                                     'status': 'Pending'
-            }
+                                    }
             return jsonify(newEmailInformation)
     except Exception as e:
         print("Error sending verification email to SASS/Financial Aid:", e)

--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -42,7 +42,7 @@ def allPendingForms(formType):
         approvalTarget = ""
         completedOverloadFormCounter = 0
         laborStatusFormCounter = FormHistory.select().where(((FormHistory.status == "Pending")|(FormHistory.status == 'Pre-Student Approval')) & (FormHistory.historyType == 'Labor Status Form')).count()
-        adjustedFormCounter = FormHistory.select().where((FormHistory.status == 'Pending') & (FormHistory.historyType == 'Labor Adjustment Form')).count()
+        adjustedFormCounter = FormHistory.select().where(((FormHistory.status == 'Pending')|(FormHistory.status == 'Pre-Student Approval')) & (FormHistory.historyType == 'Labor Adjustment Form')).count()
         releaseFormCounter = FormHistory.select().where((FormHistory.status == 'Pending') & (FormHistory.historyType == 'Labor Release Form')).count()
 
         if currentUser.isLaborAdmin:

--- a/app/logic/emailHandler.py
+++ b/app/logic/emailHandler.py
@@ -197,6 +197,10 @@ class emailHandler():
         self.link = link
         self.checkRecipient("Labor Overload Form Submitted For Student",
                       "Labor Overload Form Submitted For Supervisor")
+    def laborOverloadFormStudentReminder(self,link):
+        self.link = link
+        self.checkRecipient("Labor Overload Form Submitted For Student")
+
     def LaborOverLoadFormSubmittedNotification(self):
         """
         Emails that will be sent after the student has submitted their

--- a/app/static/js/allPendingForms.js
+++ b/app/static/js/allPendingForms.js
@@ -11,13 +11,10 @@ $(document).ready(function() {
 
   if ($('#overloadTab').hasClass('active') || $('#releaseTab').hasClass('active') || $('#completedOverloadTab').hasClass('active')) {
     targetsList = [9]
-    console.log(targetsList);
   } else if ($('#adjustedTab').hasClass('active')) {
     targetsList = [0, 10]
-    console.log("here", targetsList);
   } else {
     targetsList = [0, 9]
-    console.log("here", targetsList);
   }
   // If overload tab has been clicked, then we
   table = $('#pendingForms, #statusForms, #adjustedForms, #releaseForms').DataTable({

--- a/app/static/js/allPendingForms.js
+++ b/app/static/js/allPendingForms.js
@@ -10,11 +10,14 @@ $(document).ready(function() {
   // ordering functionality on different headers
 
   if ($('#overloadTab').hasClass('active') || $('#releaseTab').hasClass('active') || $('#completedOverloadTab').hasClass('active')) {
-    targetsList = [8]
+    targetsList = [9]
+    console.log(targetsList);
   } else if ($('#adjustedTab').hasClass('active')) {
     targetsList = [0, 10]
+    console.log("here", targetsList);
   } else {
     targetsList = [0, 9]
+    console.log("here", targetsList);
   }
   // If overload tab has been clicked, then we
   table = $('#pendingForms, #statusForms, #adjustedForms, #releaseForms').DataTable({

--- a/app/static/js/allPendingForms.js
+++ b/app/static/js/allPendingForms.js
@@ -9,9 +9,11 @@ $(document).ready(function() {
   // If the overload tab has been selected, then we need to restrict the
   // ordering functionality on different headers
 
-  if ($('#overloadTab').hasClass('active') || $('#releaseTab').hasClass('active') || $('#completedOverloadTab').hasClass('active')) {
+  if  ($('#releaseTab').hasClass('active') || $('#completedOverloadTab').hasClass('active')) {
+    targetsList = [8]
+  } else if ($('#overloadTab').hasClass('active')) {
     targetsList = [9]
-  } else if ($('#adjustedTab').hasClass('active')) {
+  }else if ($('#adjustedTab').hasClass('active')) {
     targetsList = [0, 10]
   } else {
     targetsList = [0, 9]

--- a/app/templates/admin/allPendingForms.html
+++ b/app/templates/admin/allPendingForms.html
@@ -106,9 +106,11 @@
                   </td>
                 {% endif %}
               {% endif %}
+              {% if formType == "pendingOverload" %}
               <td> {# Status #}
                 {{allForms.status}}
               </td>
+              {% endif %}
               <td> {# TERM #}
                 {{allForms.formID.termCode.termName}}
               </td>

--- a/app/templates/admin/allPendingForms.html
+++ b/app/templates/admin/allPendingForms.html
@@ -63,7 +63,7 @@
           <!-- Made empty header tags because we need to hide the header -->
           <thead id="headTable" text-align="center">
             <tr id="tableHeaders" class="tableHeaders">
-              {% if formType != "pendingOverload" and formType != "pendingRelease" and formType !="completedOverload" %}
+              {% if formType != "pendingRelease" and formType !="completedOverload" %}
               <th> Approve <input type="checkbox" id="checkAll"/></th>
               {% endif %}
               <th>Term</th>
@@ -86,7 +86,7 @@
             <!--  -->
             {% for allForms in formList %}
             <tr id="tableData" class="tableData" align="center">
-              {% if formType != "pendingOverload" and formType != "pendingRelease" and formType !="completedOverload" %}
+              {% if formType != "pendingRelease" and formType !="completedOverload" %}
                 {% if allForms.formHistoryID in pendingOverloadFormPairs %}
                   <td> {# REDIRECT #}
                     {% with modalTarget = modalTarget %}
@@ -99,7 +99,11 @@
                   </td>
                 {% else %}
                   <td> {# APPROVE #}
+                    {% if formType == "pendingOverload" %}
+                    {{allForms.status}}
+                    {% else %}
                     <input class="approveCheckbox" type='checkbox' id='chk_{{allForms.formHistoryID}}' value="{{allForms.formHistoryID}}" name="check[]" autocomplete="off" />
+                    {% endif %}
                   </td>
                 {% endif %}
               {% endif %}

--- a/app/templates/admin/allPendingForms.html
+++ b/app/templates/admin/allPendingForms.html
@@ -63,8 +63,11 @@
           <!-- Made empty header tags because we need to hide the header -->
           <thead id="headTable" text-align="center">
             <tr id="tableHeaders" class="tableHeaders">
-              {% if formType != "pendingRelease" and formType !="completedOverload" %}
+              {% if formType != "pendingOverload" and formType != "pendingRelease" and formType !="completedOverload" %}
               <th> Approve <input type="checkbox" id="checkAll"/></th>
+              {% endif %}
+              {% if formType == "pendingOverload" %}
+              <th> Status </th>
               {% endif %}
               <th>Term</th>
               <th>Department</th>
@@ -86,7 +89,7 @@
             <!--  -->
             {% for allForms in formList %}
             <tr id="tableData" class="tableData" align="center">
-              {% if formType != "pendingRelease" and formType !="completedOverload" %}
+              {% if formType != "pendingOverload" and formType != "pendingRelease" and formType !="completedOverload" %}
                 {% if allForms.formHistoryID in pendingOverloadFormPairs %}
                   <td> {# REDIRECT #}
                     {% with modalTarget = modalTarget %}
@@ -99,14 +102,13 @@
                   </td>
                 {% else %}
                   <td> {# APPROVE #}
-                    {% if formType == "pendingOverload" %}
-                    {{allForms.status}}
-                    {% else %}
                     <input class="approveCheckbox" type='checkbox' id='chk_{{allForms.formHistoryID}}' value="{{allForms.formHistoryID}}" name="check[]" autocomplete="off" />
-                    {% endif %}
                   </td>
                 {% endif %}
               {% endif %}
+              <td> {# Status #}
+                {{allForms.status}}
+              </td>
               <td> {# TERM #}
                 {{allForms.formID.termCode.termName}}
               </td>

--- a/app/templates/snips/pendingOverloadModal.html
+++ b/app/templates/snips/pendingOverloadModal.html
@@ -39,7 +39,7 @@
 
             {% if status == "Pending" %}
             <dt class="col-sm-4">Overload Reason</dt>
-            <dd class="col-sm-8">{{form.overloadForm.studentOverloadReason}}</dd>/strong></dd>
+            <dd class="col-sm-8">{{form.overloadForm.studentOverloadReason}}</dd>
             {% elif status == "Pre-Student Approval" %}
             <dd style="text-align: left; color: red;"><strong> *The student has not completed their approval form*</strong></dd>
             {% endif %}

--- a/app/templates/snips/pendingOverloadModal.html
+++ b/app/templates/snips/pendingOverloadModal.html
@@ -37,9 +37,14 @@
             <dt class="col-sm-4">Department</dt>
             <dd class="col-sm-8">{{form.formID.department.DEPT_NAME}}</dd>
 
+            {% if status == "Pending" %}
             <dt class="col-sm-4">Overload Reason</dt>
-            <dd class="col-sm-8">{{form.overloadForm.studentOverloadReason}}</dd>
+            <dd class="col-sm-8">{{form.overloadForm.studentOverloadReason}}</dd>/strong></dd>
+            {% elif status == "Pre-Student Approval" %}
+            <dd style="text-align: left; color: red;"><strong> *The student has not completed their approval form*</strong></dd>
+            {% endif %}
           </dl>
+
         {% endfor %}
         </div>
         <div class="row col-sm-2" id="notes" align="right">
@@ -57,7 +62,7 @@
     </div>
   </div>
 
-  {% if (currentUser.isLaborAdmin and currentUser.isFinancialAidAdmin and departmentStatusInfo['financialAidStatus']) or (currentUser.isLaborAdmin and currentUser.isSaasAdmin and departmentStatusInfo['SAASStatus']) or (currentUser.isLaborAdmin and not currentUser.isFinancialAidAdmin and not currentUser.isSaasAdmin) %}
+  {% if ((currentUser.isLaborAdmin and currentUser.isFinancialAidAdmin and departmentStatusInfo['financialAidStatus']) or (currentUser.isLaborAdmin and currentUser.isSaasAdmin and departmentStatusInfo['SAASStatus']) or (currentUser.isLaborAdmin and not currentUser.isFinancialAidAdmin and not currentUser.isSaasAdmin)) and status == "Pending" %}
   <table id="overloadDepartmentTable" class="table table-bordered">
     <thead>
       <tr>
@@ -84,7 +89,7 @@
   </table>
   {% endif %}
 
-  {% if formType != "completedOverload" %}
+  {% if formType != "completedOverload" and status != "Pre-Student Approval" %}
   <p class="status-warning" style="color:red;" hidden><span class="glyphicon glyphicon-exclamation-sign"></span><strong> A Status is required in order to submit</strong></p>
   <div id='radioDiv'>
     <!-- Need to pass in the notes counter from the notes counter method -->
@@ -130,14 +135,18 @@
 </div>
 
 <div class="modal-footer">
-  {% if formType == "completedOverload" %}
+  {% if formType == "completedOverload"%}
     <button type="button" class="btn btn-secondary floatleft" id="close" data-dismiss="modal">Close</button>
   {% else %}
     <div class="col-sm-6" align="left">
       <button type="button" class="btn btn-secondary floatleft" id="close" data-dismiss="modal">Close</button>
     </div>
     <div class="col-sm-6" align="right">
+      {% if status == "Pre-Student Approval" %}
+        <button id="studentEmail" value='{{formHistoryID}}' type="button" class ="btn btn-info col-sm-12" onclick="sendEmail(this.value, this.id)" data-dismiss="modal">Send Student Reminder Email</button>
+      {% else %}
         <button type="submit" class="btn btn-success floatright" class="submitOverload" onclick="submitOverload({{formHistoryID}}, '{{currentUser.isLaborAdmin}}')">Submit</button>
+      {% endif %}
     </div>
   {% endif %}
 </div>


### PR DESCRIPTION
Issue: https://bitbucket.org/laborstudents/lsf-flask/issues/306/306-labor-admin-overload-visibility

Admin can now view overload forms that have been submitted by supervisors but not yet approved by students.

 

To test:

Create an overload form and check on pending form

