### PR TITLE
Show pending form on student labor history page

### DIFF
--- a/app/logic/buttonStatus.py
+++ b/app/logic/buttonStatus.py
@@ -33,7 +33,7 @@ class ButtonStatus:
 
         return: a form history object representing the original LSF form
         '''
-        return FormHistory.get(FormHistory.formID == historyForm.formID, FormHistory.status == "Approved", FormHistory.historyType == "Labor Status Form")
+        return FormHistory.get(FormHistory.formID == historyForm.formID, (FormHistory.status == "Approved") | (FormHistory.status == "Pending"), FormHistory.historyType == "Labor Status Form")
 
     def set_evaluation_button(self, historyForm, currentUser):
         ogHistoryForm = self.get_history_form_from_lsf(historyForm)


### PR DESCRIPTION
fixes issue #350 

-Added a or condition in the buttonStatus.py file to get the pending form for the student Labor History page