### PR TITLE
Added email button to email labor student position information

### DIFF
--- a/app/static/css/studentHistoryModal.css
+++ b/app/static/css/studentHistoryModal.css
@@ -1,4 +1,4 @@
-#modalid {
+#studentLaborDetailsModal {
   overflow: auto;
   height:350px;
   overflow:auto;
@@ -71,7 +71,4 @@
 
 .mailtoIcon{
   font-size: smaller;
-}
-#easyEmail{
-  float:right;
 }

--- a/app/static/css/studentHistoryModal.css
+++ b/app/static/css/studentHistoryModal.css
@@ -72,3 +72,6 @@
 .mailtoIcon{
   font-size: smaller;
 }
+#easyEmail{
+  float:right;
+}

--- a/app/static/js/laborhistory.js
+++ b/app/static/js/laborhistory.js
@@ -36,7 +36,11 @@ function redirection(laborStatusKey){
   // console.log(laborStatusKey);
 }
 
-function mailPositionToLabor(){
+$("#modal").on('transitionend', function(){ //Had to search for css element visibility changes to make this work
+  $('#emailLabor').on('click', mailToLabor);
+})
+
+function mailToLabor(){
   let subject = `Labor Position Information for ${$('#studentDetails').text()}`
   subject= subject.replace(/\s+/g, ' ')
   let body = `Student Name:${$('#studentDetails').text()}%0D%0A`+
@@ -47,9 +51,10 @@ function mailPositionToLabor(){
              `Position (WLS): ${$('#laborPosition').text()}%0D%0A`+
              `Start Date: ${$('#laborStartDate').text()}%0D%0A`+
              `End Date: ${$('#laborEndDate').text()}`
-  body = body.replace(/\s+/g, ' ')
+  body = body.replace(/(\s+|\&)/g, function(match) { //regex searches for whitespace characters or ampersand and replaces them accordingly
+    return match === "&" ? "%26" : ' ';
+  });
   window.location.href = `mailto:labor@berea.edu?subject=${subject}&body=${body}`;
-
 }
 
 function fillPDF(laborStatusKey){

--- a/app/static/js/laborhistory.js
+++ b/app/static/js/laborhistory.js
@@ -36,6 +36,22 @@ function redirection(laborStatusKey){
   // console.log(laborStatusKey);
 }
 
+function mailPositionToLabor(){
+  let subject = `Labor Position Information for ${$('#studentDetails').text()}`
+  subject= subject.replace(/\s+/g, ' ')
+  let body = `Student Name:${$('#studentDetails').text()}%0D%0A`+
+             `Term: ${$('#laborTerm').text()}%0D%0A`+
+             `Department (ID): ${$('#laborDepartment').text()}%0D%0A`+
+             `Supervisor: ${$('#laborSupervisor').text()}%0D%0A`+
+             `Job Type (Hours): ${$('#laborJobType').text()}%0D%0A`+
+             `Position (WLS): ${$('#laborPosition').text()}%0D%0A`+
+             `Start Date: ${$('#laborStartDate').text()}%0D%0A`+
+             `End Date: ${$('#laborEndDate').text()}`
+  body = body.replace(/\s+/g, ' ')
+  window.location.href = `mailto:labor@berea.edu?subject=${subject}&body=${body}`;
+
+}
+
 function fillPDF(laborStatusKey){
   /* This function gets a response from controller function: ConvertToPDF() in laborHistory.py. The response is an HTML Template
      that is converted to pdf using jsPDF*/

--- a/app/static/js/laborhistory.js
+++ b/app/static/js/laborhistory.js
@@ -7,13 +7,10 @@ function goback(departmentName){
 }
 
 $('#positionTable tbody tr td').on('click',function(){
-  /*If boolean value is false, flash container letting user know that they do not
-  have access. Else, load student labor history modal.*/
  if (this.getAttribute('value') == 'false') {
    $("#flash_container").html('<div class="alert alert-danger" role="alert" id="flasher">You do not have access to this department\'s information.</div>');
    $("#flasher").delay(3000).fadeOut();
- }
- else {
+ } else {
    loadLaborHistoryModal(this.id)
  }
 });
@@ -33,21 +30,20 @@ function redirection(laborStatusKey){
   $("#rehire").attr("href", "/laborstatusform/" + laborStatusKey); // will go to the lsf controller
   $("#release").attr("href", "/laborReleaseForm/" + laborStatusKey); // will go to labor release form controller
   $("#sle").attr("href", "/sle/" + laborStatusKey); // will go to student labor evaluations controller
-  // console.log(laborStatusKey);
 }
 
 function mailPositionToLabor(){
-  let subject = `Labor Position Information for ${$('#studentDetails').text()}`
+  let subject = `Labor Position Question about ${$('#studentDetails').text()}`
   subject= subject.replace(/\s+/g, ' ')
-  let body = `Student Name:${$('#studentDetails').text()}%0D%0A`+
+  let body = `%0D%0A%0D%0AStudent Name:${$('#studentDetails').text()}%0D%0A`+
              `Term: ${$('#laborTerm').text()}%0D%0A`+
-             `Department (ID): ${$('#laborDepartment').text()}%0D%0A`+
              `Supervisor: ${$('#laborSupervisor').text()}%0D%0A`+
+             `Department (ID): ${$('#laborDepartment').text()}%0D%0A`+
              `Job Type (Hours): ${$('#laborJobType').text()}%0D%0A`+
              `Position (WLS): ${$('#laborPosition').text()}%0D%0A`+
              `Start Date: ${$('#laborStartDate').text()}%0D%0A`+
              `End Date: ${$('#laborEndDate').text()}`
-  body = body.replace(/\s+/g, ' ')
+  body = body.replace(/\s+/g, '%20')
   window.location.href = `mailto:labor@berea.edu?subject=${subject}&body=${body}`;
 
 }

--- a/app/templates/snips/studentHistoryModal.html
+++ b/app/templates/snips/studentHistoryModal.html
@@ -14,9 +14,8 @@
       <div class="original-name">Originally filed under "{{statusForm.studentName}}"</div>
       {% endif %}
   </span>
-  <div class="btn btn-primary" id="easyEmail" onClick="mailPositionToLabor()"><span>Email Labor</span></div>
 </div>
-<div class="modal-body" id="modalid">
+<div class="modal-body" id="studentLaborDetailsModal">
 
   <dl class="row">
     <dt class="col-sm-3">Term</dt>
@@ -205,11 +204,12 @@
     {% else %}
       <div class = "col-sm-{{12/buttonState.num_buttons}}">
 
+      <a href="#"><button class="btn btn-primary" id="emailLabor">Email Labor</button></a>
       {% if buttonState.rehire %}
         <a id="rehire" href="#"><button type="submit" name="submit" value="submit" class="btn btn-success" onclick="redirection({{statusForm.laborStatusFormID}})">Rehire</button></a>
       {% endif %}
       {% if buttonState.withdraw %}
-        <button type="button" class="btn btn-danger" data-dismiss="modal" onclick = "withdrawform({{statusForm.laborStatusFormID}})">Withdraw</button>
+        <button type="button" class="btn btn-danger"  data-dismiss="modal" onclick = "withdrawform({{statusForm.laborStatusFormID}})">Withdraw</button>
       {% endif %}
       {% if buttonState.correction %}
         <a id="alter" href="#"><button type="button" class="btn btn-info" onclick="redirection({{statusForm.laborStatusFormID}})">Modify</button></a>

--- a/app/templates/snips/studentHistoryModal.html
+++ b/app/templates/snips/studentHistoryModal.html
@@ -7,40 +7,40 @@
   <button type="button" class="close" data-dismiss="modal">&times;</button>
 
   <span style="text-align: right;"><button type="button" class="btn btn-default btn col-sm-2" id="print" onclick="fillPDF({{statusForm.laborStatusFormID}})"><span class="glyphicon glyphicon-print"></span> Print</button></span>
-  <span class="h3 col-sm-9 modalHeader">
+  <span class="h3 col-sm-9 modalHeader" id="studentDetails">
       {{statusForm.studentSupervisee.FIRST_NAME}} {{statusForm.studentSupervisee.LAST_NAME}} <a href="mailto:{{statusForm.studentSupervisee.STU_EMAIL}}"><span class="glyphicon glyphicon-envelope mailtoIcon"></span></a>
       <br><span class="h4">{{statusForm.studentSupervisee.ID}}</span>
       {% if statusForm.studentSupervisee.FIRST_NAME + " " + statusForm.studentSupervisee.LAST_NAME != statusForm.studentName %}
       <div class="original-name">Originally filed under "{{statusForm.studentName}}"</div>
       {% endif %}
   </span>
-
+  <div class="btn btn-primary" id="easyEmail" onClick="mailPositionToLabor()"><span>Email Labor</span></div>
 </div>
 <div class="modal-body" id="modalid">
 
   <dl class="row">
     <dt class="col-sm-3">Term</dt>
-    <dd class="col-sm-9">{{statusForm.termCode.termName}}</dd>
+    <dd class="col-sm-9" id="laborTerm">{{statusForm.termCode.termName}}</dd>
 
     <dt class="col-sm-3">Department (ID)</dt>
-    <dd class="col-sm-9">{{statusForm.department.DEPT_NAME}} ({{statusForm.department.ORG}}-{{statusForm.department.ACCOUNT}})</dd>
+    <dd class="col-sm-9" id="laborDepartment">{{statusForm.department.DEPT_NAME}} ({{statusForm.department.ORG}}-{{statusForm.department.ACCOUNT}})</dd>
 
     <dt class="col-sm-3">Supervisor</dt>
-    <dd class="col-sm-9">{{statusForm.supervisor.FIRST_NAME}} {{statusForm.supervisor.LAST_NAME}} - {{statusForm.supervisor.ID}} <a href="mailto:{{statusForm.supervisor.EMAIL}}"><span class="glyphicon glyphicon-envelope mailtoIcon"></span></a></dd>
+    <dd class="col-sm-9" id="laborSupervisor">{{statusForm.supervisor.FIRST_NAME}} {{statusForm.supervisor.LAST_NAME}} - {{statusForm.supervisor.ID}} <a href="mailto:{{statusForm.supervisor.EMAIL}}"><span class="glyphicon glyphicon-envelope mailtoIcon"></span></a></dd>
 
     <dt class="col-sm-3">Job Type (Hours)</dt>
-    <dd class="col-sm-9">{{statusForm.jobType}}
+    <dd class="col-sm-9" id="laborJobType">{{statusForm.jobType}}
       ({% if statusForm.weeklyHours == None %}{{statusForm.contractHours}}{% else %}{{statusForm.weeklyHours}}{% endif %})
     </dd>
 
     <dt class="col-sm-3">Position (WLS)</dt>
-    <dd class="col-sm-9">{{statusForm.POSN_CODE}}  {{statusForm.POSN_TITLE}} ({{statusForm.WLS}})</dd>
+    <dd class="col-sm-9" id="laborPosition">{{statusForm.POSN_CODE}}  {{statusForm.POSN_TITLE}} ({{statusForm.WLS}})</dd>
 
     <dt class="col-sm-3">Start Date</dt>
-    <dd class="col-sm-9">{{statusForm.startDate.strftime('%m-%d-%Y')}}</dd>
+    <dd class="col-sm-9" id="laborStartDate">{{statusForm.startDate.strftime('%m-%d-%Y')}}</dd>
 
     <dt class="col-sm-3">End Date</dt>
-    <dd class="col-sm-9">{{statusForm.endDate.strftime('%m-%d-%Y')}}</dd>
+    <dd class="col-sm-9" id="laborEndDate">{{statusForm.endDate.strftime('%m-%d-%Y')}}</dd>
   </dl>
 
   <hr>


### PR DESCRIPTION
Issue:
Needed the ability to send an email from the position view page as a supervisor.

Fixes:
Added a mailto in JavaScript which gets student information and information about the labor position the student is enrolled in and opens an email to the labor department.

Test:
Go to supervisor portal, complete form search information to find a student. Click the student's name on the table which appears after the search. From there Click the Email Labor button which should open the default email handler on your system and populate the body and subject with the appropriate information from the modal. 

Fixes #418