### PR TITLE
Add link to student overload reason for admins: issue 374

### DIFF
--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -145,7 +145,7 @@ def allPendingForms(formType):
                     print(e)
 
             checkAdjustment(allForms)
-        return render_template( 'admin/allPendingForms.html', 
+        return render_template( 'admin/allPendingForms.html',
                                 title=pageTitle,
                                 username=currentUser.username,
                                 formList = formList,
@@ -455,7 +455,6 @@ def getOverloadModalData(formHistoryID):
         studentLinks = {}
         for form in historyForm:
             studentLinks[form.formHistoryID] = makeThirdPartyLink("student", request.host, form.formHistoryID)
-        print(studentLinks)
         try:
             financialAidLastEmail = EmailTracker.select().limit(1).where((EmailTracker.recipient == 'Financial Aid') & (EmailTracker.formID == historyForm[0].formID.laborStatusFormID)) .order_by(EmailTracker.date.desc())
             financialAidEmailDate = financialAidLastEmail[0].date.strftime('%m/%d/%y')

--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -145,7 +145,6 @@ def allPendingForms(formType):
                     print(e)
 
             checkAdjustment(allForms)
-
         return render_template( 'admin/allPendingForms.html', 
                                 title=pageTitle,
                                 username=currentUser.username,
@@ -158,7 +157,7 @@ def allPendingForms(formType):
                                 releaseFormCounter = releaseFormCounter,
                                 completedOverloadFormCounter = completedOverloadFormCounter,
                                 pendingOverloadFormPairs = pendingOverloadFormPairs
-                                )
+                              )
     except Exception as e:
         print("Error Loading all Pending Forms:", e)
         return render_template('errors/500.html'), 500
@@ -453,6 +452,10 @@ def getOverloadModalData(formHistoryID):
         currentUser = require_login()
         departmentStatusInfo = {}
         historyForm = FormHistory.select().where(FormHistory.formHistoryID == int(formHistoryID))
+        studentLinks = {}
+        for form in historyForm:
+            studentLinks[form.formHistoryID] = makeThirdPartyLink("student", request.host, form.formHistoryID)
+        print(studentLinks)
         try:
             financialAidLastEmail = EmailTracker.select().limit(1).where((EmailTracker.recipient == 'Financial Aid') & (EmailTracker.formID == historyForm[0].formID.laborStatusFormID)) .order_by(EmailTracker.date.desc())
             financialAidEmailDate = financialAidLastEmail[0].date.strftime('%m/%d/%y')
@@ -514,7 +517,8 @@ def getOverloadModalData(formHistoryID):
                                             pendingForm = pendingForm,
                                             pendingFormType = pendingFormType,
                                             formType = returnToTab,
-                                            status = status
+                                            status = status,
+                                            studentLinks = studentLinks
                                             )
     except Exception as e:
         print("Error Populating Overload Modal:", e)

--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -146,7 +146,7 @@ def allPendingForms(formType):
 
             checkAdjustment(allForms)
 
-        return render_template( 'admin/allPendingForms.html',
+        return render_template( 'admin/allPendingForms.html', 
                                 title=pageTitle,
                                 username=currentUser.username,
                                 formList = formList,
@@ -396,7 +396,7 @@ def getNotes(formid):
         supervisorNotes =  LaborStatusForm.get(LaborStatusForm.laborStatusFormID == formid)
         laborNotes = list(Notes.select().where(Notes.formID == formid))
         laborNotes.reverse()
-        
+
         notesDict = {}
         if supervisorNotes.supervisorNotes:
             notesDict["supervisorNotes"] = supervisorNotes.supervisorNotes

--- a/app/controllers/main_routes/studentOverloadApp.py
+++ b/app/controllers/main_routes/studentOverloadApp.py
@@ -22,10 +22,10 @@ def studentOverloadApp(formHistoryId):
             return render_template('errors/403.html'), 403
         if not currentUser.student:
             return render_template('errors/403.html'), 403
+        overloadForm = FormHistory.get_by_id(formHistoryId)
         if currentUser.student.ID != overloadForm.formID.studentSupervisee.ID:
             return render_template('errors/403.html'), 403
-    overloadForm = FormHistory.get_by_id(formHistoryId)
-        
+
     lsfForm = (LaborStatusForm.select(LaborStatusForm, Student, Term, Department)
                     .join(Student, attr="studentSupervisee").switch()
                     .join(Term).switch()
@@ -113,7 +113,7 @@ def withdrawRequest(formHistoryId):
     # send a withdrawal notification to student and supervisor
     email = emailHandler(formHistory.formHistoryID)
     email.LaborOverloadFormWithdrawn()
-    
+
     # TODO should we email financial aid?
 
     formHistory.overloadForm.delete_instance()

--- a/app/controllers/main_routes/studentOverloadApp.py
+++ b/app/controllers/main_routes/studentOverloadApp.py
@@ -17,12 +17,12 @@ from app.models.overloadForm import *
 @main_bp.route('/studentOverloadApp/<formHistoryId>', methods=['GET'])
 def studentOverloadApp(formHistoryId):
     currentUser = require_login()
+    overloadForm = FormHistory.get_by_id(formHistoryId)
     if not currentUser.isLaborAdmin:
         if not currentUser:        # Not logged in
             return render_template('errors/403.html'), 403
         if not currentUser.student:
             return render_template('errors/403.html'), 403
-        overloadForm = FormHistory.get_by_id(formHistoryId)
         if currentUser.student.ID != overloadForm.formID.studentSupervisee.ID:
             return render_template('errors/403.html'), 403
 

--- a/app/templates/snips/pendingOverloadModal.html
+++ b/app/templates/snips/pendingOverloadModal.html
@@ -48,8 +48,11 @@
                 <dd style="text-align: left; color: red;">
                     <strong> *The student has not completed their overload request*</strong>
                     <br> 
-                    <a href="javascript:void()" style="text-decoration: underline" onclick="sendEmail('{{formHistoryID}}', 'studentEmail')" data-dismiss="modal">Send Reminder Email</a>
-                    <a href = "{{studentLinks[form.formHistoryID]}}" > Student Overload Request</a>
+                    <div class = "d-flex justify-content-between">
+                       <a href="javascript:void()" style="text-decoration: underline" onclick="sendEmail('{{formHistoryID}}', 'studentEmail')" data-dismiss="modal">Send Reminder Email</a>
+                       <span style = "color: black;"> or view </span>
+                       <a href = "{{studentLinks[form.formHistoryID]}}" style="text-decoration: underline" > Student Overload Request</a>
+                    </div>
                   </dd>
             {% endif %}
           </dl>

--- a/app/templates/snips/pendingOverloadModal.html
+++ b/app/templates/snips/pendingOverloadModal.html
@@ -47,8 +47,10 @@
             {% elif status == "Pre-Student Approval" %}
                 <dd style="text-align: left; color: red;">
                     <strong> *The student has not completed their overload request*</strong>
+                    <br> 
                     <a href="javascript:void()" style="text-decoration: underline" onclick="sendEmail('{{formHistoryID}}', 'studentEmail')" data-dismiss="modal">Send Reminder Email</a>
-                </dd>
+                    <a href = "{{studentLinks[form.formHistoryID]}}" > Student Overload Request</a>
+                  </dd>
             {% endif %}
           </dl>
 


### PR DESCRIPTION
This PR fixes issue #374 

Summary: We first made sure that admins are able to view the page by giving them permission. We are using `makeThirdPartyLink()` function to create the link, and we are passing the form.formHistoryID to create the link. Once the link is created we are rendering it. We added the link in pendingOverloadModal.html where admins are able to view it under the Pending forms. 


To Test:
- Open up one of the closed terms
- Create an overload form (15-20 hours)
- review the form and submit
- Under Pending Forms click on the red exclamation point for the overload form that you just created
- click on Student Overload Request, and it should take you to the student's overload request app

