### PR TITLE
Add note section for third party Approvers 

### DIFF
--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -396,8 +396,7 @@ def getNotes(formid):
         supervisorNotes =  LaborStatusForm.get(LaborStatusForm.laborStatusFormID == formid)
         laborNotes = list(Notes.select().where(Notes.formID == formid))
         laborNotes.reverse()
-
-
+        
         notesDict = {}
         if supervisorNotes.supervisorNotes:
             notesDict["supervisorNotes"] = supervisorNotes.supervisorNotes

--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -753,7 +753,7 @@ def getNotesCounter():
     try:
         rsp = eval(request.data.decode("utf-8"))
         if rsp:
-            noteTotal = Notes.select().where(Notes.formID == rsp['laborStatusFormID'], Notes.noteType == "Labor Note").count()
+            noteTotal = Notes.select().where(Notes.formID == rsp['laborStatusFormID']).count()
             noteDictionary = {'noteTotal': noteTotal}
             return jsonify(noteDictionary)
     except Exception as e:

--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -207,7 +207,7 @@ def downloadAllPendingForms():
     else:
         abort(403)
 
-    excel = CSVMaker(downloadType, allPendingForms)    
+    excel = CSVMaker(downloadType, allPendingForms)
     return send_file(excel.relativePath, as_attachment=True, attachment_filename=excel.relativePath.split('/').pop())
 
 @admin.route('/admin/checkedForms', methods=['POST'])
@@ -393,10 +393,10 @@ def getNotes(formid):
     '''
     try:
         currentUser = require_login()
-        supervisorNotes =  LaborStatusForm.get(LaborStatusForm.laborStatusFormID == formid) 
+        supervisorNotes =  LaborStatusForm.get(LaborStatusForm.laborStatusFormID == formid)
         laborNotes = list(Notes.select().where(Notes.formID == formid))
         laborNotes.reverse()
-        
+
 
         notesDict = {}
         if supervisorNotes.supervisorNotes:
@@ -429,7 +429,12 @@ def insertNotes(formId):
         currentDate = datetime.now().strftime("%Y-%m-%d")  # formats the date to match the peewee format for the database
 
         if stripresponse:
-            Notes.create(formID=formId, createdBy=currentUser, date=currentDate, notesContents=stripresponse, noteType = "Labor Note") # creates a new entry in the laborOfficeNotes table
+            if currentUser.isLaborAdmin:
+                Notes.create(formID=formId, createdBy=currentUser, date=currentDate, notesContents=stripresponse, noteType = "Labor Note") # creates a new entry in the laborOfficeNotes table
+            elif currentUser.isFinancialAidAdmin:
+                Notes.create(formID=formId, createdBy=currentUser, date=currentDate, notesContents=stripresponse, noteType = "Financial Aid Note")
+            elif currentUser.isSaasAdmin:
+                Notes.create(formID=formId, createdBy=currentUser, date=currentDate, notesContents=stripresponse, noteType = "SAAS Note") 
 
             return jsonify({"Success": True})
 

--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -207,7 +207,7 @@ def downloadAllPendingForms():
     else:
         abort(403)
 
-    excel = CSVMaker(downloadType, allPendingForms)    
+    excel = CSVMaker(downloadType, allPendingForms)
     return send_file(excel.relativePath, as_attachment=True, attachment_filename=excel.relativePath.split('/').pop())
 
 @admin.route('/admin/checkedForms', methods=['POST'])
@@ -393,10 +393,10 @@ def getNotes(formid):
     '''
     try:
         currentUser = require_login()
-        supervisorNotes =  LaborStatusForm.get(LaborStatusForm.laborStatusFormID == formid) 
+        supervisorNotes =  LaborStatusForm.get(LaborStatusForm.laborStatusFormID == formid)
         laborNotes = list(Notes.select().where(Notes.formID == formid))
         laborNotes.reverse()
-        
+
 
         notesDict = {}
         if supervisorNotes.supervisorNotes:
@@ -429,8 +429,12 @@ def insertNotes(formId):
         currentDate = datetime.now().strftime("%Y-%m-%d")  # formats the date to match the peewee format for the database
 
         if stripresponse:
-            Notes.create(formID=formId, createdBy=currentUser, date=currentDate, notesContents=stripresponse, noteType = "Labor Note") # creates a new entry in the laborOfficeNotes table
-
+            if currentUser.isLaborAdmin:
+                Notes.create(formID=formId, createdBy=currentUser, date=currentDate, notesContents=stripresponse, noteType = "Labor Note") # creates a new entry in the laborOfficeNotes table
+            elif currentUser.isFinancialAidAdmin:
+                Notes.create(formID=formId, createdBy=currentUser, date=currentDate, notesContents=stripresponse, noteType = "Financial Aid Note")
+            elif currentUser.isSaasAdmin:
+                Notes.create(formID=formId, createdBy=currentUser, date=currentDate, notesContents=stripresponse, noteType = "SAAS Note")
             return jsonify({"Success": True})
 
         elif stripresponse=="" or stripresponse==None:

--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -207,7 +207,7 @@ def downloadAllPendingForms():
     else:
         abort(403)
 
-    excel = CSVMaker(downloadType, allPendingForms)
+    excel = CSVMaker(downloadType, allPendingForms)    
     return send_file(excel.relativePath, as_attachment=True, attachment_filename=excel.relativePath.split('/').pop())
 
 @admin.route('/admin/checkedForms', methods=['POST'])
@@ -393,10 +393,10 @@ def getNotes(formid):
     '''
     try:
         currentUser = require_login()
-        supervisorNotes =  LaborStatusForm.get(LaborStatusForm.laborStatusFormID == formid)
+        supervisorNotes =  LaborStatusForm.get(LaborStatusForm.laborStatusFormID == formid) 
         laborNotes = list(Notes.select().where(Notes.formID == formid))
         laborNotes.reverse()
-
+        
 
         notesDict = {}
         if supervisorNotes.supervisorNotes:
@@ -429,12 +429,7 @@ def insertNotes(formId):
         currentDate = datetime.now().strftime("%Y-%m-%d")  # formats the date to match the peewee format for the database
 
         if stripresponse:
-            if currentUser.isLaborAdmin:
-                Notes.create(formID=formId, createdBy=currentUser, date=currentDate, notesContents=stripresponse, noteType = "Labor Note") # creates a new entry in the laborOfficeNotes table
-            elif currentUser.isFinancialAidAdmin:
-                Notes.create(formID=formId, createdBy=currentUser, date=currentDate, notesContents=stripresponse, noteType = "Financial Aid Note")
-            elif currentUser.isSaasAdmin:
-                Notes.create(formID=formId, createdBy=currentUser, date=currentDate, notesContents=stripresponse, noteType = "SAAS Note") 
+            Notes.create(formID=formId, createdBy=currentUser, date=currentDate, notesContents=stripresponse, noteType = "Labor Note") # creates a new entry in the laborOfficeNotes table
 
             return jsonify({"Success": True})
 

--- a/app/controllers/admin_routes/financialAidOverload.py
+++ b/app/controllers/admin_routes/financialAidOverload.py
@@ -36,7 +36,7 @@ def financialAidOverload(formHistoryID):
                                 .join(FormHistory)
                                 .where(FormHistory.status_id.in_(["Approved", "Approved Reluctantly", "Pending"]),
                                        FormHistory.historyType_id == "Labor Status Form",
-                                       LaborStatusForm.studentSupervisee == lsfForm.studentSupervisee.ID,
+                                       LaborStatusForm.studentSupervisee == lsfForm.studentSupervisee.ID, 
                                        LaborStatusForm.termCode == lsfForm.termCode))
     totalHours = {"secondaryHours" : 0, "primaryHours": 0}
     supervisor = department = ""
@@ -54,9 +54,8 @@ def financialAidOverload(formHistoryID):
     userDept = "Financial Aid"
     if currentUser.isSaasAdmin:
         userDept = "SAAS"
-# will need to add term to the interface and then have a prefill variable
 
-    notesList = Notes.select().where(Notes.formID == lsfForm)
+# will need to add term to the interface and then have a prefill variable
     return render_template( 'admin/financialAidOverload.html',
                         overloadFormHistory = overloadFormHistory,
                         lsfForm = lsfForm,
@@ -65,8 +64,7 @@ def financialAidOverload(formHistoryID):
                         department = department,
                         supervisor= supervisor,
                         contractDate = contractDate,
-                        totalOverloadHours = totalHours["primaryHours"] + totalHours["secondaryHours"],
-                        notesList = notesList
+                        totalOverloadHours = totalHours["primaryHours"] + totalHours["secondaryHours"]
                       )
 
 @admin.route("/admin/financialAidOverloadApproval/<status>", methods=["POST"])

--- a/app/controllers/admin_routes/financialAidOverload.py
+++ b/app/controllers/admin_routes/financialAidOverload.py
@@ -36,7 +36,7 @@ def financialAidOverload(formHistoryID):
                                 .join(FormHistory)
                                 .where(FormHistory.status_id.in_(["Approved", "Approved Reluctantly", "Pending"]),
                                        FormHistory.historyType_id == "Labor Status Form",
-                                       LaborStatusForm.studentSupervisee == lsfForm.studentSupervisee.ID, 
+                                       LaborStatusForm.studentSupervisee == lsfForm.studentSupervisee.ID,
                                        LaborStatusForm.termCode == lsfForm.termCode))
     totalHours = {"secondaryHours" : 0, "primaryHours": 0}
     supervisor = department = ""
@@ -54,8 +54,9 @@ def financialAidOverload(formHistoryID):
     userDept = "Financial Aid"
     if currentUser.isSaasAdmin:
         userDept = "SAAS"
-
 # will need to add term to the interface and then have a prefill variable
+
+    notesList = Notes.select().where(Notes.formID == lsfForm)
     return render_template( 'admin/financialAidOverload.html',
                         overloadFormHistory = overloadFormHistory,
                         lsfForm = lsfForm,
@@ -64,7 +65,8 @@ def financialAidOverload(formHistoryID):
                         department = department,
                         supervisor= supervisor,
                         contractDate = contractDate,
-                        totalOverloadHours = totalHours["primaryHours"] + totalHours["secondaryHours"]
+                        totalOverloadHours = totalHours["primaryHours"] + totalHours["secondaryHours"],
+                        notesList = notesList
                       )
 
 @admin.route("/admin/financialAidOverloadApproval/<status>", methods=["POST"])

--- a/app/controllers/admin_routes/financialAidOverload.py
+++ b/app/controllers/admin_routes/financialAidOverload.py
@@ -36,7 +36,7 @@ def financialAidOverload(formHistoryID):
                                 .join(FormHistory)
                                 .where(FormHistory.status_id.in_(["Approved", "Approved Reluctantly", "Pending"]),
                                        FormHistory.historyType_id == "Labor Status Form",
-                                       LaborStatusForm.studentSupervisee == lsfForm.studentSupervisee.ID, 
+                                       LaborStatusForm.studentSupervisee == lsfForm.studentSupervisee.ID,
                                        LaborStatusForm.termCode == lsfForm.termCode))
     totalHours = {"secondaryHours" : 0, "primaryHours": 0}
     supervisor = department = ""
@@ -55,6 +55,8 @@ def financialAidOverload(formHistoryID):
     if currentUser.isSaasAdmin:
         userDept = "SAAS"
 
+    notesList = Notes.select().where(Notes.formID == lsfForm)
+
 # will need to add term to the interface and then have a prefill variable
     return render_template( 'admin/financialAidOverload.html',
                         overloadFormHistory = overloadFormHistory,
@@ -64,7 +66,8 @@ def financialAidOverload(formHistoryID):
                         department = department,
                         supervisor= supervisor,
                         contractDate = contractDate,
-                        totalOverloadHours = totalHours["primaryHours"] + totalHours["secondaryHours"]
+                        totalOverloadHours = totalHours["primaryHours"] + totalHours["secondaryHours"],
+                        notesList = notesList
                       )
 
 @admin.route("/admin/financialAidOverloadApproval/<status>", methods=["POST"])

--- a/app/controllers/admin_routes/financialAidOverload.py
+++ b/app/controllers/admin_routes/financialAidOverload.py
@@ -55,7 +55,8 @@ def financialAidOverload(formHistoryID):
     if currentUser.isSaasAdmin:
         userDept = "SAAS"
 
-    notesList = Notes.select().where(Notes.formID == lsfForm)
+    notesList = list(Notes.select().where(Notes.formID == lsfForm))
+    notesList.reverse()
 
 # will need to add term to the interface and then have a prefill variable
     return render_template( 'admin/financialAidOverload.html',

--- a/app/static/js/financialAidOverload.js
+++ b/app/static/js/financialAidOverload.js
@@ -76,15 +76,3 @@ function insertOverloadNote(textareaID, buttonID) {
       }
   });
 }
-
-export function setNotesLimit(textboxId, labelId){
-  var maxCharacters = 250;
-  var textLength = 0;
-  var textVal = $("#" + textboxId).val();
-  var textLength = textVal.length;
-  $(labelId).text("Remaining Characters: " + (maxCharacters - textLength));
-  if (textLength > maxCharacters){
-    $("#" + textboxId).val(textVal.substring(0, maxCharacters));
-    $(labelId).text("Remaining Characters: " + 0);
-  }
-}

--- a/app/static/js/financialAidOverload.js
+++ b/app/static/js/financialAidOverload.js
@@ -77,13 +77,12 @@ function insertOverloadNote(textareaID, buttonID) {
   });
 }
 
-function setNotesLimit(textboxId, labelId){
+export function setNotesLimit(textboxId, labelId){
   var maxCharacters = 250;
   var textLength = 0;
   var textVal = $("#" + textboxId).val();
   var textLength = textVal.length;
   $(labelId).text("Remaining Characters: " + (maxCharacters - textLength));
-  console.log(maxCharacters - textLength);
   if (textLength > maxCharacters){
     $("#" + textboxId).val(textVal.substring(0, maxCharacters));
     $(labelId).text("Remaining Characters: " + 0);

--- a/app/static/js/financialAidOverload.js
+++ b/app/static/js/financialAidOverload.js
@@ -58,9 +58,10 @@ function openApproveDenyModal(status){
     $("#finOverloadModal").modal("show");
   }
 }
+
 function overloadNoteInsert(textareaID, buttonID) {
-  var laborNotes = $("#" + textareaID).val(); //this is getting the id of the labor notes text area
-  var data = JSON.stringify(laborNotes);
+  var overloadNotes = $("#" + textareaID).val();
+  var data = JSON.stringify(overloadNotes);
   $("#" + buttonID).on('submit', function(e) {
     e.preventDefault();
   });

--- a/app/static/js/financialAidOverload.js
+++ b/app/static/js/financialAidOverload.js
@@ -76,3 +76,16 @@ function insertOverloadNote(textareaID, buttonID) {
       }
   });
 }
+
+function setNotesLimit(textboxId, labelId){
+  var maxCharacters = 250;
+  var textLength = 0;
+  var textVal = $("#" + textboxId).val();
+  var textLength = textVal.length;
+  $(labelId).text("Remaining Characters: " + (maxCharacters - textLength));
+  console.log(maxCharacters - textLength);
+  if (textLength > maxCharacters){
+    $("#" + textboxId).val(textVal.substring(0, maxCharacters));
+    $(labelId).text("Remaining Characters: " + 0);
+  }
+}

--- a/app/static/js/financialAidOverload.js
+++ b/app/static/js/financialAidOverload.js
@@ -59,9 +59,9 @@ function openApproveDenyModal(status){
   }
 }
 
-function overloadNoteInsert(textareaID, buttonID) {
-  var overloadNotes = $("#" + textareaID).val();
-  var data = JSON.stringify(overloadNotes);
+function insertOverloadNote(textareaID, buttonID) {
+  var overloadNote = $("#" + textareaID).val();
+  var data = JSON.stringify(overloadNote);
   $("#" + buttonID).on('submit', function(e) {
     e.preventDefault();
   });

--- a/app/static/js/financialAidOverload.js
+++ b/app/static/js/financialAidOverload.js
@@ -58,3 +58,20 @@ function openApproveDenyModal(status){
     $("#finOverloadModal").modal("show");
   }
 }
+function overloadNoteInsert(textareaID, buttonID) {
+  var laborNotes = $("#" + textareaID).val(); //this is getting the id of the labor notes text area
+  var data = JSON.stringify(laborNotes);
+  $("#" + buttonID).on('submit', function(e) {
+    e.preventDefault();
+  });
+
+  $.ajax({
+    method: "POST",
+    url: '/admin/notesInsert/' + textareaID,
+    data: data,
+    contentType: 'application/json',
+    success: function(response) {
+        location.reload(true);
+      }
+  });
+}

--- a/app/templates/admin/financialAidOverload.html
+++ b/app/templates/admin/financialAidOverload.html
@@ -83,9 +83,8 @@
          <textarea type="text" class="form-control" id="overloadReason" value="{{overloadFormHistory.overloadForm.studentOverloadReason}}" disabled>{{overloadFormHistory.overloadForm.studentOverloadReason}}</textarea>
        </div>
        <div class="form-group">
-         <label>{{userDept}} Note:</label>
-         <a id="remainingCharacters"></a>
-         <textarea type="text" class="form-control" id="{{lsfForm.laborStatusFormID}}" onkeyup="setNotesLimit(this.id, remainingCharacters)"></textarea>
+         <label>{{userDept}} Note: </label>
+         <textarea type="text" class="form-control" id="{{lsfForm.laborStatusFormID}}" maxlength="250" placeholder="250 Characters Maximum"></textarea>
          <div class="text-right">
             <button class="btn btn-primary" value="{{lsfForm.laborStatusFormID}}" id="saveNotes" onclick="insertOverloadNote(this.value, this.id)">Save Notes</button>
           </div>

--- a/app/templates/admin/financialAidOverload.html
+++ b/app/templates/admin/financialAidOverload.html
@@ -51,10 +51,8 @@
          </div>
 
          <div class="form-group">
-           <label>Notes Log:</label>
-             {%for note in notesList%}
-             <li>{{note.date.strftime('%m/%d/%Y')}} | {{note.noteType}} | {{note.createdBy.username}} | {{note.notesContents}}</li>
-             {%endfor%}
+           <label>Labor Office Notes:</label>
+           <textarea type="text" class="form-control" id="laborNotes" value="{{lsfForm.laborDepartmentNotes}}" disabled>{{lsfForm.laborDepartmentNotes}}</textarea>
          </div>
      </div>
 

--- a/app/templates/admin/financialAidOverload.html
+++ b/app/templates/admin/financialAidOverload.html
@@ -29,16 +29,16 @@
            <div>
              <h3>Current Primary Position</h3>
            </div>
-           <label for="Student">Student Name:</label> 
-           <input type="text" class="form-control" id="student" value="{{lsfForm.studentSupervisee.FIRST_NAME}} {{lsfForm.studentSupervisee.LAST_NAME}}" disabled> 
+           <label for="Student">Student Name:</label>
+           <input type="text" class="form-control" id="student" value="{{lsfForm.studentSupervisee.FIRST_NAME}} {{lsfForm.studentSupervisee.LAST_NAME}}" disabled>
          </div>
          <div class="form-group">
            <label for="primaryPosition" class="field">Primary Position (WLS):</label>
            <input type="text" class="form-control" id= "primaryPosition" value="{{primaryForm.POSN_TITLE}} ({{primaryForm.WLS}})" disabled> </input> <!-- stores value of original-->
          </div>
          <div class="form-group">
-           <label for="primaryPosHours">Total Primary Position Hours:</label> 
-           <input type="text" class="form-control" id="primaryPosHours" value="{{primaryForm.weeklyHours}}" disabled> 
+           <label for="primaryPosHours">Total Primary Position Hours:</label>
+           <input type="text" class="form-control" id="primaryPosHours" value="{{primaryForm.weeklyHours}}" disabled>
          </div>
          <div class="form-group">
            <label for="primarySupervisor" class="field">Primary Supervisor:</label>
@@ -46,8 +46,13 @@
          </div>
          <!-- This selectpicker will be disabled if term is for a break, since jobtype is always Secondary-->
          <div class="form-group">
-           <label for="department">Department:</label> 
-           <input type="text" class="form-control" id="department" value="{{department}}" disabled> 
+           <label for="department">Department:</label>
+           <input type="text" class="form-control" id="department" value="{{department}}" disabled>
+         </div>
+
+         <div class="form-group">
+           <label>Labor Office Notes:</label>
+           <textarea type="text" class="form-control" id="laborNotes" value="{{lsfForm.laborDepartmentNotes}}" disabled>{{lsfForm.laborDepartmentNotes}}</textarea>
          </div>
      </div>
 
@@ -56,30 +61,34 @@
          <div>
            <h3>Overload Request Info</h3>
          </div>
-         <label for="overloadPosition">New Position (WLS):</label> 
-         <input type="text" class="form-control" id="overloadPosition" value="{{lsfForm.POSN_TITLE}} ({{lsfForm.WLS}})" disabled> 
+         <label for="overloadPosition">New Position (WLS):</label>
+         <input type="text" class="form-control" id="overloadPosition" value="{{lsfForm.POSN_TITLE}} ({{lsfForm.WLS}})" disabled>
        </div>
        <div class="form-group">
-         <label for="dates">Contract Hours:</label> 
-           <input type="text" class="form-control" id="dates" value= "{{lsfForm.weeklyHours}}" disabled> 
+         <label for="dates">Contract Hours:</label>
+           <input type="text" class="form-control" id="dates" value= "{{lsfForm.weeklyHours}}" disabled>
        </div>
        <div class="form-group">
-         <label for="overloadHours">Total hours with overload (including all secondaries):</label> 
-         <input type="text" class="form-control" id="overloadHours" value= "{{totalOverloadHours}}" disabled> 
+         <label for="overloadHours">Total hours with overload (including all secondaries):</label>
+         <input type="text" class="form-control" id="overloadHours" value= "{{totalOverloadHours}}" disabled>
        </div>
        <div class="form-group">
-         <label for="dates">Contract Dates:</label> 
-           <input type="text" class="form-control" id="dates" value= "{{contractDate}}" disabled> 
+         <label for="dates">Contract Dates:</label>
+           <input type="text" class="form-control" id="dates" value= "{{contractDate}}" disabled>
        </div>
        <div class="form-group">
          <label>Student's Overload Reason:</label>
          <textarea type="text" class="form-control" id="overloadReason" value="{{overloadFormHistory.overloadForm.studentOverloadReason}}" disabled>{{overloadFormHistory.overloadForm.studentOverloadReason}}</textarea>
        </div>
+       <div class="form-group">
+         <label>{{userDept}} Note:</label>
+         <textarea type="text" class="form-control" id="{{userDept}}_overloadApprovalNote" ></textarea>
+         <div class="text-right">
+            <button class="btn btn-primary" value="{{userDept}}_laborNotesText" id="{{userDept}}_saveNotes" onclick="notesInsert(this.value, this.id)">Save Notes</button>
+          </div>
+       </div>
+
     </div>
-   <div class="form-group">
-     <label>Labor Office Notes:</label>
-     <textarea type="text" class="form-control" id="laborNotes" value="{{lsfForm.laborDepartmentNotes}}" disabled>{{lsfForm.laborDepartmentNotes}}</textarea>
-   </div>
   </div>
   <div class="container" align="center" id="buttonContainer">
     <div class="col-md-6" align="right">

--- a/app/templates/admin/financialAidOverload.html
+++ b/app/templates/admin/financialAidOverload.html
@@ -51,8 +51,10 @@
          </div>
 
          <div class="form-group">
-           <label>Labor Office Notes:</label>
-           <textarea type="text" class="form-control" id="laborNotes" value="{{lsfForm.laborDepartmentNotes}}" disabled>{{lsfForm.laborDepartmentNotes}}</textarea>
+           <label>Notes Log:</label>
+             {%for note in notesList%}
+             <li>{{note.date.strftime('%m/%d/%Y')}} | {{note.noteType}} | {{note.createdBy.username}} | {{note.notesContents}}</li>
+             {%endfor%}
          </div>
      </div>
 

--- a/app/templates/admin/financialAidOverload.html
+++ b/app/templates/admin/financialAidOverload.html
@@ -84,7 +84,7 @@
        </div>
        <div class="form-group">
          <label>{{userDept}} Note:</label>
-         <label id="remainingCharacters"></label>
+         <a id="remainingCharacters"></a>
          <textarea type="text" class="form-control" id="{{lsfForm.laborStatusFormID}}" onkeyup="setNotesLimit(this.id, remainingCharacters)"></textarea>
          <div class="text-right">
             <button class="btn btn-primary" value="{{lsfForm.laborStatusFormID}}" id="saveNotes" onclick="insertOverloadNote(this.value, this.id)">Save Notes</button>

--- a/app/templates/admin/financialAidOverload.html
+++ b/app/templates/admin/financialAidOverload.html
@@ -53,7 +53,7 @@
          <div class="form-group">
            <label>Notes Log:</label>
              {%for note in notesList%}
-             <li>{{note.date.strftime('%m/%d/%Y')}} | {{note.noteType}} | {{note.createdBy.username}} | {{note.notesContents}}</li>
+             <li>{{note.date.strftime('%m/%d/%Y')}} | {{note.noteType}} | <strong><i>{{note.createdBy.username}}</i></strong> | {{note.notesContents}}</li>
              {%endfor%}
          </div>
      </div>

--- a/app/templates/admin/financialAidOverload.html
+++ b/app/templates/admin/financialAidOverload.html
@@ -81,10 +81,10 @@
          <textarea type="text" class="form-control" id="overloadReason" value="{{overloadFormHistory.overloadForm.studentOverloadReason}}" disabled>{{overloadFormHistory.overloadForm.studentOverloadReason}}</textarea>
        </div>
        <div class="form-group">
-         <label>{{userDept}} Note:</label>
-         <textarea type="text" class="form-control" id="{{userDept}}_overloadApprovalNote" ></textarea>
+         <label>{{userDept}} Note :</label>
+         <textarea type="text" class="form-control" id="{{lsfForm.laborStatusFormID}}" ></textarea>
          <div class="text-right">
-            <button class="btn btn-primary" value="{{userDept}}_laborNotesText" id="{{userDept}}_saveNotes" onclick="notesInsert(this.value, this.id)">Save Notes</button>
+            <button class="btn btn-primary" value="{{lsfForm.laborStatusFormID}}" id="saveNotes" onclick="overloadNoteInsert(this.value, this.id)">Save Notes</button>
           </div>
        </div>
 

--- a/app/templates/admin/financialAidOverload.html
+++ b/app/templates/admin/financialAidOverload.html
@@ -84,7 +84,7 @@
          <label>{{userDept}} Note :</label>
          <textarea type="text" class="form-control" id="{{lsfForm.laborStatusFormID}}" ></textarea>
          <div class="text-right">
-            <button class="btn btn-primary" value="{{lsfForm.laborStatusFormID}}" id="saveNotes" onclick="overloadNoteInsert(this.value, this.id)">Save Notes</button>
+            <button class="btn btn-primary" value="{{lsfForm.laborStatusFormID}}" id="saveNotes" onclick="insertOverloadNote(this.value, this.id)">Save Notes</button>
           </div>
        </div>
 

--- a/app/templates/admin/financialAidOverload.html
+++ b/app/templates/admin/financialAidOverload.html
@@ -83,8 +83,9 @@
          <textarea type="text" class="form-control" id="overloadReason" value="{{overloadFormHistory.overloadForm.studentOverloadReason}}" disabled>{{overloadFormHistory.overloadForm.studentOverloadReason}}</textarea>
        </div>
        <div class="form-group">
-         <label>{{userDept}} Note :</label>
-         <textarea type="text" class="form-control" id="{{lsfForm.laborStatusFormID}}" ></textarea>
+         <label>{{userDept}} Note:</label>
+         <label id="remainingCharacters"></label>
+         <textarea type="text" class="form-control" id="{{lsfForm.laborStatusFormID}}" onkeyup="setNotesLimit(this.id, remainingCharacters)"></textarea>
          <div class="text-right">
             <button class="btn btn-primary" value="{{lsfForm.laborStatusFormID}}" id="saveNotes" onclick="insertOverloadNote(this.value, this.id)">Save Notes</button>
           </div>

--- a/app/templates/finAidBase.html
+++ b/app/templates/finAidBase.html
@@ -48,7 +48,7 @@
   </div>
   <div class="row bottom-buffer"></div>
   {% block footer %}
-    <div class="footer navbar-fixed-bottom">
+    <div class="footer">
             <span><strong>Issues? Contact: </strong><a href="mailto:support@bereacollege.onmicrosoft.com" class="footerlink">Systems Support </a>
             <strong>Created & Designed by the </strong><a href="/contributors" id = "contribLink" class="footerlink">Student Software Development Team</a></span>
     </div>

--- a/app/templates/snips/FormsDeny.html
+++ b/app/templates/snips/FormsDeny.html
@@ -24,7 +24,7 @@
       </tbody>
     </table>
     <p><strong>Reason for denial:</strong></p>
-    <textarea id='denyReason' name="name" rows="4" cols="80" style="max-width:100%;resize:none" placeholder=""></textarea>
+    <textarea id='denyReason' name="name" rows="4" cols="80" style="max-width:100%;resize:none" maxlength="250" placeholder="250 Characters Maximum"></textarea>
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-secondary" data-dismiss="modal" onclick="denialModalClose()">Close</button>

--- a/app/templates/snips/financialAidOverloadModals.html
+++ b/app/templates/snips/financialAidOverloadModals.html
@@ -8,7 +8,7 @@
       <div class="modal-body">
         <p align = "left" id="modal-body-content"> You have chosen to deny this student's Overload Request. Please provide a reason.</p>
         <p id="required-error" style="color:red;" hidden><span class="glyphicon glyphicon-exclamation-sign"></span><strong> This field is required</strong></p>
-            <textarea class="textarea-required" id="denyReason_{{overload.formHistoryID}}" rows="5" cols="60" style="resize: none;" required> </textarea>
+            <textarea class="textarea-required" id="denyReason_{{overload.formHistoryID}}" rows="5" cols="60" style="resize: none;" maxlength="250" placeholder="250 Characters Maximum"></textarea>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal" id="closeModal">Close</button>

--- a/app/templates/snips/pendingNotesModal.html
+++ b/app/templates/snips/pendingNotesModal.html
@@ -15,13 +15,13 @@
       <div class="modal-body" id="noteModalBody">
         <div id="notesDiv">
            <h4 class="supeNotesLabel col-md-4 control-label text-left" for ="supervisor">Supervisor Notes: </h4>
-              <textarea class="notesText" rows="2" cols="70" disabled> </textarea>
+              <textarea class="notesText" rows="2" cols="70" maxlength="250" placeholder="250 Characters Maximum" disabled> </textarea>
           {% if currentUser.isLaborAdmin %}
-            <h4 class="col-md-4 control-label text-left" for ="laboroffice" align = "left">Labor Office Notes: </h4>
+            <h4 class="col-md-6 control-label text-left" for ="laboroffice" align = "left">Labor Office Notes: </h4>
           {% elif currentUser.isFinancialAidAdmin %}
             <h4 class="col-md-6 control-label text-left" for ="laboroffice" align = "left">Financial Aid Office Notes: </h4>
           {% endif %}
-              <textarea id="laborNotesText" rows="2" cols="70"></textarea>
+              <textarea id="laborNotesText" rows="2" cols="70" maxlength="250" placeholder="250 Characters Maximum"></textarea>
           <h4 class=" control-label text-left" id="notesLogTitle" for="notesLog">Notes Log:</h4>
               <div class="notesLogArea"></div>
         </div>

--- a/app/templates/snips/pendingNotesModal.html
+++ b/app/templates/snips/pendingNotesModal.html
@@ -14,14 +14,7 @@
       </div>
       <div class="modal-body" id="noteModalBody">
         <div id="notesDiv">
-           <h4 class="supeNotesLabel col-md-4 control-label text-left" for ="supervisor">Supervisor Notes: </h4>
-              <textarea class="notesText" rows="2" cols="70" maxlength="250" placeholder="250 Characters Maximum" disabled> </textarea>
-          {% if currentUser.isLaborAdmin %}
-            <h4 class="col-md-6 control-label text-left" for ="laboroffice" align = "left">Labor Office Notes: </h4>
-          {% elif currentUser.isFinancialAidAdmin %}
-            <h4 class="col-md-6 control-label text-left" for ="laboroffice" align = "left">Financial Aid Office Notes: </h4>
-          {% endif %}
-              <textarea id="laborNotesText" rows="2" cols="70" maxlength="250" placeholder="250 Characters Maximum"></textarea>
+          <textarea id="laborNotesText" rows="2" cols="70" maxlength="250" placeholder="250 Characters Maximum"></textarea>
           <h4 class=" control-label text-left" id="notesLogTitle" for="notesLog">Notes Log:</h4>
               <div class="notesLogArea"></div>
         </div>

--- a/app/templates/snips/pendingNotesModal.html
+++ b/app/templates/snips/pendingNotesModal.html
@@ -8,6 +8,8 @@
           <h3 class="modal-title" id="notesModalLabel">Labor Office Notes </h3>
         {% elif currentUser.isFinancialAidAdmin %}
           <h3 class="modal-title" id="notesModalLabel">Financial Aid Office Notes </h3>
+        {% elif currentUser.isSaasAdmin %}
+          <h3 class="modal-title" id="notesModalLabel">Saas Office Notes </h3>
         {% endif %}
       </div>
       <div class="modal-body" id="noteModalBody">

--- a/app/templates/snips/pendingOverloadModal.html
+++ b/app/templates/snips/pendingOverloadModal.html
@@ -66,7 +66,7 @@
     </div>
     <div class="logNotesDiv row col-sm-12" style='display:none'>
       <h4 class="supeNotesLabel control-label text-left" for="supervisor">Supervisor Notes: </h4>
-      <textarea class="notesText form-control" rows="2" cols="70" disabled> </textarea>
+      <textarea class="notesText form-control" rows="2" cols="70" maxlength="250" disabled> </textarea>
       <h4 class=" control-label text-left" id="notesLogHeader" for="notesLog">Notes Log:</h4>
       <div class="notesLogArea"></div>
       <br>
@@ -104,7 +104,7 @@
   {% endif %}
 
   {########################################
-    Approval 
+    Approval
    ########################################}
 
   {% if formType != "completedOverload" and (currentUser.isLaborAdmin or status != "Pre-Student Approval") %}
@@ -136,18 +136,18 @@
     </div>
   </div>
   <div id="notesTextAreaOverload" class="notesTextArea">
-    <textarea id='overloadNotes' class="finalNote form-control" name="name" rows="4" cols="80" style="max-width:100%;resize:none" placeholder="Enter a reason for approval"></textarea>
+    <textarea id='overloadNotes' class="finalNote form-control" name="name" rows="4" cols="80" style="max-width:100%;resize:none" placeholder="Enter a reason for approval (250 Characters)" maxlength="250"></textarea>
   </div>
   <div id="denyTextAreaOverload" class="denyTextArea" style="display:None">
-    <textarea id='denyOverloadReason' class="finalDeny form-control" name="name" rows="4" cols="80" style="max-width:100%;resize:none" placeholder="Enter a reason for denial"></textarea>
+    <textarea id='denyOverloadReason' class="finalDeny form-control" name="name" rows="4" cols="80" style="max-width:100%;resize:none" placeholder="Enter a reason for denial (250 Characters)" maxlength="250"></textarea>
     <p id="required-error" style="color:red;" hidden><span class="glyphicon glyphicon-exclamation-sign"></span><b> This field is required</b></p>
   </div>
 
   {########################################
-    Initials Entry 
+    Initials Entry
    ########################################}
 
-    {% if (currentUser.isFinancialAidAdmin and not departmentStatusInfo['financialAidStatus']) or 
+    {% if (currentUser.isFinancialAidAdmin and not departmentStatusInfo['financialAidStatus']) or
           (currentUser.isSaasAdmin and not departmentStatusInfo['SAASStatus']) %}
       <div align="left" style="margin-top:2%;">
           <span class="tooltip-right" data-tooltip="Required">Mark approved by <strong>{{currentUser.fullName}}: </strong><span class="required-mark">*</span>


### PR DESCRIPTION
This PR fixes issue #358 : "The financial aid and saas reviewers should be able to manage notes on their approval pages. Currently there is a disabled input box that shows only labor notes. We should change it so that they have a way to view and add notes without having to approve and deny the form. Same interface pretty much as the current View Notes action on the overloads page."

Did: Added a textarea and a Save Note button on `/admin/saasOverloadApproval/formId`. 
Added a function called `overloadNoteInsert` in `financialAidOverload.js `file to handle note insertion from the financialOverload page.

Test: 
- Submit an Overload form for a student. An Overload Form is created when the total labor hour for student is over 20. 
- Log in as Financial Aid and navigate `http://0.0.0.0:8080/admin/financialAidOverloadApproval/<formId>`. Under "Financial Aid Note", add a note and click "Save Note". The page should reload and clear the text. Check the note table in php or mysql workbench, a note entry should be created for the note you just input.
-  Log in as Saaa admin and navigate `http://0.0.0.0:8080/admin/saasOverloadApproval/<formId>`. Under "Saas Note", add a note and click "Save Note". The page should reload and clear the text. Check the note table in php or mysql workbench, a note entry should be created for the note you just input.
