### PR TITLE
added button for resubmitting forms to banner

### DIFF
--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -258,8 +258,7 @@ def submitToBanner(form_id):
         
         # Add to Banner only if the form is approved
         if form_history.status.statusName == "Approved":
-            history_type_data = FormHistory.get(FormHistory.formID == int(form_id))
-            history_type = str(history_type_data.historyType)
+            history_type = str(form_history.historyType)
             labor_form = FormHistory.get(FormHistory.formID == int(form_id), FormHistory.historyType == history_type)
     
             conn = Banner()

--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -247,37 +247,34 @@ def finalUpdateStatus(raw_status):
 @admin.route('/admin/addToBanner/<form_id>', methods=['POST'])
 def submitToBanner(form_id):
     print(form_id)
-    print("Hell000000")
 
-    ''' This method adds a form to Banner if it's not already approved '''
+    ''' This method adds a form to Banner if it's already approved '''
     currentUser = require_login()
-    if not currentUser:  # Not logged in
-        return jsonify({"success": False, "message": "User not logged in"}), 403
-    if not currentUser.isLaborAdmin:  # Not an admin
-        return jsonify({"success": False, "message": "User is not an admin"}), 403
+    if not currentUser:                    # Not logged in
+        return render_template('errors/403.html'), 403
+    if not currentUser.isLaborAdmin:       # Not an admin
+        return render_template('errors/403.html'), 403
 
     try:
-        form_history = FormHistory.get(FormHistory.formHistoryID == int(form_id))
+        form_history = FormHistory.get(FormHistory.formID == int(form_id))
+        
+        # Add to Banner only if the form is approved
         if form_history.status.statusName == "Approved":
-            print("-------------------------yes-------------------")
-            # Add to Banner only if the form is approved
-
-            history_type_data = FormHistory.get(FormHistory.formHistoryID == int(form_id))
+            history_type_data = FormHistory.get(FormHistory.formID == int(form_id))
             history_type = str(history_type_data.historyType)
-
-            labor_form = FormHistory.get(FormHistory.formHistoryID == int(form_id), FormHistory.historyType == history_type)
+            labor_form = FormHistory.get(FormHistory.formID == int(form_id), FormHistory.historyType == history_type)
     
             conn = Banner()
             save_status = conn.insert(labor_form)
             if save_status:
-                return jsonify({"success": True, "message": "Form added to Banner"})
+                return jsonify({"success": True})
             else:
-                return jsonify({"success": False, "message": "Unable to add form to Banner"}), 500
+                return jsonify({"success": False}), 500
         else:
-            return jsonify({"success": False, "message": "Form has not been approved yet"})
+            return jsonify({"success": False})
     except Exception as e:
         print("Error adding form to Banner:", e)
-        return jsonify({"success": False, "message": "Error adding form to Banner"}), 500
+        return jsonify({"success": False}), 500
 
 def saveStatus(new_status, form_ids, currentUser):
     try:

--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -246,8 +246,6 @@ def finalUpdateStatus(raw_status):
 
 @admin.route('/admin/addToBanner/<form_id>', methods=['POST'])
 def submitToBanner(form_id):
-    print(form_id)
-
     ''' This method adds a form to Banner if it's already approved '''
     currentUser = require_login()
     if not currentUser:                    # Not logged in

--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -244,6 +244,27 @@ def finalUpdateStatus(raw_status):
     form_ids = eval(request.data.decode("utf-8"))
     return saveStatus(new_status, form_ids, currentUser)
 
+@admin.route('/admin/addToBanner', methods=['POST'])
+def addToBanner(form_ids, currenttUser):
+    for id in form_ids:
+            history_type_data = FormHistory.get(FormHistory.formHistoryID == int(id))
+            history_type = str(history_type_data.historyType)
+
+            labor_forms = FormHistory.get(FormHistory.formHistoryID == int(id), FormHistory.historyType == history_type)
+            labor_forms.status = Status.get(Status.statusName == new_status)
+            labor_forms.reviewedDate = date.today()
+            labor_forms.reviewedBy = currentUser
+
+            # Add to BANNER
+            save_status = True # default true so that we will still save in other cases
+            if new_status == 'Approved' and history_type == "Labor Status Form" and labor_forms.formID.POSN_CODE != "S12345": # don't update banner for Adjustment forms or for CS dummy position
+                if labor_forms.formID.POSN_CODE == "SNOLAB":
+                       labor_forms.formID.weeklyHours = 10
+                conn = Banner()
+                save_status = conn.insert(labor_forms)
+
+
+
 def saveStatus(new_status, form_ids, currentUser):
     try:
         if new_status == 'Denied':

--- a/app/static/js/allPendingForms.js
+++ b/app/static/js/allPendingForms.js
@@ -145,16 +145,35 @@ function finalApproval() { //this method changes the status of the lsf from pend
   });
 }
 
-function addToBanner(){
+function submitToBanner() {
+  $(".btn").prop("disabled", true);
+  $(".close").prop("disabled", true);
+  $("#submitToBannerButton").text("Processing...");
+  var data = JSON.stringify(labor_details_ids);
   $.ajax({
     type: "POST",
-    url: "/admin/addToBanner",
-    datatype: "json",
-    data: data,
+    url: "/admin/submitToBanner",  // Remove the trailing slash
+    data: data,  // Pass the JSON data in the request body
     contentType: 'application/json',
+    success: function(response) {
+      if (response) {
+        if (response.success) {
+          $(".btn").prop("disabled", false);
+          $(".close").prop("disabled", false);
+          $("#submitToBannerButton").text("Submit to Banner");
 
+          // Handle success as needed
+          alert("Form submitted to Banner successfully!");
+        } else {
+          // Handle submission failure
+          alert("Failed to submit form to Banner.");
+        }
+      }
+    }
   });
 }
+
+
 
 
 var laborDenialInfo = []; //this arrary is for insertDenial() and finalDenial() methods

--- a/app/static/js/allPendingForms.js
+++ b/app/static/js/allPendingForms.js
@@ -145,35 +145,20 @@ function finalApproval() { //this method changes the status of the lsf from pend
   });
 }
 
-function submitToBanner() {
-  $(".btn").prop("disabled", true);
-  $(".close").prop("disabled", true);
-  $("#submitToBannerButton").text("Processing...");
-  var data = JSON.stringify(labor_details_ids);
+
+function submitToBanner(formId) {
   $.ajax({
     type: "POST",
-    url: "/admin/submitToBanner",  // Remove the trailing slash
-    data: data,  // Pass the JSON data in the request body
-    contentType: 'application/json',
+    url: "/admin/addToBanner/" + formId,
     success: function(response) {
-      if (response) {
-        if (response.success) {
-          $(".btn").prop("disabled", false);
-          $(".close").prop("disabled", false);
-          $("#submitToBannerButton").text("Submit to Banner");
-
-          // Handle success as needed
-          alert("Form submitted to Banner successfully!");
-        } else {
-          // Handle submission failure
-          alert("Failed to submit form to Banner.");
-        }
+      if (response.success) {
+        alert(response.message);
+      } else {
+        alert("Error: " + response.message);
       }
     }
   });
 }
-
-
 
 
 var laborDenialInfo = []; //this arrary is for insertDenial() and finalDenial() methods

--- a/app/static/js/allPendingForms.js
+++ b/app/static/js/allPendingForms.js
@@ -145,6 +145,9 @@ function finalApproval() { //this method changes the status of the lsf from pend
   });
 }
 
+function studentHistoryModalClose(){
+  modal.style.display = "none";
+}
 
 function submitToBanner(formId) {
   $.ajax({
@@ -152,14 +155,16 @@ function submitToBanner(formId) {
     url: "/admin/addToBanner/" + formId,
     success: function(response) {
       if (response.success) {
-        alert(response.message);
+        msgFlash("Form submitted to banner successfully ", "success");
+        studentHistoryModalClose();
       } else {
-        alert("Error: " + response.message);
+        msgFlash("Form failed to submit to banner", "fail");
+        studentHistoryModalClose();
+
       }
     }
   });
 }
-
 
 var laborDenialInfo = []; //this arrary is for insertDenial() and finalDenial() methods
 //This method calls AJAX from checkforms methods in the controller

--- a/app/static/js/allPendingForms.js
+++ b/app/static/js/allPendingForms.js
@@ -160,7 +160,6 @@ function submitToBanner(formId) {
       } else {
         msgFlash("Form failed to submit to banner", "fail");
         studentHistoryModalClose();
-
       }
     }
   });

--- a/app/static/js/allPendingForms.js
+++ b/app/static/js/allPendingForms.js
@@ -145,6 +145,18 @@ function finalApproval() { //this method changes the status of the lsf from pend
   });
 }
 
+function addToBanner(){
+  $.ajax({
+    type: "POST",
+    url: "/admin/addToBanner",
+    datatype: "json",
+    data: data,
+    contentType: 'application/json',
+
+  });
+}
+
+
 var laborDenialInfo = []; //this arrary is for insertDenial() and finalDenial() methods
 //This method calls AJAX from checkforms methods in the controller
 function insertDenial(val) {

--- a/app/templates/snips/studentHistoryModal.html
+++ b/app/templates/snips/studentHistoryModal.html
@@ -234,6 +234,10 @@
             </a>
           </div>
       {% endif %}
+      {% if buttonState.evaluation_exists %}
+        <button type="submit" name="submit" value="submit" class="btn btn-primary" onclick="addToBanner()"> Resubmit </button>
+    </div>
+    {% endif %}
     {% endif %}
 
 

--- a/app/templates/snips/studentHistoryModal.html
+++ b/app/templates/snips/studentHistoryModal.html
@@ -221,18 +221,18 @@
         <a id="alter" href="#"><button type="button" class="btn btn-info" onclick="redirection({{statusForm.laborStatusFormID}})">Adjustment Form</button></a>
       {% endif %}
       {% if buttonState.evaluate %}
-        <a id="sle" href="#">
-          <button type="submit" name="submit" value="submit" class="btn btn-warning" onclick="redirection({{statusForm.laborStatusFormID}})"> Evaluate
-          </button>
-          </a>
-        </div>
+            <a id="sle" href="#">
+              <button type="submit" name="submit" value="submit" class="btn btn-warning" onclick="redirection({{statusForm.laborStatusFormID}})"> Evaluate
+              </button>
+            </a>
+          </div>
       {% endif %}
       {% if buttonState.evaluation_exists %}
-        <a id="sle" href="#">
-          <button type="submit" name="submit" value="submit" class="btn btn-warning" onclick="redirection({{statusForm.laborStatusFormID}})"> Show Evaluation
-          </button>
-          </a>
-        </div>
+            <a id="sle" href="#">
+              <button type="submit" name="submit" value="submit" class="btn btn-warning" onclick="redirection({{statusForm.laborStatusFormID}})"> Show Evaluation
+              </button>
+            </a>
+          </div>
       {% endif %}
       <button type="button" class="btn btn-primary" data-dismiss="modal" onclick="submitToBanner({{statusForm.laborStatusFormID}})">Submit to Banner</button>      
     {% endif %}

--- a/app/templates/snips/studentHistoryModal.html
+++ b/app/templates/snips/studentHistoryModal.html
@@ -234,7 +234,7 @@
           </a>
         </div>
       {% endif %}
-      <button id="submitToBannerButton" type="button" class="btn btn-primary" data-dismiss="modal" onclick="submitToBanner()">Submit to Banner</button>
+      <button type="button" class="btn btn-primary" onclick="submitToBanner({{statusForm.laborStatusFormID}})">Submit to Banner</button>
       <div id="result"></div>
       
     {% endif %}

--- a/app/templates/snips/studentHistoryModal.html
+++ b/app/templates/snips/studentHistoryModal.html
@@ -234,7 +234,7 @@
           </a>
         </div>
       {% endif %}
-      <button type="button" class="btn btn-primary" onclick="submitToBanner({{statusForm.laborStatusFormID}})">Submit to Banner</button>
+      <button type="button" class="btn btn-primary" data-dismiss="modal" onclick="submitToBanner({{statusForm.laborStatusFormID}})">Submit to Banner</button>
       <div id="result"></div>
       
     {% endif %}

--- a/app/templates/snips/studentHistoryModal.html
+++ b/app/templates/snips/studentHistoryModal.html
@@ -234,9 +234,7 @@
           </a>
         </div>
       {% endif %}
-      <button type="button" class="btn btn-primary" data-dismiss="modal" onclick="submitToBanner({{statusForm.laborStatusFormID}})">Submit to Banner</button>
-      <div id="result"></div>
-      
+      <button type="button" class="btn btn-primary" data-dismiss="modal" onclick="submitToBanner({{statusForm.laborStatusFormID}})">Submit to Banner</button>      
     {% endif %}
 
     

--- a/app/templates/snips/studentHistoryModal.html
+++ b/app/templates/snips/studentHistoryModal.html
@@ -221,26 +221,30 @@
         <a id="alter" href="#"><button type="button" class="btn btn-info" onclick="redirection({{statusForm.laborStatusFormID}})">Adjustment Form</button></a>
       {% endif %}
       {% if buttonState.evaluate %}
-            <a id="sle" href="#">
-              <button type="submit" name="submit" value="submit" class="btn btn-warning" onclick="redirection({{statusForm.laborStatusFormID}})"> Evaluate
-              </button>
-            </a>
-          </div>
+          <a id="sle" href="#">
+            <button type="submit" name="submit" value="submit" class="btn btn-warning" onclick="redirection({{statusForm.laborStatusFormID}})"> Evaluate
+            </button>
+          </a>
+        </div>
       {% endif %}
       {% if buttonState.evaluation_exists %}
-            <a id="sle" href="#">
-              <button type="submit" name="submit" value="submit" class="btn btn-warning" onclick="redirection({{statusForm.laborStatusFormID}})"> Show Evaluation
-              </button>
-            </a>
-            <a id="submitToBanner"><button type="submit" name="submit" value="submit" class="btn btn-primary" onclick="finalApproval()">Submit to Banner</button></a>
-          </div>
+          <a id="sle" href="#">
+            <button type="submit" name="submit" value="submit" class="btn btn-warning" onclick="redirection({{statusForm.laborStatusFormID}})"> Show Evaluation
+            </button>
+          </a>
+        </div>
       {% endif %}
-      {% if buttonState.evaluation_exists %}
-    </div>
+      <button id="submitToBannerButton" type="button" class="btn btn-primary" data-dismiss="modal" onclick="submitToBanner()">Submit to Banner</button>
+      <div id="result"></div>
+      
     {% endif %}
-    {% endif %}
+
+    
+    
+    
+    
+  </div>
 
 
 
 
-</div>

--- a/app/templates/snips/studentHistoryModal.html
+++ b/app/templates/snips/studentHistoryModal.html
@@ -199,49 +199,48 @@
 </div>
 
 <div class="modal-footer" id="modalFooter">
-    {% if buttonState.num_buttons == 0 %}
-    <div class = "col-sm-{{12}}">
-      <p style="color:blue;" class="pTag"><span class="glyphicon glyphicon-exclamation-sign"></span><strong> Changes to this form are unavailable currently. Contact the Labor Office if you feel this is an error.</strong></p>
-    {% else %}
-      <div class = "col-sm-{{12/buttonState.num_buttons}}">
+  {% if buttonState.num_buttons == 0 %}
+  <div class = "col-sm-{{12}}">
+    <p style="color:blue;" class="pTag"><span class="glyphicon glyphicon-exclamation-sign"></span><strong> Changes to this form are unavailable currently. Contact the Labor Office if you feel this is an error.</strong></p>
+  {% else %}
+    <div class = "col-sm-{{12/buttonState.num_buttons}}">
 
-      {% if buttonState.rehire %}
-        <a id="rehire" href="#"><button type="submit" name="submit" value="submit" class="btn btn-success" onclick="redirection({{statusForm.laborStatusFormID}})">Rehire</button></a>
-      {% endif %}
-      {% if buttonState.withdraw %}
-        <button type="button" class="btn btn-danger" data-dismiss="modal" onclick = "withdrawform({{statusForm.laborStatusFormID}})">Withdraw</button>
-      {% endif %}
-      {% if buttonState.correction %}
-        <a id="alter" href="#"><button type="button" class="btn btn-info" onclick="redirection({{statusForm.laborStatusFormID}})">Modify</button></a>
-      {% endif %}
-      {% if buttonState.release %}
-        <a id="release" href="#"><button type="button" class="btn btn-danger" onclick="redirection({{statusForm.laborStatusFormID}})">Release</button></a>
-      {% endif %}
-      {% if buttonState.adjust %}
-        <a id="alter" href="#"><button type="button" class="btn btn-info" onclick="redirection({{statusForm.laborStatusFormID}})">Adjustment Form</button></a>
-      {% endif %}
-      {% if buttonState.evaluate %}
+    {% if buttonState.rehire %}
+      <a id="rehire" href="#"><button type="submit" name="submit" value="submit" class="btn btn-success" onclick="redirection({{statusForm.laborStatusFormID}})">Rehire</button></a>
+    {% endif %}
+    {% if buttonState.withdraw %}
+      <button type="button" class="btn btn-danger" data-dismiss="modal" onclick = "withdrawform({{statusForm.laborStatusFormID}})">Withdraw</button>
+    {% endif %}
+    {% if buttonState.correction %}
+      <a id="alter" href="#"><button type="button" class="btn btn-info" onclick="redirection({{statusForm.laborStatusFormID}})">Modify</button></a>
+    {% endif %}
+    {% if buttonState.release %}
+      <a id="release" href="#"><button type="button" class="btn btn-danger" onclick="redirection({{statusForm.laborStatusFormID}})">Release</button></a>
+    {% endif %}
+    {% if buttonState.adjust %}
+      <a id="alter" href="#"><button type="button" class="btn btn-info" onclick="redirection({{statusForm.laborStatusFormID}})">Adjustment Form</button></a>
+    {% endif %}
+    {% if buttonState.evaluate %}
           <a id="sle" href="#">
             <button type="submit" name="submit" value="submit" class="btn btn-warning" onclick="redirection({{statusForm.laborStatusFormID}})"> Evaluate
             </button>
           </a>
         </div>
-      {% endif %}
-      {% if buttonState.evaluation_exists %}
+    {% endif %}
+    {% if buttonState.evaluation_exists %}
           <a id="sle" href="#">
             <button type="submit" name="submit" value="submit" class="btn btn-warning" onclick="redirection({{statusForm.laborStatusFormID}})"> Show Evaluation
             </button>
           </a>
         </div>
-      {% endif %}
-      <button type="button" class="btn btn-primary" data-dismiss="modal" onclick="submitToBanner({{statusForm.laborStatusFormID}})">Submit to Banner</button>      
     {% endif %}
+    <button type="button" class="btn btn-primary" data-dismiss="modal" onclick="submitToBanner({{statusForm.laborStatusFormID}})">Submit to Banner</button>      
+  {% endif %}
 
-    
-    
-    
-    
-  </div>
+
+
+</div>
+   
 
 
 

--- a/app/templates/snips/studentHistoryModal.html
+++ b/app/templates/snips/studentHistoryModal.html
@@ -199,48 +199,47 @@
 </div>
 
 <div class="modal-footer" id="modalFooter">
-  {% if buttonState.num_buttons == 0 %}
-  <div class = "col-sm-{{12}}">
-    <p style="color:blue;" class="pTag"><span class="glyphicon glyphicon-exclamation-sign"></span><strong> Changes to this form are unavailable currently. Contact the Labor Office if you feel this is an error.</strong></p>
-  {% else %}
-    <div class = "col-sm-{{12/buttonState.num_buttons}}">
+    {% if buttonState.num_buttons == 0 %}
+    <div class = "col-sm-{{12}}">
+      <p style="color:blue;" class="pTag"><span class="glyphicon glyphicon-exclamation-sign"></span><strong> Changes to this form are unavailable currently. Contact the Labor Office if you feel this is an error.</strong></p>
+    {% else %}
+      <div class = "col-sm-{{12/buttonState.num_buttons}}">
 
-    {% if buttonState.rehire %}
-      <a id="rehire" href="#"><button type="submit" name="submit" value="submit" class="btn btn-success" onclick="redirection({{statusForm.laborStatusFormID}})">Rehire</button></a>
-    {% endif %}
-    {% if buttonState.withdraw %}
-      <button type="button" class="btn btn-danger" data-dismiss="modal" onclick = "withdrawform({{statusForm.laborStatusFormID}})">Withdraw</button>
-    {% endif %}
-    {% if buttonState.correction %}
-      <a id="alter" href="#"><button type="button" class="btn btn-info" onclick="redirection({{statusForm.laborStatusFormID}})">Modify</button></a>
-    {% endif %}
-    {% if buttonState.release %}
-      <a id="release" href="#"><button type="button" class="btn btn-danger" onclick="redirection({{statusForm.laborStatusFormID}})">Release</button></a>
-    {% endif %}
-    {% if buttonState.adjust %}
-      <a id="alter" href="#"><button type="button" class="btn btn-info" onclick="redirection({{statusForm.laborStatusFormID}})">Adjustment Form</button></a>
-    {% endif %}
-    {% if buttonState.evaluate %}
-          <a id="sle" href="#">
-            <button type="submit" name="submit" value="submit" class="btn btn-warning" onclick="redirection({{statusForm.laborStatusFormID}})"> Evaluate
-            </button>
+      {% if buttonState.rehire %}
+        <a id="rehire" href="#"><button type="submit" name="submit" value="submit" class="btn btn-success" onclick="redirection({{statusForm.laborStatusFormID}})">Rehire</button></a>
+      {% endif %}
+      {% if buttonState.withdraw %}
+        <button type="button" class="btn btn-danger" data-dismiss="modal" onclick = "withdrawform({{statusForm.laborStatusFormID}})">Withdraw</button>
+      {% endif %}
+      {% if buttonState.correction %}
+        <a id="alter" href="#"><button type="button" class="btn btn-info" onclick="redirection({{statusForm.laborStatusFormID}})">Modify</button></a>
+      {% endif %}
+      {% if buttonState.release %}
+        <a id="release" href="#"><button type="button" class="btn btn-danger" onclick="redirection({{statusForm.laborStatusFormID}})">Release</button></a>
+      {% endif %}
+      {% if buttonState.adjust %}
+        <a id="alter" href="#"><button type="button" class="btn btn-info" onclick="redirection({{statusForm.laborStatusFormID}})">Adjustment Form</button></a>
+      {% endif %}
+      {% if buttonState.evaluate %}
+        <a id="sle" href="#">
+          <button type="submit" name="submit" value="submit" class="btn btn-warning" onclick="redirection({{statusForm.laborStatusFormID}})"> Evaluate
+          </button>
           </a>
         </div>
-    {% endif %}
-    {% if buttonState.evaluation_exists %}
-          <a id="sle" href="#">
-            <button type="submit" name="submit" value="submit" class="btn btn-warning" onclick="redirection({{statusForm.laborStatusFormID}})"> Show Evaluation
-            </button>
+      {% endif %}
+      {% if buttonState.evaluation_exists %}
+        <a id="sle" href="#">
+          <button type="submit" name="submit" value="submit" class="btn btn-warning" onclick="redirection({{statusForm.laborStatusFormID}})"> Show Evaluation
+          </button>
           </a>
         </div>
+      {% endif %}
+      <button type="button" class="btn btn-primary" data-dismiss="modal" onclick="submitToBanner({{statusForm.laborStatusFormID}})">Submit to Banner</button>      
     {% endif %}
-    <button type="button" class="btn btn-primary" data-dismiss="modal" onclick="submitToBanner({{statusForm.laborStatusFormID}})">Submit to Banner</button>      
-  {% endif %}
 
-
-
-</div>
-   
+    
+    
+  </div>
 
 
 

--- a/app/templates/snips/studentHistoryModal.html
+++ b/app/templates/snips/studentHistoryModal.html
@@ -232,10 +232,10 @@
               <button type="submit" name="submit" value="submit" class="btn btn-warning" onclick="redirection({{statusForm.laborStatusFormID}})"> Show Evaluation
               </button>
             </a>
+            <a id="submitToBanner"><button type="submit" name="submit" value="submit" class="btn btn-primary" onclick="finalApproval()">Submit to Banner</button></a>
           </div>
       {% endif %}
       {% if buttonState.evaluation_exists %}
-        <button type="submit" name="submit" value="submit" class="btn btn-primary" onclick="addToBanner()"> Resubmit </button>
     </div>
     {% endif %}
     {% endif %}


### PR DESCRIPTION
fixes issue #419 

Did:
- added a `Submit to Banner` button on the student history modal in supervisor portal for resubmitting a form to banner that was not properly submitted when the form was approved

Test:
- reset database `from-backup` in lsf
- run flask
- select the supervisor portal from the sidebar, click form search, select `Approved` under Limit Form Status
- you should see a list of students, click any student's name
- when the modal pops up, click `Submit to Banner`
- the modal should close
- there should be a flash message indicating whether it was successfully submitted or not