### PR TITLE
424 supervisor department

### DIFF
--- a/app/controllers/admin_routes/manage_departments.py
+++ b/app/controllers/admin_routes/manage_departments.py
@@ -32,7 +32,7 @@ def manage_departments():
                 return render_template('errors/403.html'), 403
 
         departmentTracy = Tracy().getDepartments()
-        allSupervisors= Supervisor.select()
+        allSupervisors= Supervisor.select().order_by(Supervisor.LAST_NAME)
         for dept in departmentTracy:
             d, created = Department.get_or_create(DEPT_NAME = dept.DEPT_NAME, ACCOUNT=dept.ACCOUNT, ORG = dept.ORG)
             d.save()

--- a/app/controllers/admin_routes/manage_departments.py
+++ b/app/controllers/admin_routes/manage_departments.py
@@ -47,7 +47,6 @@ def manage_departments():
 
 @admin.route("/admin/manageDepartments/<departmentID>", methods=['GET'])
 def getSupervisorsInDepartment(departmentID):
-    try:
         currentUser = require_login()
         if not currentUser:                    # Not logged in
             return render_template('errors/403.html')
@@ -58,11 +57,9 @@ def getSupervisorsInDepartment(departmentID):
                 return render_template('errors/403.html'), 403
         
         supervisors = getSupervisorsForDepartment(departmentID)
-        departmentID=Department.get_by_id(departmentID)
-        supervisors= [model_to_dict(supervisor) for supervisor in supervisors]
-        return jsonify([model_to_dict(departmentID), supervisors])
-    except Exception as e:
-        return render_template('errors/500.html'), 500
+        selectedDepartment = Department.get_by_id(departmentID)
+        supervisors = [model_to_dict(supervisor) for supervisor in supervisors]
+        return jsonify([model_to_dict(selectedDepartment), supervisors])
     
 @admin.route('/admin/manageDepartments/removeSupervisorFromDepartment', methods=['POST'])
 def removeSupervisorFromDepartment():

--- a/app/controllers/admin_routes/manage_departments.py
+++ b/app/controllers/admin_routes/manage_departments.py
@@ -47,7 +47,7 @@ def manage_departments():
         return render_template('errors/500.html'), 500
 
 @admin.route("/admin/manageDepartments/<departmentID>", methods=['GET'])
-def getSupervisorsinDepartment(departmentID):
+def getSupervisorsInDepartment(departmentID):
     try:
         currentUser = require_login()
         if not currentUser:                    # Not logged in

--- a/app/controllers/admin_routes/manage_departments.py
+++ b/app/controllers/admin_routes/manage_departments.py
@@ -46,8 +46,8 @@ def manage_departments():
         print("Error Loading all Departments", e)
         return render_template('errors/500.html'), 500
 
-@admin.route("/admin/manageDepartments/<currentDepartment>", methods=['GET'])
-def getSupervisorsinDepartment(currentDepartment):
+@admin.route("/admin/manageDepartments/<departmentID>", methods=['GET'])
+def getSupervisorsinDepartment(departmentID):
     try:
         currentUser = require_login()
         if not currentUser:                    # Not logged in
@@ -58,17 +58,15 @@ def getSupervisorsinDepartment(currentDepartment):
             elif currentUser.supervisor:
                 return render_template('errors/403.html'), 403
         
-        supervisors = getSupervisorsForDepartment(currentDepartment)
-        currentDepartment=Department.get_by_id(currentDepartment)
+        supervisors = getSupervisorsForDepartment(departmentID)
+        departmentID=Department.get_by_id(departmentID)
         supervisors= [model_to_dict(supervisor) for supervisor in supervisors]
-        return jsonify([model_to_dict(currentDepartment), supervisors])
+        return jsonify([model_to_dict(departmentID), supervisors])
     except Exception as e:
         return render_template('errors/500.html'), 500
     
 @admin.route('/admin/manageDepartments/removeSupervisorFromDepartment', methods=['POST'])
 def removeSupervisorFromDepartment():
-    supervisorDeptRecord=request.form
-    supervisorDeptRecord = SupervisorDepartment.get_or_none(supervisor = supervisorDeptRecord['supervisor'], department = supervisorDeptRecord['department'])
     try:
         currentUser = require_login()
         if not currentUser:                    # Not logged in
@@ -78,16 +76,18 @@ def removeSupervisorFromDepartment():
                 return redirect('/laborHistory/' + currentUser.student.ID)
             elif currentUser.supervisor:
                 return render_template('errors/403.html'), 403
-            
+        
+        supervisorDeptRecord = request.form
+        supervisorDeptRecord = SupervisorDepartment.get_or_none(supervisor = supervisorDeptRecord['supervisorID'], department = supervisorDeptRecord['departmentID'])
+    
         if supervisorDeptRecord:
             supervisorDeptRecord.delete_instance()
             return "True"
-
         else:
             return "False"
     
     except Exception as e:
-        print(f'Could not add user to department: {e}')
+        print(f'Could not remove user from department: {e}')
         return "", 500
 
 @admin.route('/admin/complianceStatus', methods=['POST'])

--- a/app/controllers/admin_routes/manage_departments.py
+++ b/app/controllers/admin_routes/manage_departments.py
@@ -70,6 +70,15 @@ def removeSupervisorFromDepartment():
     supervisorDeptRecord=request.form
     supervisorDeptRecord = SupervisorDepartment.get_or_none(supervisor = supervisorDeptRecord['supervisor'], department = supervisorDeptRecord['department'])
     try:
+        currentUser = require_login()
+        if not currentUser:                    # Not logged in
+            return render_template('errors/403.html')
+        if not currentUser.isLaborAdmin:       # Not an admin
+            if currentUser.student: # logged in as a student
+                return redirect('/laborHistory/' + currentUser.student.ID)
+            elif currentUser.supervisor:
+                return render_template('errors/403.html'), 403
+            
         if supervisorDeptRecord:
             supervisorDeptRecord.delete_instance()
             return "True"

--- a/app/controllers/admin_routes/manage_departments.py
+++ b/app/controllers/admin_routes/manage_departments.py
@@ -77,8 +77,8 @@ def removeSupervisorFromDepartment():
             elif currentUser.supervisor:
                 return render_template('errors/403.html'), 403
         
-        supervisorDeptRecord = request.form
-        supervisorDeptRecord = SupervisorDepartment.get_or_none(supervisor = supervisorDeptRecord['supervisorID'], department = supervisorDeptRecord['departmentID'])
+        formData = request.form
+        supervisorDeptRecord = SupervisorDepartment.get_or_none(supervisor = formData['supervisorID'], department = formData['departmentID'])
     
         if supervisorDeptRecord:
             supervisorDeptRecord.delete_instance()

--- a/app/controllers/admin_routes/manage_departments.py
+++ b/app/controllers/admin_routes/manage_departments.py
@@ -57,9 +57,8 @@ def getSupervisorsInDepartment(departmentID):
                 return render_template('errors/403.html'), 403
         
         supervisors = getSupervisorsForDepartment(departmentID)
-        selectedDepartment = Department.get_by_id(departmentID)
         supervisors = [model_to_dict(supervisor) for supervisor in supervisors]
-        return jsonify([model_to_dict(selectedDepartment), supervisors])
+        return jsonify(supervisors)
     
 @admin.route('/admin/manageDepartments/removeSupervisorFromDepartment', methods=['POST'])
 def removeSupervisorFromDepartment():

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -304,13 +304,13 @@ def getFormattedData(filteredSearchResults):
 @main_bp.route('/supervisorPortal/addUserToDept', methods=['GET', 'POST'])
 def addUserToDept():
     userDeptData = request.form
-    supervisorDeptRecord = SupervisorDepartment.get_or_none(supervisor = userDeptData['supervisor'], department = userDeptData['department'])
+    supervisorDeptRecord = SupervisorDepartment.get_or_none(supervisor = userDeptData['supervisorID'], department = userDeptData['departmentID'])
     try:
         if supervisorDeptRecord:
             return "False"
 
         else:
-            SupervisorDepartment.create(supervisor=userDeptData['supervisor'], department=userDeptData['department'])
+            SupervisorDepartment.create(supervisor=userDeptData['supervisorID'], department=userDeptData['departmentID'])
             return "True"
     
     except Exception as e:

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -46,7 +46,7 @@ def supervisorPortal():
         return render_template('errors/403.html'), 403
     
     terms = LaborStatusForm.select(LaborStatusForm.termCode).distinct().order_by(LaborStatusForm.termCode.desc())
-    allSupervisors = Supervisor.select()
+    allSupervisors = Supervisor.select().order_by(Supervisor.LAST_NAME)
     if currentUser.isLaborAdmin or currentUser.isFinancialAidAdmin or currentUser.isSaasAdmin:
         departments = Department.select().order_by(Department.DEPT_NAME.asc())
         departments = [department for department in departments]

--- a/app/logic/search.py
+++ b/app/logic/search.py
@@ -66,5 +66,5 @@ def getDepartmentsForSupervisor(currentUser):
     return alldepts
 
 def getSupervisorsForDepartment(currentDepartment):
-    supervisors = Supervisor.select().join(SupervisorDepartment).where(SupervisorDepartment.department == currentDepartment).order_by(Supervisor.LAST_NAME)
-    return supervisors.execute()
+    departmentSupervisors = Supervisor.select().join(SupervisorDepartment).where(SupervisorDepartment.department == currentDepartment).order_by(Supervisor.LAST_NAME).execute()
+    return departmentSupervisors

--- a/app/logic/search.py
+++ b/app/logic/search.py
@@ -64,3 +64,8 @@ def getDepartmentsForSupervisor(currentUser):
     # removes duplicate departments
     alldepts = list(set(alldepts))
     return alldepts
+
+def getSupervisorsForDepartment(currentDepartment):
+    supervisors = Supervisor.select().join(SupervisorDepartment).where(SupervisorDepartment.deparment == currentDepartment)
+    supervisors = [supervisor for supervisor in supervisors]
+    

--- a/app/logic/search.py
+++ b/app/logic/search.py
@@ -66,5 +66,5 @@ def getDepartmentsForSupervisor(currentUser):
     return alldepts
 
 def getSupervisorsForDepartment(currentDepartment):
-    supervisors = Supervisor.select().join(SupervisorDepartment).where(SupervisorDepartment.department == currentDepartment)
+    supervisors = Supervisor.select().join(SupervisorDepartment).where(SupervisorDepartment.department == currentDepartment).order_by(Supervisor.LAST_NAME)
     return supervisors.execute()

--- a/app/logic/search.py
+++ b/app/logic/search.py
@@ -65,6 +65,6 @@ def getDepartmentsForSupervisor(currentUser):
     alldepts = list(set(alldepts))
     return alldepts
 
-def getSupervisorsForDepartment(currentDepartment):
-    departmentSupervisors = Supervisor.select().join(SupervisorDepartment).where(SupervisorDepartment.department == currentDepartment).order_by(Supervisor.LAST_NAME).execute()
+def getSupervisorsForDepartment(departmentId):
+    departmentSupervisors = Supervisor.select().join(SupervisorDepartment).where(SupervisorDepartment.department == departmentId).order_by(Supervisor.LAST_NAME).execute()
     return departmentSupervisors

--- a/app/logic/search.py
+++ b/app/logic/search.py
@@ -66,6 +66,5 @@ def getDepartmentsForSupervisor(currentUser):
     return alldepts
 
 def getSupervisorsForDepartment(currentDepartment):
-    supervisors = Supervisor.select().join(SupervisorDepartment).where(SupervisorDepartment.deparment == currentDepartment)
-    supervisors = [supervisor for supervisor in supervisors]
-    
+    supervisors = Supervisor.select().join(SupervisorDepartment).where(SupervisorDepartment.department == currentDepartment)
+    return supervisors.execute()

--- a/app/static/css/manageDepartments.css
+++ b/app/static/css/manageDepartments.css
@@ -28,6 +28,10 @@ h1 {
   height:10px;
   width:20px;
 }
-.complianceBtn{
+/* .complianceBtn{
   style="width:150px;
+} */
+
+#flasher{
+	z-index: 999999;
 }

--- a/app/static/css/manageDepartments.css
+++ b/app/static/css/manageDepartments.css
@@ -28,9 +28,9 @@ h1 {
   height:10px;
   width:20px;
 }
-/* .complianceBtn{
-  style="width:150px;
-} */
+.complianceBtn{
+  width:150px;
+}
 
 #flasher{
 	z-index: 999999;

--- a/app/static/js/addSupervisorsToDepartment.js
+++ b/app/static/js/addSupervisorsToDepartment.js
@@ -6,10 +6,10 @@ function addSupervisorToDepartment(supervisorID, departmentID, callback=None) {
       success: function(response) {
         if (response == "True") {
           msgFlash("Supervisor has been added to department.", 'success')
-          clearDropdown()
+          clearDropdowns()
         } else {
           msgFlash("Supervisor is already a member of this department.", "warning")
-          clearDropdown()
+          clearDropdowns()
         }
         if (callback){
           callback()
@@ -17,13 +17,13 @@ function addSupervisorToDepartment(supervisorID, departmentID, callback=None) {
       },
       error: function() {
         msgFlash("Failed to add supervisor, please try again.", "fail")
-        clearDropdown()
+        clearDropdowns()
       },
     })
 
 }
 
-function clearDropdown(){
+function clearDropdowns(){
     $('select.selectpicker').each(function() {
       $(`#${this.id} option:eq(0)`).prop("selected", true);
       $(`#${this.id}`).selectpicker("refresh");

--- a/app/static/js/addSupervisorsToDepartment.js
+++ b/app/static/js/addSupervisorsToDepartment.js
@@ -1,5 +1,5 @@
-function addSupervisorToDepartment(supervisorID, departmentID) {
-    $.ajax({
+function addSupervisorToDepartment(supervisorID, departmentID, callback=None) {
+    return $.ajax({
       method: "POST",
       url: `/supervisorPortal/addUserToDept`,
       data: {"supervisorID": supervisorID, "departmentID": departmentID},
@@ -11,12 +11,16 @@ function addSupervisorToDepartment(supervisorID, departmentID) {
           msgFlash("Supervisor is already a member of this department.", "warning")
           clearDropdown()
         }
+        if (callback){
+          callback()
+        }
       },
       error: function() {
         msgFlash("Failed to add supervisor, please try again.", "fail")
         clearDropdown()
       },
     })
+
 }
 
 function clearDropdown(){

--- a/app/static/js/addSupervisorsToDepartment.js
+++ b/app/static/js/addSupervisorsToDepartment.js
@@ -1,0 +1,27 @@
+function addSupervisorToDepartment(data) {
+    $.ajax({
+      method: "POST",
+      url: `/supervisorPortal/addUserToDept`,
+      data: data,
+      success: function(response) {
+        if (response == "True") {
+          msgFlash("Supervisor has been added to department.", 'success')
+          clearDropdown()
+        } else {
+          msgFlash("Supervisor is already a member of this department.", "warning")
+          clearDropdown()
+        }
+      },
+      error: function() {
+        msgFlash("Failed to add supervisor, please try again.", "fail")
+        clearDropdown()
+      },
+    })
+}
+
+function clearDropdown(){
+    $('select.selectpicker').each(function() {
+      $(`#${this.id} option:eq(0)`).prop("selected", true);
+      $(`#${this.id}`).selectpicker("refresh");
+    });
+};

--- a/app/static/js/addSupervisorsToDepartment.js
+++ b/app/static/js/addSupervisorsToDepartment.js
@@ -1,8 +1,8 @@
-function addSupervisorToDepartment(data) {
+function addSupervisorToDepartment(supervisorID, departmentID) {
     $.ajax({
       method: "POST",
       url: `/supervisorPortal/addUserToDept`,
-      data: data,
+      data: {"supervisorID": supervisorID, "departmentID": departmentID},
       success: function(response) {
         if (response == "True") {
           msgFlash("Supervisor has been added to department.", 'success')

--- a/app/static/js/addSupervisorsToDepartment.js
+++ b/app/static/js/addSupervisorsToDepartment.js
@@ -1,11 +1,11 @@
-function addSupervisorToDepartment(supervisorID, departmentID, callback=None) {
+function addSupervisorToDepartment(supervisorID, departmentID, callback=() => {}) {
     return $.ajax({
       method: "POST",
       url: `/supervisorPortal/addUserToDept`,
       data: {"supervisorID": supervisorID, "departmentID": departmentID},
       success: function(response) {
         if (response == "True") {
-          msgFlash("Supervisor has been added to department.", 'success')
+          msgFlash("Supervisor has been added to department.", "success")
           clearDropdowns()
         } else {
           msgFlash("Supervisor is already a member of this department.", "warning")

--- a/app/static/js/base.js
+++ b/app/static/js/base.js
@@ -3,31 +3,3 @@ function msgFlash(flash_message, status){
     $("#flash_container").prepend('<div class="alert alert-'+ category +'" role="alert" id="flasher">'+flash_message+'</div>');
     $("#flasher").delay(5000).fadeOut();
 }
-
-function addSupervisorToDepartment(data) {
-    $.ajax({
-      method: "POST",
-      url: `/supervisorPortal/addUserToDept`,
-      data: data,
-      success: function(response) {
-        if (response == "True") {
-          msgFlash("Supervisor has been added to department.", 'success')
-          clearDropdown()
-        } else {
-          msgFlash("Supervisor is already a member of this department.", "warning")
-          clearDropdown()
-        }
-      },
-      error: function() {
-        msgFlash("Failed to add supervisor, please try again.", "fail")
-        clearDropdown()
-      },
-    })
-}
-
-function clearDropdown(){
-    $('select.selectpicker').each(function() {
-      $(`#${this.id} option:eq(0)`).prop("selected", true);
-      $(`#${this.id}`).selectpicker("refresh");
-    });
-  };

--- a/app/static/js/base.js
+++ b/app/static/js/base.js
@@ -4,3 +4,30 @@ function msgFlash(flash_message, status){
     $("#flasher").delay(5000).fadeOut();
 }
 
+function addSupervisorToDepartment(data) {
+    $.ajax({
+      method: "POST",
+      url: `/supervisorPortal/addUserToDept`,
+      data: data,
+      success: function(response) {
+        if (response == "True") {
+          msgFlash("Supervisor has been added to department.", 'success')
+          clearDropdown()
+        } else {
+          msgFlash("Supervisor is already a member of this department.", "warning")
+          clearDropdown()
+        }
+      },
+      error: function() {
+        msgFlash("Failed to add supervisor, please try again.", "fail")
+        clearDropdown()
+      },
+    })
+}
+
+function clearDropdown(){
+    $('select.selectpicker').each(function() {
+      $(`#${this.id} option:eq(0)`).prop("selected", true);
+      $(`#${this.id}`).selectpicker("refresh");
+    });
+  };

--- a/app/static/js/manageDepartments.js
+++ b/app/static/js/manageDepartments.js
@@ -30,12 +30,11 @@ function attachModalToDepartment() {
 }
 
 
-$("#supervisorModalSelect").on('change', async function() {
-  let supervisor = $('#supervisorModalSelect :selected').val()
-  let department = $('#departmentModalSelect').data('department-id')
-  let data = {"supervisor": supervisor, "department": department}
-  await addSupervisorToDepartment(data)
-  getSupervisorsInDepartment(department)
+$("#supervisorModalSelect").on('change', function() {
+  let supervisorID = $('#supervisorModalSelect :selected').val()
+  let departmentID = $('#departmentModalSelect').data('department-id')
+  $.when(addSupervisorToDepartment(supervisorID, departmentID)).done(getSupervisorsInDepartment(departmentID))
+  
 })
 
   
@@ -70,7 +69,7 @@ function getSupervisorsInDepartment(departmentID) {
 function removeSupervisorFromDepartment () {
   let department = $(`#${this.id}`).data('department')
   let supervisor = $(`#${this.id}`).data('supervisor')
-  let data = {"supervisor": supervisor, "department": department}
+  let data = {"supervisorID": supervisor, "departmentID": department}
   $.ajax({
     method: "POST",
     url: "/admin/manageDepartments/removeSupervisorFromDepartment",

--- a/app/static/js/manageDepartments.js
+++ b/app/static/js/manageDepartments.js
@@ -13,29 +13,28 @@ $(document).ready( function(){
       attachModalToDepartment()
     })
     $('#manageDepartmentSupervisorModal').on('hidden.bs.modal', function() {
-      $('.changing-content').empty()  
       clearDropdown()
     })
 });
 
 
 function updateModal(departmentID) {
-  $('.changing-content').empty() 
   getSupervisorsInDepartment(departmentID)
 }
 
 function attachModalToDepartment() {
-    $('.supervisorDeptModal').off()
+    $('.supervisorDeptModal').off('click')
     $('.supervisorDeptModal').on('click', function() {
-      console.log(this.id)
+      $('#manageSupervisorContent .modal-header .department-name')
+       .replaceWith(`<h2 class='department-name' id="departmentModalSelect" data-department-id="${this.id}">
+                          ${$(`#${this.id}`).html()}
+                     </h2>`)
       getSupervisorsInDepartment(this.id)
     })
 }
 
 
-
-// Stole from Finn's work review to ensure functionality
-$("#addSupervisorsToDepartmentSubmit").on('click', function() {
+$("#supervisorModalSelect").on('change', function() {
   let supervisor = $('#supervisorModalSelect :selected').val()
   let department = $('#departmentModalSelect').data('department-id')
   let data = {"supervisor": supervisor, "department": department}
@@ -52,10 +51,6 @@ function getSupervisorsInDepartment(departmentID) {
     success: function(departmentsAndSupervisors) {
       let currentDepartment=departmentsAndSupervisors[0]
       let supervisors=departmentsAndSupervisors[1]
-      $('#manageSupervisorContent .modal-header .changing-content')
-       .replaceWith(`<h2 class='changing-content' id="departmentModalSelect" data-department-id="${currentDepartment['departmentID']}">
-                          ${currentDepartment['DEPT_NAME']}
-                     </h2>`)
       
       let supervisorContent = '<div class="changing-content">'
       for (let i=0; i<supervisors.length; i++) {
@@ -67,7 +62,7 @@ function getSupervisorsInDepartment(departmentID) {
                                   data-department="${currentDepartment['departmentID']}" 
                                   id="${supervisors[i]['ID']}-${currentDepartment['departmentID']}">Remove</div>
                                </span>`)}
-      supervisorContent.concat("</div>")
+      supervisorContent += ("</div>")
       $('#manageSupervisorContent .modal-body .changing-content').replaceWith(supervisorContent)
       
       $('#manageDepartmentSupervisorModal').modal('show')

--- a/app/static/js/manageDepartments.js
+++ b/app/static/js/manageDepartments.js
@@ -19,7 +19,8 @@ $(document).ready( function(){
 
 
 function updateModal(departmentID) {
-  getSupervisorsInDepartment(departmentID)
+  setTimeout(getSupervisorsInDepartment(departmentID), 100)
+  
 }
 
 function attachModalToDepartment() {

--- a/app/static/js/manageDepartments.js
+++ b/app/static/js/manageDepartments.js
@@ -8,13 +8,11 @@ $(document).ready( function(){
         pageLength: 25
     });
 
-    attachModalsToDepartment()
+    attachModalToDepartment()
     $('#departmentsTable').on('draw.dt', function() {
-      updateModal()
-      attachModalsToDepartment()
+      attachModalToDepartment()
     })
     $('#manageDepartmentSupervisorModal').on('hidden.bs.modal', function() {
-      $('#manageDepartmentSupervisorModal').modal('hide')
       $('.changing-content').empty()  
       clearDropdown()
     })
@@ -23,12 +21,14 @@ $(document).ready( function(){
 
 function updateModal(departmentID) {
   $('.changing-content').empty() 
-  getSupervisorDepartments(departmentID)
+  getSupervisorsInDepartment(departmentID)
 }
 
-function attachModalsToDepartment() {
+function attachModalToDepartment() {
+    $('.supervisorDeptModal').off()
     $('.supervisorDeptModal').on('click', function() {
-      getSupervisorDepartments(this.id)
+      console.log(this.id)
+      getSupervisorsInDepartment(this.id)
     })
 }
 
@@ -45,7 +45,7 @@ $("#addSupervisorsToDepartmentSubmit").on('click', function() {
 
 
 
-function getSupervisorDepartments(departmentID) {
+function getSupervisorsInDepartment(departmentID) {
     $.ajax({
     method: "GET",
     url: `/admin/manageDepartments/${departmentID}`,
@@ -53,19 +53,23 @@ function getSupervisorDepartments(departmentID) {
       let currentDepartment=departmentsAndSupervisors[0]
       let supervisors=departmentsAndSupervisors[1]
       $('#manageSupervisorContent .modal-header .changing-content')
-            .append(`<h2 id="departmentModalSelect" data-department-id="${currentDepartment['departmentID']}">
+       .replaceWith(`<h2 class='changing-content' id="departmentModalSelect" data-department-id="${currentDepartment['departmentID']}">
                           ${currentDepartment['DEPT_NAME']}
                      </h2>`)
+      
+      let supervisorContent = '<div class="changing-content">'
       for (let i=0; i<supervisors.length; i++) {
         let supervisorFirstName= supervisors[i]['preferred_name'] ? supervisors[i]['preferred_name'] : supervisors[i]['legal_name']
-        $('#manageSupervisorContent .modal-body .changing-content')
-              .append(`<div class="row">
-                        <div class="col-xs-10">${supervisors[i]['ID']} ${supervisorFirstName} ${supervisors[i]['LAST_NAME']}</div>
-                        <div class='btn btn-danger col-auto removeSupervisorFromDepartment' 
-                          data-supervisor="${supervisors[i]['ID']}" 
-                          data-department="${currentDepartment['departmentID']}" 
-                          id="${supervisors[i]['ID']}-${currentDepartment['departmentID']}">Remove</div>
-                      </div><br>`)}
+        supervisorContent += (`<span class="row">
+                                <div class="col-xs-10">${supervisors[i]['ID']} ${supervisorFirstName} ${supervisors[i]['LAST_NAME']}</div>
+                                <div class='btn btn-danger col-auto removeSupervisorFromDepartment' 
+                                  data-supervisor="${supervisors[i]['ID']}" 
+                                  data-department="${currentDepartment['departmentID']}" 
+                                  id="${supervisors[i]['ID']}-${currentDepartment['departmentID']}">Remove</div>
+                               </span>`)}
+      supervisorContent.concat("</div>")
+      $('#manageSupervisorContent .modal-body .changing-content').replaceWith(supervisorContent)
+      
       $('#manageDepartmentSupervisorModal').modal('show')
       $('.removeSupervisorFromDepartment').on('click', removeSupervisorFromDepartment)
     }

--- a/app/static/js/manageDepartments.js
+++ b/app/static/js/manageDepartments.js
@@ -34,25 +34,11 @@ function attachModalsToDepartment() {
 
 
 // Stole from Finn's work review to ensure functionality
-$("#addSupervisorsToDepartmentSubmit").on('click', function () {
+$("#addSupervisorsToDepartmentSubmit").on('click', function() {
   let supervisor = $('#supervisorModalSelect :selected').val()
   let department = $('#departmentModalSelect').data('department-id')
   let data = {"supervisor": supervisor, "department": department}
-  $.ajax({
-    method: "POST",
-    url: `/supervisorPortal/addUserToDept`,
-    data: data,
-    success: function(response) {
-      if (response == "True") {
-        msgFlash("Supervisor has been added to department.", 'success')
-      } else {
-        msgFlash("Supervisor is already a member of this department.", "warning")
-      }
-    },
-    error: function() {
-      msgFlash("Failed to add supervisor, please try again.", "fail")
-    },
-  })
+  addSupervisorToDepartment(data)
 })
 
 

--- a/app/static/js/manageDepartments.js
+++ b/app/static/js/manageDepartments.js
@@ -7,17 +7,20 @@ $(document).ready( function(){
     x.DataTable({
         pageLength: 25
     });
-    $('#departmentsTable').on('draw.dt', function() {
-      $('.supervisorDeptModal').on('click', function(){
-        console.log(this.id)
-        getSupervisorDepartments(this.id)
-        console.log("Beans")
-        $('#manageDepartmentSupervisorModal').modal('show')
-      })
-    })
+
+    attachModalsToDepartment()
+    $('#departmentsTable').on('draw.dt', attachModalsToDepartment)
     $('#manageDepartmentSupervisorModal').on('blur', emptyManageDepartmentSupervisorModal)
     $('#closeManageDepartmentSupervisorModal').on('click', emptyManageDepartmentSupervisorModal)
+    
 });
+
+function attachModalsToDepartment() {
+    $('.supervisorDeptModal').on('click', function(){
+        getSupervisorDepartments(this.id)
+        $('#manageDepartmentSupervisorModal').modal('show')
+    })
+}
 
 function emptyManageDepartmentSupervisorModal() {
   $('#manageDepartmentSupervisorModal').modal('hide')

--- a/app/static/js/manageDepartments.js
+++ b/app/static/js/manageDepartments.js
@@ -13,9 +13,7 @@ $(document).ready( function(){
     $('#manageDepartmentSupervisorModal').on('hidden.bs.modal', function() {
       $('#manageDepartmentSupervisorModal').modal('hide')
       $('.changing-content').empty()  
-    })
-    $('#manageDepartmentSupervisorModal').on('shown.bs.modal', function() {
-      $('.removeSupervisorFromDepartment').on('click', removeSupervisorFromDepartment)
+      clearDropdown()
     })
 });
 
@@ -39,6 +37,7 @@ $("#addSupervisorsToDepartmentSubmit").on('click', function() {
   let department = $('#departmentModalSelect').data('department-id')
   let data = {"supervisor": supervisor, "department": department}
   addSupervisorToDepartment(data)
+  updateModal(department)
 })
 
 
@@ -55,15 +54,17 @@ function getSupervisorDepartments(departmentID) {
                           ${currentDepartment['DEPT_NAME']}
                      </h2>`)
       for (let i=0; i<supervisors.length; i++) {
+        let supervisorFirstName= supervisors[i]['preferred_name'] ? supervisors[i]['preferred_name'] : supervisors[i]['legal_name']
         $('#manageSupervisorContent .modal-body .changing-content')
-              .append(`<div class="row form-group">
-                        <div class="col">${supervisors[i]['ID']} ${supervisors[i]['preferred_name']} ${supervisors[i]['LAST_NAME']}</div>
-                        <div class='btn btn-danger col removeSupervisorFromDepartment' 
+              .append(`<div class="row">
+                        <div class="col-xs-10">${supervisors[i]['ID']} ${supervisorFirstName} ${supervisors[i]['LAST_NAME']}</div>
+                        <div class='btn btn-danger col-auto removeSupervisorFromDepartment' 
                           data-supervisor="${supervisors[i]['ID']}" 
                           data-department="${currentDepartment['departmentID']}" 
                           id="${supervisors[i]['ID']}-${currentDepartment['departmentID']}">Remove</div>
-                      </div>`)}
+                      </div><br>`)}
       $('#manageDepartmentSupervisorModal').modal('show')
+      $('.removeSupervisorFromDepartment').on('click', removeSupervisorFromDepartment)
     }
     })
   }

--- a/app/static/js/manageDepartments.js
+++ b/app/static/js/manageDepartments.js
@@ -33,7 +33,7 @@ function attachModalToDepartment() {
 $("#supervisorModalSelect").on('change', function() {
   let supervisorID = $('#supervisorModalSelect :selected').val()
   let departmentID = $('#departmentModalSelect').data('department-id')
-  $.when(addSupervisorToDepartment(supervisorID, departmentID)).done(getSupervisorsInDepartment(departmentID))
+  addSupervisorToDepartment(supervisorID, departmentID, ()=>getSupervisorsInDepartment(departmentID))
   
 })
 

--- a/app/static/js/manageDepartments.js
+++ b/app/static/js/manageDepartments.js
@@ -29,7 +29,7 @@ $(document).ready( function(){
     })
     
     attachModalToDepartment()
-    $('#activeTable').on('draw.dt', function() {
+    $('.deptTable').on('draw.dt', function() {
       attachModalToDepartment()
     })
     $('#manageDepartmentSupervisorModal').on('hidden.bs.modal', function() {

--- a/app/static/js/manageDepartments.js
+++ b/app/static/js/manageDepartments.js
@@ -9,7 +9,10 @@ $(document).ready( function(){
     });
 
     attachModalsToDepartment()
-    $('#departmentsTable').on('draw.dt', attachModalsToDepartment)
+    $('#departmentsTable').on('draw.dt', function() {
+      updateModal()
+      attachModalsToDepartment()
+    })
     $('#manageDepartmentSupervisorModal').on('hidden.bs.modal', function() {
       $('#manageDepartmentSupervisorModal').modal('hide')
       $('.changing-content').empty()  

--- a/app/static/js/manageDepartments.js
+++ b/app/static/js/manageDepartments.js
@@ -63,8 +63,7 @@ function showSupervisorsInDepartment(departmentID) {
     $.ajax({
     method: "GET",
     url: `/admin/manageDepartments/${departmentID}`,
-    success: function(departmentsAndSupervisors) {
-      let [currentDepartment, supervisors] = departmentsAndSupervisors      
+    success: function(supervisors) {   
       let supervisorContent = '<div class="changing-content">'
       for (let i=0; i<supervisors.length; i++) {
         let supervisorFirstName = supervisors[i]['preferred_name'] ? supervisors[i]['preferred_name'] : supervisors[i]['legal_name']
@@ -72,8 +71,8 @@ function showSupervisorsInDepartment(departmentID) {
                                 <div class="col-xs-10">${supervisors[i]['ID']} ${supervisorFirstName} ${supervisors[i]['LAST_NAME']}</div>
                                 <div class='btn btn-danger col-auto removeSupervisorFromDepartment' 
                                   data-supervisor="${supervisors[i]['ID']}" 
-                                  data-department="${currentDepartment['departmentID']}" 
-                                  id="${supervisors[i]['ID']}-${currentDepartment['departmentID']}">Remove</div>
+                                  data-department="${departmentID}" 
+                                  id="${supervisors[i]['ID']}-${departmentID}">Remove</div>
                                </span>`)}
       supervisorContent += ("</div>")
       $('#manageSupervisorContent .modal-body .changing-content').replaceWith(supervisorContent)

--- a/app/static/js/manageDepartments.js
+++ b/app/static/js/manageDepartments.js
@@ -39,13 +39,13 @@ $(document).ready( function(){
 
 
 function attachModalToDepartment() {
-    $('.supervisorDeptModal').off('click')
-    $('.supervisorDeptModal').on('click', function() {
+    $('.deptTable .departmentName').off('click')
+    $('.deptTable .departmentName').on('click', function() {
       $('#manageSupervisorContent .modal-header .department-name')
                 .replaceWith(`<h2 class='department-name' id="departmentModalSelect" data-department-id="${this.id}">
                                     ${$(`#${this.id}`).html()}
                               </h2>`)
-      getSupervisorsInDepartment(this.id)
+      showSupervisorsInDepartment(this.id)
     })
 }
 
@@ -53,23 +53,21 @@ function attachModalToDepartment() {
 $("#supervisorModalSelect").on('change', function() {
   let supervisorID = $('#supervisorModalSelect :selected').val()
   let departmentID = $('#departmentModalSelect').data('department-id')
-  addSupervisorToDepartment(supervisorID, departmentID, ()=>getSupervisorsInDepartment(departmentID))
+  addSupervisorToDepartment(supervisorID, departmentID, ()=>showSupervisorsInDepartment(departmentID))
   
 })
 
   
 
-function getSupervisorsInDepartment(departmentID) {
+function showSupervisorsInDepartment(departmentID) {
     $.ajax({
     method: "GET",
     url: `/admin/manageDepartments/${departmentID}`,
     success: function(departmentsAndSupervisors) {
-      let currentDepartment=departmentsAndSupervisors[0]
-      let supervisors=departmentsAndSupervisors[1]
-      
+      let [currentDepartment, supervisors] = departmentsAndSupervisors      
       let supervisorContent = '<div class="changing-content">'
       for (let i=0; i<supervisors.length; i++) {
-        let supervisorFirstName= supervisors[i]['preferred_name'] ? supervisors[i]['preferred_name'] : supervisors[i]['legal_name']
+        let supervisorFirstName = supervisors[i]['preferred_name'] ? supervisors[i]['preferred_name'] : supervisors[i]['legal_name']
         supervisorContent += (`<span class="row">
                                 <div class="col-xs-10">${supervisors[i]['ID']} ${supervisorFirstName} ${supervisors[i]['LAST_NAME']}</div>
                                 <div class='btn btn-danger col-auto removeSupervisorFromDepartment' 
@@ -87,9 +85,9 @@ function getSupervisorsInDepartment(departmentID) {
   }
 
 function removeSupervisorFromDepartment () {
-  let department = $(`#${this.id}`).data('department')
-  let supervisor = $(`#${this.id}`).data('supervisor')
-  let data = {"supervisorID": supervisor, "departmentID": department}
+  let departmentID = $(`#${this.id}`).data('department')
+  let supervisorID = $(`#${this.id}`).data('supervisor')
+  let data = {"supervisorID": supervisorID, "departmentID": departmentID}
   $.ajax({
     method: "POST",
     url: "/admin/manageDepartments/removeSupervisorFromDepartment",
@@ -97,15 +95,15 @@ function removeSupervisorFromDepartment () {
     success: function(response) {
         if (response == "True") {
           msgFlash("Supervisor has been removed from department.", 'success')
-          getSupervisorsInDepartment(department)
+          showSupervisorsInDepartment(departmentID)
         } else {
           msgFlash("Supervisor is not a member of this department.", "warning")
         }
-      },
-      error: function() {
-        msgFlash("Failed to remove supervisor, please try again.", "fail")
-      },
-    })
+    },
+    error: function() {
+    msgFlash("Failed to remove supervisor, please try again.", "fail")
+    },
+})
 }
 
 function status(department, dept_name) {

--- a/app/static/js/manageDepartments.js
+++ b/app/static/js/manageDepartments.js
@@ -13,7 +13,7 @@ $(document).ready( function(){
       attachModalToDepartment()
     })
     $('#manageDepartmentSupervisorModal').on('hidden.bs.modal', function() {
-      clearDropdown()
+      clearDropdowns()
     })
 });
 

--- a/app/static/js/manageDepartments.js
+++ b/app/static/js/manageDepartments.js
@@ -18,32 +18,27 @@ $(document).ready( function(){
 });
 
 
-function updateModal(departmentID) {
-  setTimeout(getSupervisorsInDepartment(departmentID), 100)
-  
-}
-
 function attachModalToDepartment() {
     $('.supervisorDeptModal').off('click')
     $('.supervisorDeptModal').on('click', function() {
       $('#manageSupervisorContent .modal-header .department-name')
-       .replaceWith(`<h2 class='department-name' id="departmentModalSelect" data-department-id="${this.id}">
-                          ${$(`#${this.id}`).html()}
-                     </h2>`)
+                .replaceWith(`<h2 class='department-name' id="departmentModalSelect" data-department-id="${this.id}">
+                                    ${$(`#${this.id}`).html()}
+                              </h2>`)
       getSupervisorsInDepartment(this.id)
     })
 }
 
 
-$("#supervisorModalSelect").on('change', function() {
+$("#supervisorModalSelect").on('change', async function() {
   let supervisor = $('#supervisorModalSelect :selected').val()
   let department = $('#departmentModalSelect').data('department-id')
   let data = {"supervisor": supervisor, "department": department}
-  addSupervisorToDepartment(data)
-  updateModal(department)
+  await addSupervisorToDepartment(data)
+  getSupervisorsInDepartment(department)
 })
 
-
+  
 
 function getSupervisorsInDepartment(departmentID) {
     $.ajax({
@@ -83,7 +78,7 @@ function removeSupervisorFromDepartment () {
     success: function(response) {
         if (response == "True") {
           msgFlash("Supervisor has been removed from department.", 'success')
-          updateModal(department)
+          getSupervisorsInDepartment(department)
         } else {
           msgFlash("Supervisor is not a member of this department.", "warning")
         }

--- a/app/static/js/manageDepartments.js
+++ b/app/static/js/manageDepartments.js
@@ -7,7 +7,37 @@ $(document).ready( function(){
     x.DataTable({
         pageLength: 25
     });
+    $('#departmentsTable').on('draw.dt', function() {
+      $('.supervisorDeptModal').on('click', function(){
+        console.log(this.id)
+        getSupervisorDepartments(this.id)
+        console.log("Beans")
+        $('#manageDepartmentSupervisorModal').modal('show')
+      })
+    })
+    $('#manageDepartmentSupervisorModal').on('blur', emptyManageDepartmentSupervisorModal)
+    $('#closeManageDepartmentSupervisorModal').on('click', emptyManageDepartmentSupervisorModal)
 });
+
+function emptyManageDepartmentSupervisorModal() {
+  $('#manageDepartmentSupervisorModal').modal('hide')
+  $('.changing-content').empty()
+}
+
+function getSupervisorDepartments(departmentID) {
+  $.ajax({
+    method: "GET",
+    url: `/admin/manageDepartments/${departmentID}`,
+    success: function(departmentsAndSupervisors) {
+      let currentDepartment=departmentsAndSupervisors[0]
+      let supervisors=departmentsAndSupervisors[1]
+      $('#manageSupervisorContent .modal-header .changing-content').append("<p>"+currentDepartment['DEPT_NAME']+"</p>")
+      for (let i=0; i<supervisors.length; i++) {
+        $('#manageSupervisorContent .modal-body .changing-content').append(`<p>${supervisors[i]['ID']} ${supervisors[i]['preferred_name']} ${supervisors[i]['LAST_NAME']}</p>`)
+      }
+    }
+  })
+}
 
 function status(department, dept_name) {
 /*

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -19,10 +19,9 @@ $(document).ready(function(){
   })
 
   $('#addUser').on('click', function() {
-      let supervisor = $('#supervisorModalSelect :selected').val()
-      let department = $('#departmentModalSelect :selected').val()
-      let data = {"supervisor": supervisor, "department": department}
-      addSupervisorToDepartment(data)
+      let supervisorID = $('#supervisorModalSelect :selected').val()
+      let departmentID = $('#departmentModalSelect :selected').val()
+      addSupervisorToDepartment(supervisorID, departmentID)
   })
   $('#clearSelectionsButton').on('click', function(){
     $("input:checkbox").removeAttr("checked");

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -22,24 +22,7 @@ $(document).ready(function(){
       let supervisor = $('#supervisorModalSelect :selected').val()
       let department = $('#departmentModalSelect :selected').val()
       let data = {"supervisor": supervisor, "department": department}
-      $.ajax({
-        method: "POST",
-        url: "/supervisorPortal/addUserToDept",
-        data: data,
-        success: function(response) {
-          if (response == "True") {
-            msgFlash("Supervisor has been added to department.", 'success')
-            clearDropdown()
-          } else {
-            msgFlash("Supervisor is already a member of this department.", "warning")
-            clearDropdown()
-          }
-        },
-        error: function() {
-          msgFlash("Failed to add supervisor, please try again.", "fail")
-          clearDropdown()
-        },
-    })
+      addSupervisorToDepartment(data)
   })
   $('#clearSelectionsButton').on('click', function(){
     $("input:checkbox").removeAttr("checked");
@@ -73,12 +56,7 @@ $('#currentTerm').on('click', function(){
 });
 });
 
-function clearDropdown(){
-  $('select.selectpicker').each(function() {
-    $(`#${this.id} option:eq(0)`).prop("selected", true);
-    $(`#${this.id}`).selectpicker("refresh");
-  });
-};
+
 
 function runFormSearchQuery(button) {
 

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -25,7 +25,7 @@ $(document).ready(function(){
   })
   $('#clearSelectionsButton').on('click', function(){
     $("input:checkbox").removeAttr("checked");
-    clearDropdown()
+    clearDropdowns()
     });
     
   $( function() {

--- a/app/templates/admin/manageDepartments.html
+++ b/app/templates/admin/manageDepartments.html
@@ -72,7 +72,7 @@
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
-        <div class="changing-content"></div>
+        <div class="department-name"></div>
         
       </div>
 
@@ -95,7 +95,7 @@
         <div class="changing-content"></div>
       </div>
       <div class="modal-footer">
-        <button type="button" id="addSupervisorsToDepartmentSubmit" data-dismiss="modal" class="btn btn-primary">Add User</button>
+        <button type="button" id="addSupervisorsToDepartmentSubmit" data-dismiss="modal" class="btn btn-primary">Done</button>
         <button type="button" class="btn btn-secondary pull-left closeModal" data-dismiss="modal">Close</button>
       </div>
     </div>

--- a/app/templates/admin/manageDepartments.html
+++ b/app/templates/admin/manageDepartments.html
@@ -47,7 +47,7 @@
           </ul>
 
           <br>
-          <div id='activeTable'>
+          <div class="deptTable" id='activeTable'>
             <table class="table table-striped table-bordered" id="activeDepartmentsTable">
               <thead>
                 <tr>
@@ -73,7 +73,7 @@
             </table>
           </div>
 
-          <div id='inactiveTable'>
+          <div class="deptTable" id='inactiveTable'>
             <table class="table table-striped table-bordered" id="inactiveDepartmentsTable">
               <thead>
                 <tr>

--- a/app/templates/admin/manageDepartments.html
+++ b/app/templates/admin/manageDepartments.html
@@ -45,7 +45,7 @@
             <tbody>
               {% for department in department %}
               <tr>
-                <td scope="row">{{department.DEPT_NAME}} <small>({{department.ORG}}, {{department.ACCOUNT}})</small></td>
+                <td scope="row"><a href="#" class="supervisorDeptModal" id="{{department.departmentID}}">{{department.DEPT_NAME}}</a> <small>({{department.ORG}}, {{department.ACCOUNT}})</small></td>
                 <td id="dept_{{department.departmentID}}" scope="row" data-order="{% if department.departmentCompliance == True %}1{% else %}-1{% endif %}">
                   <button type="button"
                           id="dept_btn_{{department.departmentID}}"
@@ -62,9 +62,21 @@
         <div class="col-md-2"></div>
     </div>
 </div>
-<div class="modal fade" id="manageDepartmentSupervisorModal" role="dialogue" >
+<div class="modal" id="manageDepartmentSupervisorModal" tabindex="-1" role="dialogue" >
   <div class="modal-dialog modal-dialog-scrollable" role="document">
-    <div id="manadgeSupervisorContent" class="modal-content">
+    
+    
+    <div id="manageSupervisorContent" class="modal-content">
+      <div class="modal-header">
+        <div class="changing-content"></div>
+        <div class="btn btn-danger" id="closeManageDepartmentSupervisorModal">
+          <span>X</span>
+        </div>
+      </div>
+
+      <div class="modal-body ">
+        <div class="changing-content"></div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/templates/admin/manageDepartments.html
+++ b/app/templates/admin/manageDepartments.html
@@ -63,19 +63,39 @@
     </div>
 </div>
 <div class="modal" id="manageDepartmentSupervisorModal" tabindex="-1" role="dialogue" >
-  <div class="modal-dialog modal-dialog-scrollable" role="document">
+  <div class="modal-dialog" role="document">
     
     
     <div id="manageSupervisorContent" class="modal-content">
+      
       <div class="modal-header">
         <div class="changing-content"></div>
-        <div class="btn btn-danger" id="closeManageDepartmentSupervisorModal">
-          <span>X</span>
-        </div>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
       </div>
 
       <div class="modal-body ">
+        <div class="form-group">
+        <label for="supervisorModalSelect">Select a supervisor to add:</label>
+        <div class="dropdown"><select class="selectpicker"
+          name='supervisor'
+          id='supervisorModalSelect'
+          data-live-search='true'
+          title="Supervisor">
+        {% for supervisor in allSupervisors  %}
+          <option value="{{supervisor.ID}}"
+                  data-content="{{supervisor.FIRST_NAME}} {{supervisor.LAST_NAME}}<small class='text-muted'> ({{supervisor.ID}})</small>">
+            {{supervisor.FIRST_NAME}} {{supervisor.LAST_NAME}}
+          </option>
+        {% endfor %}
+      </select></div>
+      </div>
         <div class="changing-content"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" id="addSupervisorsToDepartmentSubmit" data-dismiss="modal" class="btn btn-primary">Add User</button>
+        <button type="button" class="btn btn-secondary pull-left" data-dismiss="modal">Close</button>
       </div>
     </div>
   </div>

--- a/app/templates/admin/manageDepartments.html
+++ b/app/templates/admin/manageDepartments.html
@@ -83,7 +83,7 @@
               <tbody>
                 {% for department in inactiveDepartments %}
                 <tr>
-                  <td scope="row">{{department.DEPT_NAME}} <small>({{department.ORG}}, {{department.ACCOUNT}})</small></td>
+                    <td scope="row"><a href="#" class="supervisorDeptModal" id="{{department.departmentID}}">{{department.DEPT_NAME}}</a><small>({{department.ORG}}, {{department.ACCOUNT}})</small></td>
                 </tr>
                 {% endfor %}
               </tbody>

--- a/app/templates/admin/manageDepartments.html
+++ b/app/templates/admin/manageDepartments.html
@@ -58,7 +58,7 @@
               <tbody>
                 {% for department in activeDepartments %}
                 <tr>
-                  <td scope="row"><a href="#" class="supervisorDeptModal" id="{{department.departmentID}}">{{department.DEPT_NAME}}</a><small>({{department.ORG}}, {{department.ACCOUNT}})</small></td>
+                  <td scope="row"><a href="javascript:{}" class=" " id="{{department.departmentID}}">{{department.DEPT_NAME}}</a><small>({{department.ORG}}, {{department.ACCOUNT}})</small></td>
                   <td id="dept_{{department.departmentID}}" scope="row" data-order="{% if department.departmentCompliance == True %}1{% else %}-1{% endif %}">
                     <button type="button"
                             id="dept_btn_{{department.departmentID}}"
@@ -83,7 +83,7 @@
               <tbody>
                 {% for department in inactiveDepartments %}
                 <tr>
-                    <td scope="row"><a href="#" class="supervisorDeptModal" id="{{department.departmentID}}">{{department.DEPT_NAME}}</a><small>({{department.ORG}}, {{department.ACCOUNT}})</small></td>
+                    <td scope="row"><a href="javascript:{}" class="departmentName" id="{{department.departmentID}}">{{department.DEPT_NAME}}</a><small>({{department.ORG}}, {{department.ACCOUNT}})</small></td>
                 </tr>
                 {% endfor %}
               </tbody>
@@ -108,14 +108,14 @@
         
       </div>
 
-      <div class="modal-body ">
+      <div class="modal-body">
         <div class="form-group">
         <label for="supervisorModalSelect">Select a supervisor to add:</label>
-        <div class="dropdown"><select class="selectpicker"
+        <div class='dropdown'><select class='selectpicker'
           name='supervisorId'
           id='supervisorModalSelect'
           data-live-search='true'
-          title="Supervisor">
+          title='Supervisor'>
         {% for supervisor in allSupervisors  %}
           <option value="{{supervisor.ID}}"
                   data-content="{{supervisor.FIRST_NAME}} {{supervisor.LAST_NAME}}<small class='text-muted'> ({{supervisor.ID}})</small>">

--- a/app/templates/admin/manageDepartments.html
+++ b/app/templates/admin/manageDepartments.html
@@ -10,6 +10,7 @@
 {{super()}}
     <script type="text/javascript" src="https://cdn.datatables.net/v/bs/dt-1.10.21/b-1.6.2/datatables.min.js"></script>
     <script type="text/javascript" src="{{url_for('static', filename='js/manageDepartments.js') }}?u={{lastStaticUpdate}}"></script>
+    <script type="text/javascript" src="{{url_for('static', filename='js/addSupervisorsToDepartment.js') }}?u={{lastStaticUpdate}}"></script>
 {% endblock %}
 
 {% block app_content %}

--- a/app/templates/admin/manageDepartments.html
+++ b/app/templates/admin/manageDepartments.html
@@ -81,7 +81,7 @@
         <div class="form-group">
         <label for="supervisorModalSelect">Select a supervisor to add:</label>
         <div class="dropdown"><select class="selectpicker"
-          name='supervisor'
+          name='supervisorId'
           id='supervisorModalSelect'
           data-live-search='true'
           title="Supervisor">
@@ -96,7 +96,7 @@
         <div class="changing-content"></div>
       </div>
       <div class="modal-footer">
-        <button type="button" id="addSupervisorsToDepartmentSubmit" data-dismiss="modal" class="btn btn-primary">Done</button>
+        <button type="button" id="addSupervisorsToDepartmentExit" data-dismiss="modal" class="btn btn-primary">Done</button>
         <button type="button" class="btn btn-secondary pull-left closeModal" data-dismiss="modal">Close</button>
       </div>
     </div>

--- a/app/templates/admin/manageDepartments.html
+++ b/app/templates/admin/manageDepartments.html
@@ -58,7 +58,7 @@
               <tbody>
                 {% for department in activeDepartments %}
                 <tr>
-                  <td scope="row"><a href="javascript:{}" class=" " id="{{department.departmentID}}">{{department.DEPT_NAME}}</a><small>({{department.ORG}}, {{department.ACCOUNT}})</small></td>
+                  <td scope="row"><a href="javascript:{}" class="departmentName" id="{{department.departmentID}}">{{department.DEPT_NAME}}</a><small>({{department.ORG}}, {{department.ACCOUNT}})</small></td>
                   <td id="dept_{{department.departmentID}}" scope="row" data-order="{% if department.departmentCompliance == True %}1{% else %}-1{% endif %}">
                     <button type="button"
                             id="dept_btn_{{department.departmentID}}"

--- a/app/templates/admin/manageDepartments.html
+++ b/app/templates/admin/manageDepartments.html
@@ -62,4 +62,10 @@
         <div class="col-md-2"></div>
     </div>
 </div>
+<div class="modal fade" id="manageDepartmentSupervisorModal" role="dialogue" >
+  <div class="modal-dialog modal-dialog-scrollable" role="document">
+    <div id="manadgeSupervisorContent" class="modal-content">
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/app/templates/admin/manageDepartments.html
+++ b/app/templates/admin/manageDepartments.html
@@ -69,10 +69,11 @@
     <div id="manageSupervisorContent" class="modal-content">
       
       <div class="modal-header">
-        <div class="changing-content"></div>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
+        <div class="changing-content"></div>
+        
       </div>
 
       <div class="modal-body ">
@@ -95,7 +96,7 @@
       </div>
       <div class="modal-footer">
         <button type="button" id="addSupervisorsToDepartmentSubmit" data-dismiss="modal" class="btn btn-primary">Add User</button>
-        <button type="button" class="btn btn-secondary pull-left" data-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-secondary pull-left closeModal" data-dismiss="modal">Close</button>
       </div>
     </div>
   </div>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -13,6 +13,7 @@
   <script type="text/javascript" src="{{url_for('static', filename='js/laborhistory.js')}}?u={{lastStaticUpdate}}"></script>
   <script type="text/javascript" src="{{url_for('static', filename='js/allPendingForms.js')}}?u={{lastStaticUpdate}}"></script>
   <script type="text/javascript" src="{{url_for('static', filename='js/supervisorPortal.js') }}?u={{lastStaticUpdate}}"></script>
+  <script type="text/javascript" src="{{url_for('static', filename='js/addSupervisorsToDepartment.js') }}?u={{lastStaticUpdate}}"></script>
   <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
   <script>
       var g_currentTerm = {{g.openTerm}};

--- a/tests/code/test_search.py
+++ b/tests/code/test_search.py
@@ -8,7 +8,7 @@ from app.models.laborStatusForm import LaborStatusForm
 from app.models.formHistory import FormHistory
 from app.models.user import User
 from peewee import DoesNotExist
-from app.logic.search import limitSearchByUserDepartment, studentDbToDict,getDepartmentsForSupervisor
+from app.logic.search import limitSearchByUserDepartment, studentDbToDict, getDepartmentsForSupervisor, getSupervisorsForDepartment
 
 @pytest.mark.integration
 def test_limitSearchByUserDepartment():
@@ -219,3 +219,18 @@ def test_getDepartmentsForSupervisors():
         assert len(departments) == 3
 
         transaction.rollback()
+
+@pytest.mark.integration
+def test_getSupervisorsForDepartment():
+    with mainDB.atomic() as transaction:
+
+        SupervisorDepartment.create(supervisor = 'B00763721', department = 1) 
+        SupervisorDepartment.create(supervisor = 'B12361006', department = 1)
+
+        supervisors = getSupervisorsForDepartment(1)
+        assert len(supervisors) == 2
+    
+        transaction.rollback()
+    
+    supervisors = getSupervisorsForDepartment(1)
+    assert len(supervisors) == 0

--- a/tests/code/test_search.py
+++ b/tests/code/test_search.py
@@ -229,8 +229,10 @@ def test_getSupervisorsForDepartment():
 
         supervisors = getSupervisorsForDepartment(1)
         assert len(supervisors) == 2
-    
+
+        testDept = Department.create(DEPT_NAME="supervisorDept", ACCOUNT="6740", ORG="2114", departmentCompliance = 1)
+        supervisors = getSupervisorsForDepartment(testDept)
+        assert len(supervisors) == 0
         transaction.rollback()
     
-    supervisors = getSupervisorsForDepartment(1)
-    assert len(supervisors) == 0
+    


### PR DESCRIPTION
Issue: There was a request to add a modal on the manage department section of the website which would be able to add and remove supervisors assigned to a particular department.

Fix: Created a modal that pulls all the entries associated with a department from the supervisorDepartment table and displays them for a particular department along with a remove button that will remove that particular entry from the table. Also added a dropdown list to show all supervisors and allow you to select a supervisor to add. 

Test: To navigate to this modal, from the sidebar click the administration dropdown and click manage department. From there, you should be able to select and of the department name and attach and remove supervisors.

Fixes #424 