### PR TITLE
Fixes My Current Students page to go to right place

### DIFF
--- a/app/static/js/index.js
+++ b/app/static/js/index.js
@@ -1,8 +1,8 @@
 let table;
 $(document).ready(function() {
-  let url = document.location.href
+  let url = document.location.href;
   createButtons();
-  if (url.endsWith('/')) {
+  if (url.endsWith('/') || url.endsWith('students')) {
     changeButtonColor("#myCurrentStudents")
     $("#userDepartments").hide()
     $("#placeholder").show()

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -18,8 +18,7 @@
     <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.14/dist/js/bootstrap-select.min.js"></script>
     <script type="text/javascript" src="{{url_for('static', filename='js/base.js') }}?u={{lastStaticUpdate}}"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/1.5.3/jspdf.min.js"></script>
-    <script type="text/javascript" src="https://unpkg.com/jspdf@latest/dist/jspdf.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/1.5.3/jspdf.min.js"></script>    
    <script type="text/javascript" src="{{url_for('static', filename='js/sidebar.js') }}?u={{lastStaticUpdate}}"></script>
 {% endblock %}
 

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -198,21 +198,20 @@ and hide the department select picker. -->
     {% endfor %}
     <!-- Display all the past and inactive students by going through inactiveSupervisees list from main_route.py -->
     {% for form in inactiveSupervisees %}
-    <tr>
-      <td>
-        <a href="/laborHistory/{{form.formID.studentSupervisee.ID}}">
-          <span class="h4">{{form.formID.studentSupervisee.FIRST_NAME}}
-                          {{form.formID.studentSupervisee.LAST_NAME}}
-                          ({{form.formID.studentSupervisee.ID}})
-          </span>
-        </a>
-        <br/>
-        <span class="pushRight h5">No longer a student</span>
-        <br/>
-        <span class="pushLeft h6"> {{form.formID.termCode.termName}} - {{form.formID.POSN_TITLE}} - {{form.formID.department.DEPT_NAME}}</span>
-      </td>
-      <td style="display:none">My Past Students</td>
-    </tr>
+      <tr>
+        <td>
+          <a href="/laborHistory/{{form.formID.studentSupervisee.ID}}">
+            <span class="h4">{{form.formID.studentSupervisee.FIRST_NAME}}
+                            {{form.formID.studentSupervisee.LAST_NAME}}
+                            ({{form.formID.studentSupervisee.ID}})
+            </span>
+          </a>
+          <span class="pushRight h5">No longer a student</span>
+          <br/>
+          <span class="pushLeft h6"> {{form.formID.termCode.termName}} - {{form.formID.POSN_TITLE}} - {{form.formID.department.DEPT_NAME}}</span>
+        </td>
+        <td style="display:none">My Past Students</td>
+      </tr>
     {% endfor %}
   </table>
 </div>


### PR DESCRIPTION
- Fixes the “My Students” tab to display the correct information
- Removes a dead javascript import for jspdf (there are two imports)
- Fixed a small formatting issue on “No longer a student” display (extra line break)