### PR TITLE
Allow Students and Supervisor to Withdraw Overload Forms

### DIFF
--- a/app/logic/buttonStatus.py
+++ b/app/logic/buttonStatus.py
@@ -64,14 +64,21 @@ class ButtonStatus:
     def set_button_states(self, historyForm, currentUser):
         if currentUser.student and currentUser.student.ID == historyForm.formID.studentSupervisee.ID:
             # students get no buttons except "show evaluation"
-            self.rehire = False
-            self.release = False
-            self.withdraw = False
-            self.adjust = False
-            self.correction = False
-            self.evaluate = False
-            self.set_evaluation_button( historyForm, currentUser)
-            self.num_buttons = 1
+            if historyForm.historyType.historyTypeName == "Labor Status Form" or historyForm.historyType.historyTypeName == "Labor Overload Form" :
+                if historyForm.status.statusName == "Pending" or historyForm.status.statusName == "Pre-Student Approval":
+                    self.withdraw = True
+                    self.num_buttons = 1
+            else:
+                self.rehire = False
+                self.release = False
+                self.withdraw = False
+                self.adjust = False
+                self.correction = False
+                self.evaluate = False
+                self.set_evaluation_button( historyForm, currentUser)
+                self.num_buttons = 1
+
+
         else:
             if historyForm.releaseForm != None:     # If its a release form
                 if historyForm.status.statusName == "Approved":
@@ -104,8 +111,8 @@ class ButtonStatus:
                     # Pending adjustment forms get no buttons
                     pass
                 #FIXME: Add cases for approved and denied adjustment forms
-            elif historyForm.historyType.historyTypeName == "Labor Status Form":
-                if historyForm.status.statusName == "Pending":
+            elif historyForm.historyType.historyTypeName == "Labor Status Form" or historyForm.historyType.historyTypeName == "Labor Overload Form":
+                if historyForm.status.statusName == "Pending" or historyForm.status.statusName == "Pre-Student Approval":
                     # Pending LSF can be withdrawn or corrected
                     self.withdraw = True
                     self.correction = True

--- a/app/templates/main/formHistory.html
+++ b/app/templates/main/formHistory.html
@@ -24,7 +24,7 @@
         {% for form in authorizedForms %}
         <tr>
           <!-- If a user is a labor admin, then the value boolean is true, and allows admin access to all of a student's labor history. -->
-          {% if currentUser.isLaborAdmin or form.formID.POSN_CODE != "S12345" %}
+          {% if currentUser.isLaborAdmin or form.formID.POSN_CODE != "S12345" or student %}
           <td id="{{form.formID.laborStatusFormID}}" class="modalLink" value="true">
             <a href="#" tabindex="0"><span class="h4">{{form.formID.termCode.termName}} - {{form.formID.department.DEPT_NAME}} Dept.</span></a>
             <span class="pushRight h5">{{form.status}}</span>


### PR DESCRIPTION

issue #354 
Did: 
- Made sure submitted forms (Both Labor Status and Labor Overload Form) show up on Labor History Page at all stages (Pre-Student Approval, Pending , Approved ...)
- Allow students and their supervisor to withdraw submitted Labor Status Form at stages: Pre-Student Approval, Pending

Test: 
- Log in as a supervisor. Submit a Labor Overload Form for a student. Go to student History page and withdraw the Overload form that you just submitted.
- Submit a Labor Overload Form for a student again. Now log in as the student and go to the History page. Withdraw the Overload form that was submitted for you. 