### PR TITLE
344 fix labor history ordering

### DIFF
--- a/app/controllers/main_routes/laborHistory.py
+++ b/app/controllers/main_routes/laborHistory.py
@@ -59,9 +59,7 @@ def laborhistory(id, departmentName=None):
 
                 if len(authorizedForms) == 0:
                     return render_template('errors/403.html'), 403
-        #Beans: The ordering of these authorizedforms is what we're fixing. The plan is to create a function that tacks on an order_by statement to a query
-        # authorizedForms = sorted(list(authorizedForms),key=lambda f:f.reviewedDate if f.reviewedDate else f.createdDate, reverse=True)
-        #Beans: The following is the tentative order_by statement we'll be putting into a function
+        
         
         authorizedForms = Term.order_by_term(list(authorizedForms.objects()), reverse=True)
 

--- a/app/controllers/main_routes/laborHistory.py
+++ b/app/controllers/main_routes/laborHistory.py
@@ -60,8 +60,7 @@ def laborhistory(id, departmentName = None):
         # authorizedForms = sorted(list(authorizedForms),key=lambda f:f.reviewedDate if f.reviewedDate else f.createdDate, reverse=True)
         #Beans: The following is the tentative order_by statement we'll be putting into a function
         
-        query = authorizedForms.select(FormHistory)
-        query = FormHistory.order_by_date(query)
+        query = FormHistory.order_by_date(authorizedForms)
         # print(query) # beans
         authorizedForms = list(query)
         # print(f"{authorizedForms.seasonalCode}") # beans

--- a/app/controllers/main_routes/laborHistory.py
+++ b/app/controllers/main_routes/laborHistory.py
@@ -57,8 +57,23 @@ def laborhistory(id, departmentName = None):
                 if len(authorizedForms) == 0:
                     return render_template('errors/403.html'), 403
         #Beans: The ordering of these authorizedforms is what we're fixing. The plan is to create a function that tacks on an order_by statement to a query
-        authorizedForms = sorted(list(authorizedForms),key=lambda f:f.reviewedDate if f.reviewedDate else f.createdDate, reverse=True)
+        # authorizedForms = sorted(list(authorizedForms),key=lambda f:f.reviewedDate if f.reviewedDate else f.createdDate, reverse=True)
         #Beans: The following is the tentative order_by statement we'll be putting into a function
+        termCodeOrders = (("00", 0), ("Default", 1), ("11", 2), ("04", 3), ("01", 4), ("02", 5), ("12", 6), ("05", 7), ("03", 8), ("13", 9))
+        #Beans: The way we're getting the term codes needs some work. Namely splitting the code into year and code.
+        termCode = FormHistory.formID.termCode
+        yearColumn = fn.substring(termCode.cast("text"), 0, 4).cast("integer")
+                    #termCode.cast("text").substring(0,4).cast("integer")
+        codeColumn = fn.substring(termCode.cast("text"), 4, 6).cast("integer")
+                    #termCode.cast("text").substring(4).cast("integer")
+        orderValues = Case(codeColumn, termCodeOrders, 1)
+
+        query = authorizedForms.select(FormHistory, yearColumn.alias('year_column'), orderValues.alias('order_value')).order_by(yearColumn, orderValues)
+        print(query)
+        test = list(query)
+        print(test) # beans
+        print('*'*1000)
+
         
         laborStatusFormList = ','.join([str(form.formID.laborStatusFormID) for form in studentForms])
         return render_template( 'main/formHistory.html',

--- a/app/controllers/main_routes/laborHistory.py
+++ b/app/controllers/main_routes/laborHistory.py
@@ -59,14 +59,13 @@ def laborhistory(id, departmentName = None):
         #Beans: The ordering of these authorizedforms is what we're fixing. The plan is to create a function that tacks on an order_by statement to a query
         # authorizedForms = sorted(list(authorizedForms),key=lambda f:f.reviewedDate if f.reviewedDate else f.createdDate, reverse=True)
         #Beans: The following is the tentative order_by statement we'll be putting into a function
-        termCodeOrders = ((0, 0), ("Default", 1), (11, 2), (4, 3), (1, 4), (2, 5), (12, 6), (5, 7), (3, 8), (13, 9))
-        termCode = FormHistory.formID.termCode
-        yearColumn = fn.substring(termCode.cast("char"), 1, 4)
-        codeColumn = fn.substring(termCode.cast("char"), 5, 6)
         
-        orderValues = Case(codeColumn, termCodeOrders, 1)
-        query = authorizedForms.select(FormHistory).select(termCode.alias('user_added_term_code'), yearColumn.alias('year_column'), codeColumn.alias('code_column'), orderValues.alias('order_value')).order_by(yearColumn, orderValues)
-        
+        query = authorizedForms.select(FormHistory)
+        query = FormHistory.order_by_date(query)
+        # print(query) # beans
+        authorizedForms = list(query)
+        # print(f"{authorizedForms.seasonalCode}") # beans
+        # print('*'*1000)
         
         laborStatusFormList = ','.join([str(form.formID.laborStatusFormID) for form in studentForms])
         return render_template( 'main/formHistory.html',
@@ -80,6 +79,7 @@ def laborhistory(id, departmentName = None):
 
     except Exception as e:
         print("Error Loading Student Labor History", e)
+        raise e
         return render_template('errors/500.html'), 500
 
 @main_bp.route("/laborHistory/download" , methods=['POST'])

--- a/app/controllers/main_routes/laborHistory.py
+++ b/app/controllers/main_routes/laborHistory.py
@@ -45,15 +45,15 @@ def laborhistory(id, departmentName=None):
                 if currentUser.student.ID != id:
                     return redirect('/laborHistory/' + currentUser.student.ID)
             elif currentUser.supervisor and not currentUser.student:
-                supervisorForms = FormHistory.select(FormHistory, LaborStatusForm.termCode, LaborStatusForm.jobType) \
-                                  .join_from(FormHistory, LaborStatusForm) \
-                                  .where((FormHistory.formID.supervisor == currentUser.supervisor.ID) | (FormHistory.createdBy == currentUser)) \
-                                  .distinct()
-                deptForms = FormHistory.select(FormHistory, LaborStatusForm.termCode, LaborStatusForm.jobType) \
-                                  .join(LaborStatusForm) \
-                                  .join( Department) \
-                                  .where(FormHistory.formID.department.DEPT_NAME == currentUser.supervisor.DEPT_NAME) \
-                                  .distinct()
+                supervisorForms = (FormHistory.select(FormHistory, LaborStatusForm.termCode, LaborStatusForm.jobType)
+                                              .join_from(FormHistory, LaborStatusForm)
+                                              .where((FormHistory.formID.supervisor == currentUser.supervisor.ID) | (FormHistory.createdBy == currentUser))
+                                              .distinct())
+                deptForms = (FormHistory.select(FormHistory, LaborStatusForm.termCode, LaborStatusForm.jobType)
+                                        .join(LaborStatusForm)
+                                        .join(Department)
+                                        .where(FormHistory.formID.department.DEPT_NAME == currentUser.supervisor.DEPT_NAME)
+                                        .distinct())
                 authorizedForms = studentForms.intersect(supervisorForms.union(deptForms)).order_by(LaborStatusForm.jobType)
 
 
@@ -64,7 +64,7 @@ def laborhistory(id, departmentName=None):
         authorizedForms = Term.order_by_term(list(authorizedForms.objects()), reverse=True)
 
         laborStatusFormList = ','.join([str(form.formID.laborStatusFormID) for form in studentForms])
-        return render_template( 'main/formHistory.html',
+        return render_template('main/formHistory.html',
     				            title=('Labor History'),
                                 student = student,
                                 username=currentUser.username,

--- a/app/controllers/main_routes/laborHistory.py
+++ b/app/controllers/main_routes/laborHistory.py
@@ -2,8 +2,9 @@ import datetime
 import re
 import types
 from fpdf import FPDF
+from urllib.parse import urlparse
 
-from flask import render_template , flash, redirect, url_for, request, g, jsonify, current_app, send_file, json, make_response
+from flask import render_template , flash, redirect, url_for, request, g, session, jsonify, current_app, send_file, json, make_response
 from flask_login import current_user, login_required
 from app.controllers.main_routes import *
 from app.models.user import *
@@ -24,10 +25,12 @@ from app.models.studentLaborEvaluation import StudentLaborEvaluation
 from app.models.formHistory import FormHistory
 from app.logic.tracy import Tracy
 from app.logic.userInsertFunctions import getOrCreateStudentRecord
+from app.logic.utils import setReferrerPath
 
 @main_bp.route('/laborHistory/<id>', methods=['GET'])
 @main_bp.route('/laborHistory/<departmentName>/<id>', methods=['GET'])
 def laborhistory(id, departmentName=None):
+    setReferrerPath()
     try:
         currentUser = require_login()
         if not currentUser:                    # Not logged in

--- a/app/controllers/main_routes/laborHistory.py
+++ b/app/controllers/main_routes/laborHistory.py
@@ -33,8 +33,11 @@ def laborhistory(id, departmentName=None):
         if not currentUser:                    # Not logged in
             return render_template('errors/403.html'), 403
         student = getOrCreateStudentRecord(bnumber=id)
-        studentForms = FormHistory.select(FormHistory, LaborStatusForm.termCode).join_from(FormHistory, LaborStatusForm).join_from(FormHistory, HistoryType).where(FormHistory.formID.studentSupervisee == student,
-        FormHistory.historyType.historyTypeName == "Labor Status Form")
+        studentForms = (FormHistory.select(FormHistory, LaborStatusForm.termCode)
+                                   .join_from(FormHistory, LaborStatusForm)
+                                   .join_from(FormHistory, HistoryType)
+                                   .where(FormHistory.formID.studentSupervisee == student, 
+                                          FormHistory.historyType.historyTypeName == "Labor Status Form"))
         authorizedForms = studentForms.distinct()
         if not currentUser.isLaborAdmin:
             # View only your own form history
@@ -60,10 +63,11 @@ def laborhistory(id, departmentName=None):
         # authorizedForms = sorted(list(authorizedForms),key=lambda f:f.reviewedDate if f.reviewedDate else f.createdDate, reverse=True)
         #Beans: The following is the tentative order_by statement we'll be putting into a function
         
-        query = FormHistory.order_by_term(authorizedForms)
-        print(f"{query}") # beans
+        print(f"{authorizedForms}") # beans
         print('*'*1000)
-        authorizedForms = list(query)
+        print(f"{list(authorizedForms)[0]}") # beans
+        print('*'*1000)
+        authorizedForms = Term.order_by_term(list(authorizedForms))
         # print(f"{authorizedForms.seasonalCode}") # beans
         # print('*'*1000)
         

--- a/app/controllers/main_routes/laborHistory.py
+++ b/app/controllers/main_routes/laborHistory.py
@@ -33,7 +33,7 @@ def laborhistory(id, departmentName=None):
         if not currentUser:                    # Not logged in
             return render_template('errors/403.html'), 403
         student = getOrCreateStudentRecord(bnumber=id)
-        studentForms = (FormHistory.select(FormHistory, LaborStatusForm.termCode)
+        studentForms = (FormHistory.select(FormHistory, LaborStatusForm.termCode.alias('termCode'))
                                    .join_from(FormHistory, LaborStatusForm)
                                    .join_from(FormHistory, HistoryType)
                                    .where(FormHistory.formID.studentSupervisee == student, 
@@ -45,11 +45,11 @@ def laborhistory(id, departmentName=None):
                 if currentUser.student.ID != id:
                     return redirect('/laborHistory/' + currentUser.student.ID)
             elif currentUser.supervisor and not currentUser.student:
-                supervisorForms = FormHistory.select(FormHistory, LaborStatusForm.termCode) \
+                supervisorForms = FormHistory.select(FormHistory, LaborStatusForm.termCode.alias('termCode')) \
                                   .join_from(FormHistory, LaborStatusForm) \
                                   .where((FormHistory.formID.supervisor == currentUser.supervisor.ID) | (FormHistory.createdBy == currentUser)) \
                                   .distinct()
-                deptForms = FormHistory.select(FormHistory, LaborStatusForm.termCode) \
+                deptForms = FormHistory.select(FormHistory, LaborStatusForm.termCode.alias('termCode')) \
                                   .join(LaborStatusForm) \
                                   .join( Department) \
                                   .where(FormHistory.formID.department.DEPT_NAME == currentUser.supervisor.DEPT_NAME) \
@@ -65,9 +65,9 @@ def laborhistory(id, departmentName=None):
         
         print(f"{authorizedForms}") # beans
         print('*'*1000)
-        print(f"{list(authorizedForms)[0]}") # beans
+        print(authorizedForms.objects()[0]) # beans
         print('*'*1000)
-        authorizedForms = Term.order_by_term(list(authorizedForms))
+        authorizedForms = Term.order_by_term(list(authorizedForms.objects()))
         # print(f"{authorizedForms.seasonalCode}") # beans
         # print('*'*1000)
         

--- a/app/controllers/main_routes/laborHistory.py
+++ b/app/controllers/main_routes/laborHistory.py
@@ -62,16 +62,17 @@ def laborhistory(id, departmentName = None):
         termCodeOrders = (("00", 0), ("Default", 1), ("11", 2), ("04", 3), ("01", 4), ("02", 5), ("12", 6), ("05", 7), ("03", 8), ("13", 9))
         #Beans: The way we're getting the term codes needs some work. Namely splitting the code into year and code.
         termCode = FormHistory.formID.termCode
-        yearColumn = fn.substring(termCode.cast("text"), 0, 4).cast("integer")
-                    #termCode.cast("text").substring(0,4).cast("integer")
-        codeColumn = fn.substring(termCode.cast("text"), 4, 6).cast("integer")
-                    #termCode.cast("text").substring(4).cast("integer")
+        yearColumn = fn.substring(termCode.cast("char"), 1, 4)
+        codeColumn = fn.substring(termCode.cast("char"), 5, 6)
+        
         orderValues = Case(codeColumn, termCodeOrders, 1)
-
-        query = authorizedForms.select(FormHistory, yearColumn.alias('year_column'), orderValues.alias('order_value')).order_by(yearColumn, orderValues)
+        query = authorizedForms.select(FormHistory, termCode.alias('user_added_term_code'), yearColumn.alias('year_column'), codeColumn.alias('code_column'), orderValues.alias('order_value')).order_by(yearColumn, orderValues)
         print(query)
         test = list(query)
-        print(test) # beans
+        print(test[0]) # beans
+        print(test[0]['user_added_term_code'], f"of type {type(test[0]['user_added_term_code'])}") # beans
+        print(test[0].year_column, f"of type {type(test[0].year_column)}") # beans
+        print(test[0].code_column, f"of type {type(test[0].code_column)}") # beans
         print('*'*1000)
 
         

--- a/app/controllers/main_routes/laborHistory.py
+++ b/app/controllers/main_routes/laborHistory.py
@@ -63,7 +63,7 @@ def laborhistory(id, departmentName=None):
         # authorizedForms = sorted(list(authorizedForms),key=lambda f:f.reviewedDate if f.reviewedDate else f.createdDate, reverse=True)
         #Beans: The following is the tentative order_by statement we'll be putting into a function
         
-        authorizedForms = Term.order_by_term(list(authorizedForms.objects()))
+        authorizedForms = Term.order_by_term(list(authorizedForms.objects()), reverse=True)
 
         laborStatusFormList = ','.join([str(form.formID.laborStatusFormID) for form in studentForms])
         return render_template( 'main/formHistory.html',

--- a/app/controllers/main_routes/laborHistory.py
+++ b/app/controllers/main_routes/laborHistory.py
@@ -75,7 +75,6 @@ def laborhistory(id, departmentName=None):
 
     except Exception as e:
         print("Error Loading Student Labor History", e)
-        raise e
         return render_template('errors/500.html'), 500
 
 @main_bp.route("/laborHistory/download" , methods=['POST'])

--- a/app/controllers/main_routes/laborHistory.py
+++ b/app/controllers/main_routes/laborHistory.py
@@ -63,14 +63,9 @@ def laborhistory(id, departmentName=None):
         # authorizedForms = sorted(list(authorizedForms),key=lambda f:f.reviewedDate if f.reviewedDate else f.createdDate, reverse=True)
         #Beans: The following is the tentative order_by statement we'll be putting into a function
         
-        print(f"{authorizedForms}") # beans
-        print('*'*1000)
-        print(authorizedForms.objects()[0]) # beans
-        print('*'*1000)
-        authorizedForms = Term.order_by_term(list(authorizedForms.objects()))
-        # print(f"{authorizedForms.seasonalCode}") # beans
-        # print('*'*1000)
         
+        authorizedForms = Term.order_by_term(list(authorizedForms.objects()))
+
         laborStatusFormList = ','.join([str(form.formID.laborStatusFormID) for form in studentForms])
         return render_template( 'main/formHistory.html',
     				            title=('Labor History'),

--- a/app/controllers/main_routes/laborHistory.py
+++ b/app/controllers/main_routes/laborHistory.py
@@ -59,22 +59,14 @@ def laborhistory(id, departmentName = None):
         #Beans: The ordering of these authorizedforms is what we're fixing. The plan is to create a function that tacks on an order_by statement to a query
         # authorizedForms = sorted(list(authorizedForms),key=lambda f:f.reviewedDate if f.reviewedDate else f.createdDate, reverse=True)
         #Beans: The following is the tentative order_by statement we'll be putting into a function
-        termCodeOrders = (("00", 0), ("Default", 1), ("11", 2), ("04", 3), ("01", 4), ("02", 5), ("12", 6), ("05", 7), ("03", 8), ("13", 9))
-        #Beans: The way we're getting the term codes needs some work. Namely splitting the code into year and code.
+        termCodeOrders = ((0, 0), ("Default", 1), (11, 2), (4, 3), (1, 4), (2, 5), (12, 6), (5, 7), (3, 8), (13, 9))
         termCode = FormHistory.formID.termCode
         yearColumn = fn.substring(termCode.cast("char"), 1, 4)
         codeColumn = fn.substring(termCode.cast("char"), 5, 6)
         
         orderValues = Case(codeColumn, termCodeOrders, 1)
-        query = authorizedForms.select(FormHistory, termCode.alias('user_added_term_code'), yearColumn.alias('year_column'), codeColumn.alias('code_column'), orderValues.alias('order_value')).order_by(yearColumn, orderValues)
-        print(query)
-        test = list(query)
-        print(test[0]) # beans
-        print(test[0]['user_added_term_code'], f"of type {type(test[0]['user_added_term_code'])}") # beans
-        print(test[0].year_column, f"of type {type(test[0].year_column)}") # beans
-        print(test[0].code_column, f"of type {type(test[0].code_column)}") # beans
-        print('*'*1000)
-
+        query = authorizedForms.select(FormHistory).select(termCode.alias('user_added_term_code'), yearColumn.alias('year_column'), codeColumn.alias('code_column'), orderValues.alias('order_value')).order_by(yearColumn, orderValues)
+        
         
         laborStatusFormList = ','.join([str(form.formID.laborStatusFormID) for form in studentForms])
         return render_template( 'main/formHistory.html',

--- a/app/logic/utils.py
+++ b/app/logic/utils.py
@@ -1,3 +1,6 @@
+from flask import session, request
+from urllib.parse import urlparse
+
 
 def makeThirdPartyLink(recipient, host, formHistoryId):
     route = ""
@@ -9,3 +12,6 @@ def makeThirdPartyLink(recipient, host, formHistoryId):
         route = "studentOverloadApp"
 
     return f"http://{host}/{route}/{formHistoryId}"
+
+def setReferrerPath():
+    session['referrerPath'] = urlparse(request.referrer).path or ''

--- a/app/models/formHistory.py
+++ b/app/models/formHistory.py
@@ -23,17 +23,17 @@ class FormHistory(baseModel):
     status              = ForeignKeyField(Status)                       # Foreign key to Status # Approved, Denied, Pending
     rejectReason        = TextField(null=True)                          # This should not be null IF that status is rejected
 
-
+    
     def __str__(self):
         return str(self.__dict__)
     
     @staticmethod
-    def order_by_date(query):
+    def order_by_date(query, reverse=False):
         termCodeOrders = ((0, 0), ("Default", 1), (11, 2), (4, 3), (1, 4), (2, 5), (12, 6), (5, 7), (3, 8), (13, 9))
         termCode = FormHistory.formID.termCode
         yearColumn = fn.substring(termCode.cast("char"), 1, 4)
         seasonalColumn = fn.substring(termCode.cast("char"), 5, 6)
         orderValues = Case(seasonalColumn, termCodeOrders, 1)
-        return query.select(FormHistory, seasonalColumn.alias('seasonalCode'), yearColumn.alias('yearCode'), orderValues.alias('orderValue')).order_by(yearColumn, orderValues)
+        return query.select(FormHistory, seasonalColumn.alias('seasonalCode'), yearColumn.alias('yearCode'), orderValues.alias('orderValue')).order_by(yearColumn, orderValues, reverse=reverse)
 
 

--- a/app/models/formHistory.py
+++ b/app/models/formHistory.py
@@ -27,26 +27,3 @@ class FormHistory(baseModel):
     def __str__(self):
         return str(self.__dict__)
     
-    @staticmethod
-    def order_by_term(query, reverse=False):
-        """
-        Accepts the results of a query where each object has had a `termCode` column selected.
-        Sorts by the Term Code in logical order based first on year and then by the seasonalCode
-        
-        seasonalCode := last two digits of the term code which maps arbitrarily to the name of the term, break, etc.
-        """
-        termCodeOrders = ((0, 0), ("Default", 1), (11, 2), (4, 3), (1, 4), (2, 5), (12, 6), (5, 7), (3, 8), (13, 9))
-        termCode = FormHistory.formID.termCode
-        yearColumn = fn.substring(termCode.cast("char"), 1, 4)
-        seasonalColumn = fn.substring(termCode.cast("char"), 5, 6)
-        orderValues = Case(seasonalColumn, termCodeOrders, 1)
-        return (query
-                    #  .select(FormHistory, 
-                    #          seasonalColumn.alias('seasonalCode'), 
-                    #          yearColumn.alias('yearCode'), 
-                    #          orderValues.alias('orderValue'))
-                     #.join(LaborStatusForm, JOIN.LEFT_OUTER, on=(FormHistory.formID == LaborStatusForm.laborStatusFormID))
-                     .order_by(yearColumn.desc() if reverse else yearColumn, 
-                               orderValues.desc() if reverse else orderValues))
-
-

--- a/app/models/formHistory.py
+++ b/app/models/formHistory.py
@@ -28,12 +28,25 @@ class FormHistory(baseModel):
         return str(self.__dict__)
     
     @staticmethod
-    def order_by_date(query, reverse=False):
+    def order_by_term(query, reverse=False):
+        """
+        Accepts the results of a query where each object has had a `termCode` column selected.
+        Sorts by the Term Code in logical order based first on year and then by the seasonalCode
+        
+        seasonalCode := last two digits of the term code which maps arbitrarily to the name of the term, break, etc.
+        """
         termCodeOrders = ((0, 0), ("Default", 1), (11, 2), (4, 3), (1, 4), (2, 5), (12, 6), (5, 7), (3, 8), (13, 9))
         termCode = FormHistory.formID.termCode
         yearColumn = fn.substring(termCode.cast("char"), 1, 4)
         seasonalColumn = fn.substring(termCode.cast("char"), 5, 6)
         orderValues = Case(seasonalColumn, termCodeOrders, 1)
-        return query.select(FormHistory, seasonalColumn.alias('seasonalCode'), yearColumn.alias('yearCode'), orderValues.alias('orderValue')).order_by(yearColumn, orderValues, reverse=reverse)
+        return (query
+                    #  .select(FormHistory, 
+                    #          seasonalColumn.alias('seasonalCode'), 
+                    #          yearColumn.alias('yearCode'), 
+                    #          orderValues.alias('orderValue'))
+                     #.join(LaborStatusForm, JOIN.LEFT_OUTER, on=(FormHistory.formID == LaborStatusForm.laborStatusFormID))
+                     .order_by(yearColumn.desc() if reverse else yearColumn, 
+                               orderValues.desc() if reverse else orderValues))
 
 

--- a/app/models/formHistory.py
+++ b/app/models/formHistory.py
@@ -26,3 +26,14 @@ class FormHistory(baseModel):
 
     def __str__(self):
         return str(self.__dict__)
+    
+    @staticmethod
+    def order_by_date(query):
+        termCodeOrders = ((0, 0), ("Default", 1), (11, 2), (4, 3), (1, 4), (2, 5), (12, 6), (5, 7), (3, 8), (13, 9))
+        termCode = FormHistory.formID.termCode
+        yearColumn = fn.substring(termCode.cast("char"), 1, 4)
+        seasonalColumn = fn.substring(termCode.cast("char"), 5, 6)
+        orderValues = Case(seasonalColumn, termCodeOrders, 1)
+        return query.select(FormHistory, seasonalColumn.alias('seasonalCode'), yearColumn.alias('yearCode'), orderValues.alias('orderValue')).order_by(yearColumn, orderValues)
+
+

--- a/app/models/term.py
+++ b/app/models/term.py
@@ -42,7 +42,7 @@ class Term(baseModel):
         # TODO: beans, We'd like to use simply e.termCode here but for some reason we cannot select for it.
         # To solve the immediate problem, we're trying to use a peewee object way of looking at it by going through
         # .formID first but we're getting another error about departments now. We should try to comment out the line
-        # that calls this function to order them at all to ensure that the problem is what we're doing here
+        # that calls this function to order them at all to ensure that the problem is what we're doing here.
 
         # Sort by seasonal code
         result = sorted(queryResult, key=lambda e: seasonalCodeToOrderValue[str(e.formID.termCode)[4:]], reverse=reverse)

--- a/app/models/term.py
+++ b/app/models/term.py
@@ -21,8 +21,8 @@ class Term(baseModel):
     def order_by_term(queryResult, *, reverse=False):
         """
         Accepts the results of a query where each object has a `termCode` attribute.
-        To bring selected columns from other tables into an objects direct attributes
-        use the .objects() method on the query.
+        To collapse selected columns from other tables into an objects direct attributes
+        use the .objects() method on the query. See peewee documentation for more details.
 
         Sorts by the Term Code in logical order based first on year and then by the seasonalCode
         

--- a/app/models/term.py
+++ b/app/models/term.py
@@ -23,21 +23,23 @@ class Term(baseModel):
         Accepts the results of a query where each object has a `termCode` attribute.
         To bring selected columns from other tables into an objects direct attributes
         use the .objects() method on the query.
+
         Sorts by the Term Code in logical order based first on year and then by the seasonalCode
         
         seasonalCode := last two digits of the term code which maps arbitrarily to the name of the term, break, etc.
         """
-        seasonalCodeToOrderValue = defaultdict(lambda: 8)
+        seasonalCodeToOrderValue = defaultdict(lambda: 1)
         seasonalCodeToOrderValue.update({
-            '13' : 0,
-            '03' : 1,
-            '05' : 2,
-            '12' : 3,
-            '02' : 4,
-            '01' : 5,
-            '04' : 6,
-            '11' : 7,
-            '00' : 9,
+            '00' : 0,
+            '11' : 2,
+            '04' : 3,
+            '01' : 4,
+            '02' : 5,
+            '12' : 6,
+            '05' : 7,
+            '03' : 8,
+            '13' : 9,
+
         })
 
         # Sort by seasonal code

--- a/app/models/term.py
+++ b/app/models/term.py
@@ -20,13 +20,13 @@ class Term(baseModel):
     @staticmethod
     def order_by_term(queryResult, *, reverse=False):
         """
-        Accepts the results of a query where each object has had a `termCode` column selected.
+        Accepts the results of a query where each object has a `termCode` attribute.
+        To bring selected columns from other tables into an objects direct attributes
+        use the .objects() method on the query.
         Sorts by the Term Code in logical order based first on year and then by the seasonalCode
         
         seasonalCode := last two digits of the term code which maps arbitrarily to the name of the term, break, etc.
         """
-        print(dir(queryResult[0])) # beans
-        print("*"*100)
         seasonalCodeToOrderValue = defaultdict(lambda: 1)
         seasonalCodeToOrderValue.update({
             '00' : 0,
@@ -45,6 +45,6 @@ class Term(baseModel):
         # that calls this function to order them at all to ensure that the problem is what we're doing here.
 
         # Sort by seasonal code
-        result = sorted(queryResult, key=lambda e: seasonalCodeToOrderValue[str(e.formID.termCode)[4:]], reverse=reverse)
+        result = sorted(queryResult, key=lambda e: seasonalCodeToOrderValue[str(e.termCode)[4:]], reverse=reverse)
         # Sort by year
-        return sorted(result, key=lambda e: str(e.formID.termCode)[:4], reverse=reverse)
+        return sorted(result, key=lambda e: str(e.termCode)[:4], reverse=reverse)

--- a/app/models/term.py
+++ b/app/models/term.py
@@ -1,4 +1,5 @@
 from app.models import *
+from collections import defaultdict
 
 
 class Term(baseModel):
@@ -14,3 +15,36 @@ class Term(baseModel):
     isAcademicYear          = BooleanField(default=False)
     isFinalEvaluationOpen   = BooleanField(default=False)
     isMidyearEvaluationOpen = BooleanField(default=False)
+
+
+    @staticmethod
+    def order_by_term(queryResult, *, reverse=False):
+        """
+        Accepts the results of a query where each object has had a `termCode` column selected.
+        Sorts by the Term Code in logical order based first on year and then by the seasonalCode
+        
+        seasonalCode := last two digits of the term code which maps arbitrarily to the name of the term, break, etc.
+        """
+        print(dir(queryResult[0])) # beans
+        print("*"*100)
+        seasonalCodeToOrderValue = defaultdict(lambda: 1)
+        seasonalCodeToOrderValue.update({
+            '00' : 0,
+            '11' : 2,
+            '04' : 3,
+            '01' : 4,
+            '02' : 5,
+            '12' : 6,
+            '05' : 7,
+            '03' : 8,
+            '13' : 9,
+        })
+        # TODO: beans, We'd like to use simply e.termCode here but for some reason we cannot select for it.
+        # To solve the immediate problem, we're trying to use a peewee object way of looking at it by going through
+        # .formID first but we're getting another error about departments now. We should try to comment out the line
+        # that calls this function to order them at all to ensure that the problem is what we're doing here
+
+        # Sort by seasonal code
+        result = sorted(queryResult, key=lambda e: seasonalCodeToOrderValue[str(e.formID.termCode)[4:]], reverse=reverse)
+        # Sort by year
+        return sorted(result, key=lambda e: str(e.formID.termCode)[:4], reverse=reverse)

--- a/app/models/term.py
+++ b/app/models/term.py
@@ -27,22 +27,18 @@ class Term(baseModel):
         
         seasonalCode := last two digits of the term code which maps arbitrarily to the name of the term, break, etc.
         """
-        seasonalCodeToOrderValue = defaultdict(lambda: 1)
+        seasonalCodeToOrderValue = defaultdict(lambda: 8)
         seasonalCodeToOrderValue.update({
-            '00' : 0,
-            '11' : 2,
-            '04' : 3,
-            '01' : 4,
-            '02' : 5,
-            '12' : 6,
-            '05' : 7,
-            '03' : 8,
-            '13' : 9,
+            '13' : 0,
+            '03' : 1,
+            '05' : 2,
+            '12' : 3,
+            '02' : 4,
+            '01' : 5,
+            '04' : 6,
+            '11' : 7,
+            '00' : 9,
         })
-        # TODO: beans, We'd like to use simply e.termCode here but for some reason we cannot select for it.
-        # To solve the immediate problem, we're trying to use a peewee object way of looking at it by going through
-        # .formID first but we're getting another error about departments now. We should try to comment out the line
-        # that calls this function to order them at all to ensure that the problem is what we're doing here.
 
         # Sort by seasonal code
         result = sorted(queryResult, key=lambda e: seasonalCodeToOrderValue[str(e.termCode)[4:]], reverse=reverse)

--- a/app/static/js/laborhistory.js
+++ b/app/static/js/laborhistory.js
@@ -1,6 +1,6 @@
-function goback(departmentName){
-  if (departmentName != "None") {
-    window.location.href = '/main/department/' + departmentName
+function goback(referrerPath){
+  if (referrerPath) {
+    window.location.href = referrerPath
   } else {
     window.location.href = '/';
   }

--- a/app/templates/main/formHistory.html
+++ b/app/templates/main/formHistory.html
@@ -23,7 +23,7 @@
       <table class="table" id="positionTable" >
         {% for form in authorizedForms %}
         <tr>
-          <!-- If a user is a labor admin, then the value boolean is true, and allows admin access to all of a student's labor history. -->
+          {# If a user is a labor admin, then the value boolean is true, and allows admin access to all of a student's labor history. #}
           {% if currentUser.isLaborAdmin or form.formID.POSN_CODE != "S12345" or student %}
           <td id="{{form.formID.laborStatusFormID}}" class="modalLink" value="true">
             <a href="#" tabindex="0"><span class="h4">{{form.formID.termCode.termName}} - {{form.formID.department.DEPT_NAME}} Dept.</span></a>

--- a/app/templates/main/formHistory.html
+++ b/app/templates/main/formHistory.html
@@ -45,6 +45,6 @@
 </div>
 <!-- Modal End -->
   {% if currentUser.supervisor or currentUser.isLaborAdmin %}
-    <div align= "left"><button class='btn btn-danger' id="returnbutton" onclick="goback('{{departmentName}}')">Return</button></div>
+    <div align= "left"><button class='btn btn-danger' id="returnbutton" onclick="goback('{{session.referrerPath}}')">Return</button></div>
   {% endif %}
 {% endblock %}

--- a/tests/code/test_models.py
+++ b/tests/code/test_models.py
@@ -58,18 +58,18 @@ def test_term_model():
     with mainDB.atomic() as transaction:
         # We expect that term codes will be ordered by year with ties broken by the last two digits in this order:
         # '13', '03', '12', '02', '01', '04', '11', [default], '00'
-        correctlyOrderedSeasonCodes = ['13', '03', '05', '12', '02', '01', '04', '11', '99', '00']
+        sortedSeasonCodes = ['13', '03', '05', '12', '02', '01', '04', '11', '99', '00']
 
         # Create the forms out of order
-        unorderedSeasonCodes = ['13', '02', '04', '00', '11', '12', '03', '99', '01', '05']
-        for seasonCode in unorderedSeasonCodes:
+        unsortedSeasonCodes = ['13', '02', '04', '00', '11', '12', '03', '99', '01', '05']
+        for seasonCode in unsortedSeasonCodes:
             createLSFandFormHistoryObj(termCode=int(f'2025{seasonCode}'))
 
         newForms = FormHistory.select(FormHistory, LaborStatusForm.termCode).join(LaborStatusForm, JOIN.LEFT_OUTER).where(FormHistory.rejectReason == "testing")
         sortedForms = Term.order_by_term(newForms.objects())
         resultingTermCodes = [str(f.termCode) for f in sortedForms]
         resultingSeasonalCodes = [termCode[4:] for termCode in resultingTermCodes]
-        assert resultingSeasonalCodes == correctlyOrderedSeasonCodes
+        assert resultingSeasonalCodes == sortedSeasonCodes
 
 
         # Test that the year has more weight in the sort than the seasonal code

--- a/tests/code/test_models.py
+++ b/tests/code/test_models.py
@@ -34,17 +34,18 @@ def test_term_model():
         """
         Subprocedure to create LSF and FormHistory objects for a particular termCode with dummy data.
         """
-        Term.get_or_create(termCode= termCode, termName="idk");
+        createLSFandFormHistoryObj.callCounter += 1
+        Term.get_or_create(termCode=termCode, termName=f"dummyTerm{createLSFandFormHistoryObj.callCounter}")
 
         #                                        Alex Bryant              Brian Ramsay              CS      
         irrelevantLsfObjData = {'studentSupervisee': 'B00841417', 'supervisor': 'B00763721', 'department': 1, 'jobType': 'Primary', 'WLS': 1, 'POSN_TITLE': '', 'POSN_CODE': ''}
-        lsf = LaborStatusForm.create(termCode = termCode, **irrelevantLsfObjData);
+        lsf = LaborStatusForm.create(termCode = termCode, **irrelevantLsfObjData)
         #                                                            Scott Heggen
         irrelevantFhObjData = {'historyType': 'Labor Status Form', 'createdBy': 1, 'createdDate': '2024-01-30', 'status': 'Pending'}
-        formHistoryObj = FormHistory.create(formID = lsf, rejectReason = "testing", **irrelevantFhObjData);
+        formHistoryObj = FormHistory.create(formID = lsf, rejectReason = "testing", **irrelevantFhObjData)
         return lsf, formHistoryObj
+    createLSFandFormHistoryObj.callCounter = 0
     
- 
     with mainDB.atomic() as transaction:
         # Test that term codes will be ordered by year with ties broken by the last two digits in this order:
         #                                   default

--- a/tests/code/test_models.py
+++ b/tests/code/test_models.py
@@ -1,5 +1,6 @@
 import pytest
 from app.models.user import User
+from app.models.formHistory import FormHistory
 from peewee import DoesNotExist
 
 @pytest.mark.integration
@@ -22,3 +23,24 @@ def test_user_model():
     assert both_user.lastName == "Bryant"
     assert both_user.fullName == "Alex Bryant"
     assert both_user.email == "bryantal@berea.edu"
+
+
+@pytest.mark.integration
+def test_form_history_model():
+     """
+     Beans (what we need to do):
+     - create several labor status forms that belong to different terms in different years
+     - create corresponding form history objects for the forms
+     - write a query to select all forms
+     - order the form selection using the FormHistory.order_by_date() method
+     - assert that the forms are in correctly in order by date 
+     """
+    return
+    # [Beans] each form history object needs: formID, historyType, createdBy, createdDate, status
+    formHistories = FormHistory.create(   formID       = lsf.laborStatusFormID,
+                                           historyType  = "Labor Adjustment Form",
+                                           adjustedForm = adjustedforms.adjustedFormID,
+                                           createdBy    = currentUser,
+                                           createdDate  = date.today(),
+                                           status       = "Pending")
+

--- a/tests/code/test_models.py
+++ b/tests/code/test_models.py
@@ -58,7 +58,7 @@ def test_term_model():
     with mainDB.atomic() as transaction:
         # We expect that term codes will be ordered by year with ties broken by the last two digits in this order:
         # '13', '03', '12', '02', '01', '04', '11', [default], '00'
-        correctlyOrderedSeasonCodes = ['13', '03', '05', '12', '02', '01', '04', '11', '99', '00']
+        correctlyOrderedSeasonCodes = ['00', '99', '11', '04', '01', '02', '12', '05', '03', '13']
 
         # Create the forms out of order
         outOfOrderSeasonCodes = ['13', '02', '04', '00', '11', '12', '03', '99', '01', '05']
@@ -74,8 +74,8 @@ def test_term_model():
         
         transaction.rollback()
 
-         # Test that the year has more weight in the sort than the seasonal code
-        sortedTermCodes = [202313, 202302, 202311, 202403, 202412, 202400]
+        # Test that the year has more weight in the sort than the seasonal code
+        sortedTermCodes = [202311, 202302, 202313, 202400, 202412, 202403]
         unsortedTermCodes = [202302, 202403, 202313, 202311, 202400, 202412]
         for termCodes in unsortedTermCodes:
             createLSFandFormHistoryObj(termCode=int(termCodes))

--- a/tests/code/test_models.py
+++ b/tests/code/test_models.py
@@ -1,6 +1,8 @@
 import pytest
 from app.models.user import User
 from app.models.formHistory import FormHistory
+from app.models.laborStatusForm import LaborStatusForm
+from app.models import mainDB
 from peewee import DoesNotExist
 
 @pytest.mark.integration
@@ -27,20 +29,43 @@ def test_user_model():
 
 @pytest.mark.integration
 def test_form_history_model():
-     """
-     Beans (what we need to do):
-     - create several labor status forms that belong to different terms in different years
-     - create corresponding form history objects for the forms
-     - write a query to select all forms
-     - order the form selection using the FormHistory.order_by_date() method
-     - assert that the forms are in correctly in order by date 
-     """
-    return
-    # [Beans] each form history object needs: formID, historyType, createdBy, createdDate, status
-    formHistories = FormHistory.create(   formID       = lsf.laborStatusFormID,
-                                           historyType  = "Labor Adjustment Form",
-                                           adjustedForm = adjustedforms.adjustedFormID,
-                                           createdBy    = currentUser,
-                                           createdDate  = date.today(),
-                                           status       = "Pending")
+    """
+    Beans (what we need to do):
+    - create several labor status forms that belong to different terms in different years
+    - create corresponding form history objects for the forms
+    - write a query to select all forms
+    - order the form selection using the FormHistory.order_by_date() method
+    - assert that the forms are in correctly in order by date 
+    """
+    def createLSFandFormHistoryObj(*, termCode):
+        """
+        Subprocedure to create LSF and FormHistory objects for a particular termCode with dummy data.
+        """
+        # [Beans] lsf object: termCode (*Term), studentSupervisee (*Student), supervisor (*Supervisor), department (*Department), jobType, WLS, POSN_TITLE, POSN_CODE 
+        #                                        Alex Bryant              Brian Ramsay              CS      
+        irrelevantLsfObjData = {'studentSupervisee': 'B00841417', 'supervisor': 'B00763721', 'department': 1, 'jobType': 'Primary', 'WLS': 1, 'POSN_TITLE': '', 'POSN_CODE': ''}
+        lsf = LaborStatusForm.create(termCode = termCode, **irrelevantLsfObjData)
+        # [Beans] form history object: formID, historyType, createdBy, createdDate, status
+        #                                                            Scott Heggen
+        irrelevantFhObjData = {'historyType': 'Labor Status Form', 'createdBy': 1, 'createdDate': '2024-01-30', 'status': 'Pending'}
+        formHistoryObj = FormHistory.create(formID = lsf, **irrelevantFhObjData)
+        return lsf, formHistoryObj
+    
+    
+    with mainDB.atomic() as transaction:
+        # We expect that term codes will be ordered by year with ties broken by the last two digits in this order:
+        # 00, default, 11, 04, 01, 02, 12, 05, 03, 13
+
+        # Test that ties are broken correctly
+
+        # Create the forms out of order
+        outOfOrderSemesterCodes = ['13', '02', '04', '00', '11', '12', '03', '99', '01', '05']
+        for semesterCode in outOfOrderSemesterCodes:
+            createLSFandFormHistoryObj(termCode=int(f'2025{semesterCode}'))
+
+
+        transaction.rollback()
+    
+    
+    
 

--- a/tests/code/test_models.py
+++ b/tests/code/test_models.py
@@ -4,7 +4,7 @@ from app.models.formHistory import FormHistory
 from app.models.laborStatusForm import LaborStatusForm
 from app.models.term import Term
 from app.models import mainDB
-from peewee import DoesNotExist
+from peewee import DoesNotExist, JOIN
 
 @pytest.mark.integration
 def test_user_model():
@@ -67,12 +67,12 @@ def test_form_history_model():
             createLSFandFormHistoryObj(termCode=int(f'2025{seasonCode}'))
 
         try:
-            newForms = FormHistory.select().where(FormHistory.rejectReason == "testing")
-            sortedForms = list(FormHistory.order_by_term(newForms))
+            newForms = FormHistory.select(FormHistory, LaborStatusForm.termCode).join(LaborStatusForm, JOIN.LEFT_OUTER).where(FormHistory.rejectReason == "testing")
+            sortedForms = Term.order_by_term(newForms)
             resultingTermCodes = [str(f.formID.termCode) for f in sortedForms]
             print(resultingTermCodes)
 
-            
+
         except Exception as e:
             print(f"Broke in second half: {e}")
         

--- a/tests/code/test_models.py
+++ b/tests/code/test_models.py
@@ -30,25 +30,15 @@ def test_user_model():
 
 @pytest.mark.integration
 def test_term_model():
-    """
-    Beans (what we need to do):
-    - create several labor status forms that belong to different terms in different years
-    - create corresponding form history objects for the forms
-    - write a query to select all forms
-    - order the form selection using the FormHistory.order_by_term() method
-    - assert that the forms are in correctly in order by date 
-    """
     def createLSFandFormHistoryObj(*, termCode):
         """
         Subprocedure to create LSF and FormHistory objects for a particular termCode with dummy data.
         """
         Term.get_or_create(termCode= termCode, termName="idk");
 
-        # [Beans] lsf object: termCode (*Term), studentSupervisee (*Student), supervisor (*Supervisor), department (*Department), jobType, WLS, POSN_TITLE, POSN_CODE 
         #                                        Alex Bryant              Brian Ramsay              CS      
         irrelevantLsfObjData = {'studentSupervisee': 'B00841417', 'supervisor': 'B00763721', 'department': 1, 'jobType': 'Primary', 'WLS': 1, 'POSN_TITLE': '', 'POSN_CODE': ''}
         lsf = LaborStatusForm.create(termCode = termCode, **irrelevantLsfObjData);
-        # [Beans] form history object: formID, historyType, createdBy, createdDate, status
         #                                                            Scott Heggen
         irrelevantFhObjData = {'historyType': 'Labor Status Form', 'createdBy': 1, 'createdDate': '2024-01-30', 'status': 'Pending'}
         formHistoryObj = FormHistory.create(formID = lsf, rejectReason = "testing", **irrelevantFhObjData);
@@ -56,8 +46,8 @@ def test_term_model():
     
  
     with mainDB.atomic() as transaction:
-        # We expect that term codes will be ordered by year with ties broken by the last two digits in this order:
-        # '13', '03', '12', '02', '01', '04', '11', [default], '00'
+        # Test that term codes will be ordered by year with ties broken by the last two digits in this order:
+        #                                   default
         correctlyOrderedSeasonCodes = ['00', '99', '11', '04', '01', '02', '12', '05', '03', '13']
 
         # Create the forms out of order

--- a/tests/code/test_models.py
+++ b/tests/code/test_models.py
@@ -48,7 +48,7 @@ def test_form_history_model():
         # [Beans] form history object: formID, historyType, createdBy, createdDate, status
         #                                                            Scott Heggen
         irrelevantFhObjData = {'historyType': 'Labor Status Form', 'createdBy': 1, 'createdDate': '2024-01-30', 'status': 'Pending'}
-        formHistoryObj = FormHistory.create(formID = lsf, **irrelevantFhObjData)
+        formHistoryObj = FormHistory.create(formID = lsf, rejectReason = "banned", **irrelevantFhObjData)
         return lsf, formHistoryObj
     
     
@@ -59,12 +59,14 @@ def test_form_history_model():
         # Test that ties are broken correctly
 
         # Create the forms out of order
-        outOfOrderSemesterCodes = ['13', '02', '04', '00', '11', '12', '03', '99', '01', '05']
-        for semesterCode in outOfOrderSemesterCodes:
-            createLSFandFormHistoryObj(termCode=int(f'2025{semesterCode}'))
-
+        outOfOrderSeasonCodes = ['13', '02', '04', '00', '11', '12', '03', '99', '01', '05']
+        for seasonCode in outOfOrderSeasonCodes:
+            createLSFandFormHistoryObj(termCode=int(f'2025{seasonCode}'))
+        newForms = FormHistory.select().where(rejectReason = "banned") 
 
         transaction.rollback()
+
+    
     
     
     

--- a/tests/code/test_models.py
+++ b/tests/code/test_models.py
@@ -61,8 +61,8 @@ def test_term_model():
         correctlyOrderedSeasonCodes = ['13', '03', '05', '12', '02', '01', '04', '11', '99', '00']
 
         # Create the forms out of order
-        outOfOrderSeasonCodes = ['13', '02', '04', '00', '11', '12', '03', '99', '01', '05']
-        for seasonCode in outOfOrderSeasonCodes:
+        unorderedSeasonCodes = ['13', '02', '04', '00', '11', '12', '03', '99', '01', '05']
+        for seasonCode in unorderedSeasonCodes:
             createLSFandFormHistoryObj(termCode=int(f'2025{seasonCode}'))
 
         newForms = FormHistory.select(FormHistory, LaborStatusForm.termCode).join(LaborStatusForm, JOIN.LEFT_OUTER).where(FormHistory.rejectReason == "testing")


### PR DESCRIPTION
Issue:
The problem is in the sorting order, which is intended to be in reverse chronological order, meaning that the most future term should be displayed at the top. However, the sorting for all terms was incorrect and was instead being ordered by date modified which was improper for the form.

Changes:
- Created ordered values for the term code
- Recreated the ordering function inside of the term model" to "Created a method in the Term class to order objects by term
- Created tests 
- Recreated the ordering function inside of the term model
- Made sure that we were passing our formhistories to the term.sort_by_term method

Testing:
- switch to 344-fix-labor-history-ordering
- source setup.sh and ./database/reset_database.sh from-backup
- flask run
- Navigate to the student search  
- The page should display the labor status forms of the selected student from past terms in reverse order (newest to oldest)
- Also, run the test suite

Attached below is how a proper ordering should look like
![labor status form ssdt](https://github.com/BCStudentSoftwareDevTeam/lsf/assets/122579222/72217ed1-ddc7-43b9-bb19-cb53661a9d2d)
