### PR TITLE
417 adjustment error

### DIFF
--- a/app/controllers/main_routes/alterLSF.py
+++ b/app/controllers/main_routes/alterLSF.py
@@ -142,10 +142,8 @@ def submitAlteredLSF(laborStatusKey):
         currentDate = datetime.now().strftime("%Y-%m-%d")
         fieldsChanged = eval(request.data.decode("utf-8")) # This fixes byte indices must be intergers or slices error
         fieldsChanged = dict(fieldsChanged)
-        print(fieldsChanged)
         student = LaborStatusForm.get(LaborStatusForm.laborStatusFormID == laborStatusKey)
         formStatus = (FormHistory.get(FormHistory.formID == laborStatusKey).status_id)
-        print(formStatus)
         formHistoryIDs = []
         lsf = LaborStatusForm.get(LaborStatusForm.laborStatusFormID == laborStatusKey)
         for fieldName in fieldsChanged:
@@ -176,7 +174,6 @@ def submitAlteredLSF(laborStatusKey):
                                                                                                     student.studentSupervisee.FIRST_NAME,
                                                                                                     student.studentSupervisee.LAST_NAME)
         flash(message, "danger")
-        raise e
         print("An error occured during form submission:", e)
         return jsonify({"Success": False}), 500
 
@@ -251,7 +248,7 @@ def adjustLSF(fieldsChanged, fieldName, lsf, currentUser, host=None):
                                            status       = status.statusName)
         
         if fieldName == "weeklyHours":
-            newWeeklyHours = fieldsChanged[fieldName]['newValue']
+            newWeeklyHours = int(fieldsChanged[fieldName]['newValue'])
             createOverloadForm(newWeeklyHours, lsf, currentUser, adjustedforms.adjustedFormID, adjustedFormHistory,host=host)
 
         return adjustedFormHistory.formHistoryID
@@ -270,12 +267,8 @@ def createOverloadForm(newWeeklyHours, lsf, currentUser, adjustedForm=None,  for
     if allTermForms:
         for statusForm in allTermForms:
             previousTotalHours += statusForm.weeklyHours
-    print(f"previousTotalHours (Calculated from allTermForms): {previousTotalHours}") # beans
     changeInHours = newWeeklyHours - lsf.weeklyHours
     newTotalHours = previousTotalHours + changeInHours
-    print(f"newWeeklyHours (The one that's a parameter): {newWeeklyHours}") # beans
-    print(f"NewTotalHours (Calculated via adding the change in hours {changeInHours}): {newTotalHours}") # beans
-    print('*'*1000)
 
     if previousTotalHours <= 15 and newTotalHours > 15:  # If we weren't overloading and now we are
         newLaborOverloadForm = OverloadForm.create(studentOverloadReason = "None")
@@ -308,8 +301,6 @@ def createOverloadForm(newWeeklyHours, lsf, currentUser, adjustedForm=None,  for
 
     # This will delete an overload form after the hours are changed
     elif previousTotalHours > 15 and newTotalHours <= 15:  # If we were overloading and now we aren't
-            print("We're going to delete your overload form now!")
-            print('*'*1000)
             deleteOverloadForm = FormHistory.get((FormHistory.formID == lsf.laborStatusFormID) & (FormHistory.historyType == "Labor Overload Form"))
             deleteOverloadForm = OverloadForm.get(OverloadForm.overloadFormID == deleteOverloadForm.overloadForm.overloadFormID)
             deleteOverloadForm.delete_instance()

--- a/app/controllers/main_routes/alterLSF.py
+++ b/app/controllers/main_routes/alterLSF.py
@@ -135,6 +135,8 @@ def submitAlteredLSF(laborStatusKey):
     """
     Submits an altered LSF form and creates a formHistory entry if appropriate
     """
+    print("We're in the route correctly") # beans
+    print('*'*1000)
     try:
         currentUser = require_login()
         if not currentUser:        # Not logged in
@@ -143,11 +145,11 @@ def submitAlteredLSF(laborStatusKey):
         fieldsChanged = eval(request.data.decode("utf-8")) # This fixes byte indices must be intergers or slices error
         fieldsChanged = dict(fieldsChanged)
         student = LaborStatusForm.get(LaborStatusForm.laborStatusFormID == laborStatusKey)
-        formStatus = (FormHistory.get(FormHistory.formID == laborStatusKey).status_id)
+        formStatus = (FormHistory.get(FormHistory.formID == laborStatusKey).status_id)  # Beans, TODO: it seems like this wouldn't work if there are more than one form history values in for the form. For example, an lsf and an overload form would both have the same labor status key. Which one do we want the status for?
         formHistoryIDs = []
         lsf = LaborStatusForm.get(LaborStatusForm.laborStatusFormID == laborStatusKey)
         for fieldName in fieldsChanged:
-            if formStatus =="Pending":
+            if formStatus =="Pending" or formStatus == "Pre-Student Approval":
                 modifyLSF(fieldsChanged, fieldName, lsf, currentUser, host=request.host)
             elif formStatus =="Approved":
                 changedForm = adjustLSF(fieldsChanged, fieldName, lsf, currentUser, host=request.host)
@@ -179,6 +181,8 @@ def submitAlteredLSF(laborStatusKey):
 
 
 def modifyLSF(fieldsChanged, fieldName, lsf, currentUser, host=None):
+    print("modifying lsf") # beans
+    print('*'*1000)
     if fieldName == "supervisorNotes":
         noteEntry = Notes.create(formID           = lsf.laborStatusFormID,
                                          createdBy     = currentUser,
@@ -209,6 +213,8 @@ def modifyLSF(fieldsChanged, fieldName, lsf, currentUser, host=None):
         newWeeklyHours = int(fieldsChanged[fieldName]['newValue'])
         createOverloadForm(newWeeklyHours, lsf, currentUser, host=host)
         lsf.weeklyHours = newWeeklyHours
+        print(f"Updated the new weekly hours to {newWeeklyHours}") # beans
+        print('*'*1000)
         lsf.save()
 
     if fieldName == "contractHours":
@@ -225,6 +231,8 @@ def modifyLSF(fieldsChanged, fieldName, lsf, currentUser, host=None):
 
 
 def adjustLSF(fieldsChanged, fieldName, lsf, currentUser, host=None):
+    print("adjusting lsf") # beans
+    print('*'*1000)
     if fieldName == "supervisorNotes":
         newNoteEntry = Notes.create(formID        = lsf.laborStatusFormID,
                                          createdBy     = currentUser,
@@ -304,3 +312,4 @@ def createOverloadForm(newWeeklyHours, lsf, currentUser, adjustedForm=None,  for
             deleteOverloadForm = FormHistory.get((FormHistory.formID == lsf.laborStatusFormID) & (FormHistory.historyType == "Labor Overload Form"))
             deleteOverloadForm = OverloadForm.get(OverloadForm.overloadFormID == deleteOverloadForm.overloadForm.overloadFormID)
             deleteOverloadForm.delete_instance()
+            FormHistory.get((FormHistory.formID == lsf.laborStatusFormID) & (FormHistory.historyType == "Labor Overload Form"))

--- a/app/controllers/main_routes/alterLSF.py
+++ b/app/controllers/main_routes/alterLSF.py
@@ -135,8 +135,6 @@ def submitAlteredLSF(laborStatusKey):
     """
     Submits an altered LSF form and creates a formHistory entry if appropriate
     """
-    print("We're in the route correctly") # beans
-    print('*'*1000)
     try:
         currentUser = require_login()
         if not currentUser:        # Not logged in
@@ -145,7 +143,7 @@ def submitAlteredLSF(laborStatusKey):
         fieldsChanged = eval(request.data.decode("utf-8")) # This fixes byte indices must be intergers or slices error
         fieldsChanged = dict(fieldsChanged)
         student = LaborStatusForm.get(LaborStatusForm.laborStatusFormID == laborStatusKey)
-        formStatus = (FormHistory.get(FormHistory.formID == laborStatusKey).status_id)  # Beans, TODO: it seems like this wouldn't work if there are more than one form history values in for the form. For example, an lsf and an overload form would both have the same labor status key. Which one do we want the status for?
+        formStatus = (FormHistory.get(FormHistory.formID == laborStatusKey).status_id)
         formHistoryIDs = []
         lsf = LaborStatusForm.get(LaborStatusForm.laborStatusFormID == laborStatusKey)
         for fieldName in fieldsChanged:
@@ -181,8 +179,6 @@ def submitAlteredLSF(laborStatusKey):
 
 
 def modifyLSF(fieldsChanged, fieldName, lsf, currentUser, host=None):
-    print("modifying lsf") # beans
-    print('*'*1000)
     if fieldName == "supervisorNotes":
         noteEntry = Notes.create(formID           = lsf.laborStatusFormID,
                                          createdBy     = currentUser,
@@ -213,8 +209,6 @@ def modifyLSF(fieldsChanged, fieldName, lsf, currentUser, host=None):
         newWeeklyHours = int(fieldsChanged[fieldName]['newValue'])
         createOverloadForm(newWeeklyHours, lsf, currentUser, host=host)
         lsf.weeklyHours = newWeeklyHours
-        print(f"Updated the new weekly hours to {newWeeklyHours}") # beans
-        print('*'*1000)
         lsf.save()
 
     if fieldName == "contractHours":
@@ -231,8 +225,6 @@ def modifyLSF(fieldsChanged, fieldName, lsf, currentUser, host=None):
 
 
 def adjustLSF(fieldsChanged, fieldName, lsf, currentUser, host=None):
-    print("adjusting lsf") # beans
-    print('*'*1000)
     if fieldName == "supervisorNotes":
         newNoteEntry = Notes.create(formID        = lsf.laborStatusFormID,
                                          createdBy     = currentUser,
@@ -280,8 +272,6 @@ def createOverloadForm(newWeeklyHours, lsf, currentUser, adjustedForm=None,  for
 
     if previousTotalHours <= 15 and newTotalHours > 15:  # If we weren't overloading and now we are
         newLaborOverloadForm = OverloadForm.create(studentOverloadReason = "None")
-        print("Overload form created with reason: 'None'") # beans
-        print('*'*1000)
         newFormHistory = FormHistory.create(formID       = lsf.laborStatusFormID,
                                             historyType  = "Labor Overload Form",
                                             createdBy    = currentUser,
@@ -289,8 +279,6 @@ def createOverloadForm(newWeeklyHours, lsf, currentUser, adjustedForm=None,  for
                                             overloadForm = newLaborOverloadForm.overloadFormID,
                                             createdDate  = date.today(),
                                             status       = "Pre-Student Approval")
-        print(f"Form history created with formID: {lsf.laborStatusFormID}") # beans
-        print('*'*1000)
         try:
             if formHistories:
                 formHistories.status = "Pre-Student Approval"
@@ -314,8 +302,6 @@ def createOverloadForm(newWeeklyHours, lsf, currentUser, adjustedForm=None,  for
     # This will delete an overload form after the hours are changed
     elif previousTotalHours > 15 and newTotalHours <= 15:  # If we were overloading and now we aren't
             print(f"Trying to get formhistory with formID '{lsf.laborStatusFormID}' and history type: 'Labor Overload Form'")
-            deleteOverloadForm = FormHistory.get((FormHistory.formID == lsf.laborStatusFormID) & (FormHistory.historyType == "Labor Overload Form"))  # Beans, this has been crashing. It seems that this might be because the historyType starts as a normal Labor Status Form and isn't updated when the form becomes that of an overload
-            print("Found the form history at least") # beans
-            print('*'*1000)
+            deleteOverloadForm = FormHistory.get((FormHistory.formID == lsf.laborStatusFormID) & (FormHistory.historyType == "Labor Overload Form"))
             deleteOverloadForm = OverloadForm.get(OverloadForm.overloadFormID == deleteOverloadForm.overloadForm_id)
-            deleteOverloadForm.delete_instance()  # This line also deletes the Form History since it's set to cascade up in the model
+            deleteOverloadForm.delete_instance()  # This line also deletes the Form History since it's set to cascade up in the model file

--- a/app/controllers/main_routes/alterLSF.py
+++ b/app/controllers/main_routes/alterLSF.py
@@ -280,6 +280,8 @@ def createOverloadForm(newWeeklyHours, lsf, currentUser, adjustedForm=None,  for
 
     if previousTotalHours <= 15 and newTotalHours > 15:  # If we weren't overloading and now we are
         newLaborOverloadForm = OverloadForm.create(studentOverloadReason = "None")
+        print("Overload form created with reason: 'None'") # beans
+        print('*'*1000)
         newFormHistory = FormHistory.create(formID       = lsf.laborStatusFormID,
                                             historyType  = "Labor Overload Form",
                                             createdBy    = currentUser,
@@ -287,6 +289,8 @@ def createOverloadForm(newWeeklyHours, lsf, currentUser, adjustedForm=None,  for
                                             overloadForm = newLaborOverloadForm.overloadFormID,
                                             createdDate  = date.today(),
                                             status       = "Pre-Student Approval")
+        print(f"Form history created with formID: {lsf.laborStatusFormID}") # beans
+        print('*'*1000)
         try:
             if formHistories:
                 formHistories.status = "Pre-Student Approval"
@@ -309,7 +313,9 @@ def createOverloadForm(newWeeklyHours, lsf, currentUser, adjustedForm=None,  for
 
     # This will delete an overload form after the hours are changed
     elif previousTotalHours > 15 and newTotalHours <= 15:  # If we were overloading and now we aren't
-            deleteOverloadForm = FormHistory.get((FormHistory.formID == lsf.laborStatusFormID) & (FormHistory.historyType == "Labor Overload Form"))
-            deleteOverloadForm = OverloadForm.get(OverloadForm.overloadFormID == deleteOverloadForm.overloadForm.overloadFormID)
-            deleteOverloadForm.delete_instance()
-            FormHistory.get((FormHistory.formID == lsf.laborStatusFormID) & (FormHistory.historyType == "Labor Overload Form"))
+            print(f"Trying to get formhistory with formID '{lsf.laborStatusFormID}' and history type: 'Labor Overload Form'")
+            deleteOverloadForm = FormHistory.get((FormHistory.formID == lsf.laborStatusFormID) & (FormHistory.historyType == "Labor Overload Form"))  # Beans, this has been crashing. It seems that this might be because the historyType starts as a normal Labor Status Form and isn't updated when the form becomes that of an overload
+            print("Found the form history at least") # beans
+            print('*'*1000)
+            deleteOverloadForm = OverloadForm.get(OverloadForm.overloadFormID == deleteOverloadForm.overloadForm_id)
+            deleteOverloadForm.delete_instance()  # This line also deletes the Form History since it's set to cascade up in the model


### PR DESCRIPTION
Issue: There was a bug that occurred whenever anyone made an adjustment to a labor form that would mean they were overloading and would stop the adjustment from going through. FYI, overloading means to work strictly greater than 15 hours per week. For example, if someone was working a primary for 10 hours and had a pending secondary form for 5 hours and we adjusted it to be a secondary for 10 hours, our server logic would crash and the form wouldn't go through.

Solution: We found out that this issue was simply due to a misunderstanding of some variable names within the createOverloadForm function. The parameter "newWeeklyHours" was being passed in as the new number of hours to change a job to, but was being interpreted inside the function as the total number of hours that the user was now working/the number of hours they are working in addition to their current schedule. Needless to say this logic was wrought with inconsistency so we rewrote the function to alter the form, gathering the correct total number of hours before and after the change, using that to correctly create and delete overload forms as necessary.

To test: 
Assuming you're in the lsf directory
1. source setup.sh
2. database/reset_database.sh from-backup
3. export FLASK_ENV=staging
4. flask run
Now open the application and click Administration->Pending Forms
![image](https://github.com/BCStudentSoftwareDevTeam/lsf/assets/89316750/e5069cca-f5f0-437a-9525-cfeda98c18db)

There should be a list of pending forms. Keep searching for students until you find someone who is not currently overloading for a single academic year. If they have not overloaded, then click Actions->Modify on it and change the hours to overloading. If the request goes through and you are redirected back to the 'pending forms' page, then the fix was successful. Now try to undo the process. Go to the same person and alter it back to ensure that there are no crashes when removing the overload form.


Resolves issue #417
