### PR TITLE
Fix tests in lsf issue431

### DIFF
--- a/tests/code/test_formSearch.py
+++ b/tests/code/test_formSearch.py
@@ -1,7 +1,9 @@
 from app.controllers.main_routes.main_routes import getDatatableData, supervisorPortal
 from app import app
+from flask import g
 import pytest
 from app.models import mainDB
+from app.models.user import User
 import json
 
 @pytest.mark.integration
@@ -13,23 +15,29 @@ def test_getDatatableData():
         departmentIDDict = {'length': 25, 'start': 0,'draw': 1,'order[0][column]': 0, 'order[0][dir]': 'desc', "data": '{"termCode": "currentTerm", "departmentID": "1", "supervisorID": "currentUser", "studentID": "", "formStatus": "[]", "formType": "[]", "evaluations": "[]"}'}
         studentIDDict = {'length': 25, 'start': 0,'draw': 1,'order[0][column]': 0, 'order[0][dir]': 'desc', "data": '{"termCode": "", "departmentID": "", "supervisorID": "currentUser", "studentID": "B00730361", "formStatus": "[]", "formType": "[]", "evaluations": "[]"}'}
         allEvalDict = {'length': 25, 'start': 0,'draw': 1,'order[0][column]': 0, 'order[0][dir]': 'desc', "data": '{"termCode": "", "departmentID": "", "supervisorID": "currentUser", "studentID": "", "formStatus": "[]", "formType": "[]", "evaluations": "[allEvalMissing]"}'}
-
         with app.test_request_context("/", method="POST", data=termCodeDict):
             runGetDatatableData = supervisorPortal()
-            
+        
         with app.test_request_context("/", method="POST", data=currentTermDict):
+            g.openTerm = 201500
             runGetDatatableData = supervisorPortal()
             
         with app.test_request_context("/", method="POST", data=currentUserDict):
+            g.openTerm = 201500
+            g.currentUser = User.get_by_id(1)         
             runGetDatatableData = supervisorPortal()
             
         with app.test_request_context("/", method="POST", data=departmentIDDict):
+            g.openTerm = 201500
+            g.currentUser = User.get_by_id(1) 
             runGetDatatableData = supervisorPortal()
             
         with app.test_request_context("/", method="POST", data=studentIDDict):
+            g.currentUser = User.get_by_id(1) 
             runGetDatatableData = supervisorPortal()
-            
+        
         with app.test_request_context("/", method="POST", data=allEvalDict):
+            g.currentUser = User.get_by_id(1) 
             runGetDatatableData = supervisorPortal()
             
             assert True

--- a/tests/code/test_userInsertFunctions.py
+++ b/tests/code/test_userInsertFunctions.py
@@ -12,7 +12,7 @@ from app.logic.userInsertFunctions import *
 @pytest.mark.integration
 def test_createSupervisorFromTracy():
     # Test fail conditions
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidUserException):
         supervisor = createSupervisorFromTracy()
 
     with pytest.raises(InvalidUserException):


### PR DESCRIPTION
Issue:
There was an issue where two tests were failing, test_userInsertFunctions.py and test_formSearch.py.

Fix:
To address this issue, added context for g in the test_formSearch and changed the exception being raised in  test_userInsertFunctions.

Test:
To test this issue, reset to test data on lsf and run run_tests.sh from the tests folder.

Fixes #431 