### PR TITLE
Date submitted eval 396

### DIFF
--- a/app/controllers/main_routes/studentLaborEvaluation.py
+++ b/app/controllers/main_routes/studentLaborEvaluation.py
@@ -94,7 +94,6 @@ def sle(statusKey):
             sleForm.respect.data = existing_saved_evaluation.respect_score
             sleForm.learning.data = existing_saved_evaluation.learning_score
             sleForm.jobSpecific.data = existing_saved_evaluation.jobSpecific_score
-            sleForm.date_submitted.data = correctFormat
 
             sleForm.attendanceComments.data = existing_saved_evaluation.attendance_comment
             sleForm.accountabilityComments.data = existing_saved_evaluation.accountability_comment
@@ -180,10 +179,11 @@ def sle(statusKey):
         # Only approved evaluations get an SLE, so send them home.
         return redirect("/")
 
-    listDate = str(existing_final_evaluation.date_submitted).split('-')
-    print(listDate)
-    correctFormat = listDate[1] + '-' + listDate[2] + '-' + listDate[0]
-    print(correctFormat)
+    if existing_final_evaluation:
+        listDate = str(existing_final_evaluation.date_submitted).split('-')
+        correctFormat = listDate[1] + '-' + listDate[2] + '-' + listDate[0]
+    else:
+        correctFormat = None
 
     return render_template("main/studentLaborEvaluation.html",
                             form = sleForm,

--- a/app/controllers/main_routes/studentLaborEvaluation.py
+++ b/app/controllers/main_routes/studentLaborEvaluation.py
@@ -182,7 +182,7 @@ def sle(statusKey):
     if existing_final_evaluation:
         submittedDate = existing_final_evaluation.date_submitted.strftime("%m-%d-%Y")
     else:
-        submittedDate = None
+        submittedDate = None 
 
     return render_template("main/studentLaborEvaluation.html",
                             form = sleForm,

--- a/app/controllers/main_routes/studentLaborEvaluation.py
+++ b/app/controllers/main_routes/studentLaborEvaluation.py
@@ -10,6 +10,7 @@ from app.models.formHistory import *
 from app.models.studentLaborEvaluation import StudentLaborEvaluation
 from werkzeug.exceptions import BadRequestKeyError
 from app.logic.search import getDepartmentsForSupervisor
+from datetime import date
 
 class SLEForm(FlaskForm):
 
@@ -93,6 +94,7 @@ def sle(statusKey):
             sleForm.respect.data = existing_saved_evaluation.respect_score
             sleForm.learning.data = existing_saved_evaluation.learning_score
             sleForm.jobSpecific.data = existing_saved_evaluation.jobSpecific_score
+            sleForm.date_submitted.data = existing_saved_evaluation.date_submitted
 
             sleForm.attendanceComments.data = existing_saved_evaluation.attendance_comment
             sleForm.accountabilityComments.data = existing_saved_evaluation.accountability_comment
@@ -164,7 +166,8 @@ def sle(statusKey):
                                     jobSpecific_comment = sleForm.jobSpecificComments.data,
                                     transcript_comment = sleForm.transcriptComments.data,
                                     is_submitted = True if sleForm.isSubmitted.data == "True" else False,
-                                    submitted_by = currentUser
+                                    submitted_by = currentUser,
+                                    date_submitted = date.today()
                                 )
         if laborHistoryForm.formID.termCode.isMidyearEvaluationOpen and not submitAsFinal:
             studentLaborEvaluation.is_midyear_evaluation = True

--- a/app/controllers/main_routes/studentLaborEvaluation.py
+++ b/app/controllers/main_routes/studentLaborEvaluation.py
@@ -180,8 +180,7 @@ def sle(statusKey):
         return redirect("/")
 
     if existing_final_evaluation:
-        listDate = str(existing_final_evaluation.date_submitted).split('-')
-        correctFormat = listDate[1] + '-' + listDate[2] + '-' + listDate[0]
+        submittedDate = existing_final_evaluation.date_submitted.strftime("%m-%d-%Y")
     else:
         correctFormat = None
 
@@ -190,7 +189,7 @@ def sle(statusKey):
                             laborHistoryForm = laborHistoryForm,
                             existing_final_evaluation = existing_final_evaluation,
                             existing_midyear_evaluation = existing_midyear_evaluation,
-                            date_submitted = correctFormat,
+                            date_submitted = submittedDate,
                             overall_score = overall_score,
                             isFinalEvaluationOpen = laborHistoryForm.formID.termCode.isFinalEvaluationOpen,
                             currentUser = currentUser

--- a/app/controllers/main_routes/studentLaborEvaluation.py
+++ b/app/controllers/main_routes/studentLaborEvaluation.py
@@ -94,7 +94,7 @@ def sle(statusKey):
             sleForm.respect.data = existing_saved_evaluation.respect_score
             sleForm.learning.data = existing_saved_evaluation.learning_score
             sleForm.jobSpecific.data = existing_saved_evaluation.jobSpecific_score
-            sleForm.date_submitted.data = existing_saved_evaluation.date_submitted
+            sleForm.date_submitted.data = correctFormat
 
             sleForm.attendanceComments.data = existing_saved_evaluation.attendance_comment
             sleForm.accountabilityComments.data = existing_saved_evaluation.accountability_comment
@@ -180,11 +180,17 @@ def sle(statusKey):
         # Only approved evaluations get an SLE, so send them home.
         return redirect("/")
 
+    listDate = str(existing_final_evaluation.date_submitted).split('-')
+    print(listDate)
+    correctFormat = listDate[1] + '-' + listDate[2] + '-' + listDate[0]
+    print(correctFormat)
+
     return render_template("main/studentLaborEvaluation.html",
                             form = sleForm,
                             laborHistoryForm = laborHistoryForm,
                             existing_final_evaluation = existing_final_evaluation,
                             existing_midyear_evaluation = existing_midyear_evaluation,
+                            date_submitted = correctFormat,
                             overall_score = overall_score,
                             isFinalEvaluationOpen = laborHistoryForm.formID.termCode.isFinalEvaluationOpen,
                             currentUser = currentUser

--- a/app/controllers/main_routes/studentLaborEvaluation.py
+++ b/app/controllers/main_routes/studentLaborEvaluation.py
@@ -182,7 +182,7 @@ def sle(statusKey):
     if existing_final_evaluation:
         submittedDate = existing_final_evaluation.date_submitted.strftime("%m-%d-%Y")
     else:
-        correctFormat = None
+        submittedDate = None
 
     return render_template("main/studentLaborEvaluation.html",
                             form = sleForm,

--- a/app/models/studentLaborEvaluation.py
+++ b/app/models/studentLaborEvaluation.py
@@ -23,6 +23,7 @@ class StudentLaborEvaluation(baseModel):
     is_midyear_evaluation   = BooleanField(default=False)
     is_submitted            = BooleanField(default=False)
     submitted_by            = CharField(null=False)
+    date_submitted          = DateField(null=False)
 
     def __str__(self):
         return str(self.__dict__)

--- a/app/templates/main/studentLaborEvaluation.html
+++ b/app/templates/main/studentLaborEvaluation.html
@@ -50,6 +50,10 @@
             <dd>{{laborHistoryForm.formID.jobType}} ({{laborHistoryForm.formID.weeklyHours}})</dd>
             <dt>Position (WLS): </dt>
             <dd>{{laborHistoryForm.formID.POSN_TITLE}} ({{laborHistoryForm.formID.WLS}})</dd>
+            {% if existing_final_evaluation %}
+              <dt>Date Submitted: </dt>
+              <dd>{{existing_final_evaluation.date_submitted}}</dd>
+            {% endif %}
           </dl>
         </div>
       </div>

--- a/app/templates/main/studentLaborEvaluation.html
+++ b/app/templates/main/studentLaborEvaluation.html
@@ -52,7 +52,7 @@
             <dd>{{laborHistoryForm.formID.POSN_TITLE}} ({{laborHistoryForm.formID.WLS}})</dd>
             {% if existing_final_evaluation %}
               <dt>Date Submitted: </dt>
-              <dd>{{existing_final_evaluation.date_submitted}}</dd>
+              <dd>{{date_submitted}}</dd>
             {% endif %}
           </dl>
         </div>


### PR DESCRIPTION
Summary: 
Added the submitted date to student evaluation forms after they have been submitted. The program will access today's date when the form is submitted and then when the submission is accessed by the user will turn that date time field into the U.S. date format. 

To test:
You will have to create an LSF and a Form history for a student in the development non-backup data. Make the form for the term 2021-2022 and make sure in term management in LSF you set the final evaluations to open. You should now see Evaluate as an option on the student record modal in LSF (Click on the student's name in the Supervisor portal). Evaluate them. Now go back and check the form again and you should see the date attached at the top.