### PR TITLE
Add additional form search filters

### DIFF
--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -106,8 +106,10 @@ def getDatatableData(request):
     rowsPerPage = int(request.form.get('length', -1))
     queryFilterData = request.form.get('data')
     queryFilterDict = json.loads(queryFilterData)
-    sortBy = queryFilterDict.get('sortBy', "supervisorLastName")
-    order = queryFilterDict.get('order', "")
+    sortBy = queryFilterDict.get('sortBy', "term")
+    if sortBy == "":
+        sortBy = "term"
+    order = queryFilterDict.get('order', "ASC")
     
     termCode = queryFilterDict.get('termCode', "")
     if termCode == "currentTerm":

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -108,23 +108,29 @@ def getDatatableData(request):
     order = request.form.get('order[0][dir]')
     queryFilterData = request.form.get('data')
     queryFilterDict = json.loads(queryFilterData)
-    sortByOptions = queryFilterDict.get('sortBy', {})
+    sortBy = queryFilterDict.get('sortBy', "")
     # Allows to switch between first and last names for the column filters
-    print("I AM RUNNING")
     # Dictionary to match column indices with column names in the DB
     # It is used for identifying the column that needs to be sorted
-    colIndexColNameMap = {  0: Term.termCode,
-                            1: Department.DEPT_NAME,
-                            2: Supervisor.preferred_name | Supervisor.legal_name if sortByOptions.get('firstName', False) == True else Supervisor.LAST_NAME,
-                            3: Student.preferred_name | Student.legal_name if sortByOptions.get('firstName', False) == True else Student.LAST_NAME,
-                            4: LaborStatusForm.POSN_CODE,
-                            5: LaborStatusForm.weeklyHours,
-                            6: LaborStatusForm.startDate,
-                            7: User.username,
-                            8: FormHistory.status,
-                            9: FormHistory.historyType,
-                            10: StudentLaborEvaluation.ID}
 
+    sortValueColumnMap = {
+        "Term": Term.termCode,
+        "Department": Department.DEPT_NAME,
+        "supervisorFirstName": Supervisor.FIRST_NAME,
+        "supervisorLastName": Supervisor.LAST_NAME,
+        "studentFirstName": Student.FIRST_NAME,
+        "studentLastName": Student.LAST_NAME,
+        "positionCode": LaborStatusForm.POSN_CODE,
+        "positionWLS": LaborStatusForm.WLS,
+        "hours": LaborStatusForm.weeklyHours,
+        "length": LaborStatusForm.startDate,
+        "createdBy": User.username, 
+        "formStatus": FormHistory.status,
+        "formType": FormHistory.historyType,
+    }
+    
+    print(sortValueColumnMap[sortBy])
+    
     termCode = queryFilterDict.get('termCode', "")
     if termCode == "currentTerm":
         termCode = g.openTerm
@@ -176,11 +182,11 @@ def getDatatableData(request):
     # Sorting a column in descending order when a specific column is chosen
     # Initially, it sorts by the Term column as specified in supervisorPortal.js
     if order == "desc":
-        filteredSearchResults = formSearchResults.order_by(colIndexColNameMap[sortColIndex].desc()).limit(rowsPerPage).offset(rowNumber)
+        filteredSearchResults = formSearchResults.order_by(sortValueColumnMap[sortBy].desc()).limit(rowsPerPage).offset(rowNumber)
     # Sorting a column in ascending order when a specific column is chosen
     
     else:
-        filteredSearchResults = formSearchResults.order_by(colIndexColNameMap[sortColIndex].asc()).limit(rowsPerPage).offset(rowNumber)
+        filteredSearchResults = formSearchResults.order_by(sortValueColumnMap[sortBy].asc()).limit(rowsPerPage).offset(rowNumber)
     formattedData = getFormattedData(filteredSearchResults)
     formsDict = {"draw": draw, "recordsTotal": recordsTotal, "recordsFiltered": recordsTotal, "data": formattedData}
 

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -115,7 +115,7 @@ def getDatatableData(request):
     # It is used for identifying the column that needs to be sorted
     supervisorFirstName = Supervisor.preferred_name if Supervisor.preferred_name else Supervisor.FIRST_NAME
     studentFirstName = Student.preferred_name if Student.preferred_name else Student.FIRST_NAME
-
+    
     sortValueColumnMap = {
         "term": Term.termCode,
         "department": Department.DEPT_NAME,
@@ -183,9 +183,7 @@ def getDatatableData(request):
     
     # Sorting a column in descending order when a specific column is chosen
     # Initially, it sorts by the Term column as specified in supervisorPortal.js
-
-    print(order, sortBy)
-    if order == "Desc":
+    if order == "DESC":
         filteredSearchResults = formSearchResults.order_by(sortValueColumnMap[sortBy].desc()).limit(rowsPerPage).offset(rowNumber)
     # Sorting a column in ascending order when a specific column is chosen
     

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -110,37 +110,21 @@ def getDatatableData(request):
     queryFilterDict = json.loads(queryFilterData)
     sortByOptions = queryFilterDict.get('sortBy', {})
     # Allows to switch between first and last names for the column filters
-    print(queryFilterDict)
-    print(sortByOptions)
-    print(datetime.now())
+    print("I AM RUNNING")
     # Dictionary to match column indices with column names in the DB
     # It is used for identifying the column that needs to be sorted
-    if sortByOptions.get('firstName', False) == True:
-        colIndexColNameMap = {  0: Term.termCode,
-                                1: Department.DEPT_NAME,
-                                2: Supervisor.FIRST_NAME.__str__(),
-                                3: Student.FIRST_NAME.__str__(),
-                                4: LaborStatusForm.POSN_CODE,
-                                5: LaborStatusForm.weeklyHours,
-                                6: LaborStatusForm.startDate,
-                                7: User.username,
-                                8: FormHistory.status,
-                                9: FormHistory.historyType,
-                                10: StudentLaborEvaluation.ID}
-    else:
-        colIndexColNameMap = {  0: Term.termCode,
-                                1: Department.DEPT_NAME,
-                                2: Supervisor.LAST_NAME,
-                                3: Student.LAST_NAME,
-                                4: LaborStatusForm.POSN_CODE,
-                                5: LaborStatusForm.weeklyHours,
-                                6: LaborStatusForm.startDate,
-                                7: User.username,
-                                8: FormHistory.status,
-                                9: FormHistory.historyType,
-                                10: StudentLaborEvaluation.ID}
-    
-    print(colIndexColNameMap[2])
+    colIndexColNameMap = {  0: Term.termCode,
+                            1: Department.DEPT_NAME,
+                            2: Supervisor.preferred_name | Supervisor.legal_name if sortByOptions.get('firstName', False) == True else Supervisor.LAST_NAME,
+                            3: Student.preferred_name | Student.legal_name if sortByOptions.get('firstName', False) == True else Student.LAST_NAME,
+                            4: LaborStatusForm.POSN_CODE,
+                            5: LaborStatusForm.weeklyHours,
+                            6: LaborStatusForm.startDate,
+                            7: User.username,
+                            8: FormHistory.status,
+                            9: FormHistory.historyType,
+                            10: StudentLaborEvaluation.ID}
+
     termCode = queryFilterDict.get('termCode', "")
     if termCode == "currentTerm":
         termCode = g.openTerm

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -108,21 +108,39 @@ def getDatatableData(request):
     order = request.form.get('order[0][dir]')
     queryFilterData = request.form.get('data')
     queryFilterDict = json.loads(queryFilterData)
-    print(queryFilterDict.get('sortBy', ""))
+
+    # Allows to switch between first and last names for the column filters
+
+    print(queryFilterDict.get('sortBy')[0])
     print(datetime.now())
     # Dictionary to match column indices with column names in the DB
     # It is used for identifying the column that needs to be sorted
-    colIndexColNameMap = {  0: Term.termCode,
-                            1: Department.DEPT_NAME,
-                            2: Supervisor.LAST_NAME,
-                            3: Student.LAST_NAME,
-                            4: LaborStatusForm.POSN_CODE,
-                            5: LaborStatusForm.weeklyHours,
-                            6: LaborStatusForm.startDate,
-                            7: User.username,
-                            8: FormHistory.status,
-                            9: FormHistory.historyType,
-                            10: StudentLaborEvaluation.ID}
+    if queryFilterDict.get('sortBy')[0] == 'first name':
+        colIndexColNameMap = {  0: Term.termCode,
+                                1: Department.DEPT_NAME,
+                                2: Supervisor.FIRST_NAME,
+                                3: Student.FIRST_NAME,
+                                4: LaborStatusForm.POSN_CODE,
+                                5: LaborStatusForm.weeklyHours,
+                                6: LaborStatusForm.startDate,
+                                7: User.username,
+                                8: FormHistory.status,
+                                9: FormHistory.historyType,
+                                10: StudentLaborEvaluation.ID}
+    else:
+        colIndexColNameMap = {  0: Term.termCode,
+                                1: Department.DEPT_NAME,
+                                2: Supervisor.LAST_NAME,
+                                3: Student.LAST_NAME,
+                                4: LaborStatusForm.POSN_CODE,
+                                5: LaborStatusForm.weeklyHours,
+                                6: LaborStatusForm.startDate,
+                                7: User.username,
+                                8: FormHistory.status,
+                                9: FormHistory.historyType,
+                                10: StudentLaborEvaluation.ID}
+    
+    print(colIndexColNameMap[2])
     termCode = queryFilterDict.get('termCode', "")
     if termCode == "currentTerm":
         termCode = g.openTerm

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -104,22 +104,26 @@ def getDatatableData(request):
     draw = int(request.form.get('draw', -1))
     rowNumber = int(request.form.get('start', -1))
     rowsPerPage = int(request.form.get('length', -1))
-    sortColIndex = int(request.form.get("order[0][column]", 0)) # default to student if sorting a kajillion or more times.
-    order = request.form.get('order[0][dir]')
     queryFilterData = request.form.get('data')
     queryFilterDict = json.loads(queryFilterData)
     sortBy = queryFilterDict.get('sortBy', "")
+    if not sortBy:
+        sortBy = "supervisorLastName"
+    order = queryFilterDict.get('order', "")
     # Allows to switch between first and last names for the column filters
     # Dictionary to match column indices with column names in the DB
     # It is used for identifying the column that needs to be sorted
+    supervisorFirstName = Supervisor.preferred_name if Supervisor.preferred_name else Supervisor.FIRST_NAME
+    studentFirstName = Student.preferred_name if Student.preferred_name else Student.FIRST_NAME
 
     sortValueColumnMap = {
-        "Term": Term.termCode,
-        "Department": Department.DEPT_NAME,
-        "supervisorFirstName": Supervisor.FIRST_NAME,
+        "term": Term.termCode,
+        "department": Department.DEPT_NAME,
+        "supervisorFirstName": supervisorFirstName,
         "supervisorLastName": Supervisor.LAST_NAME,
-        "studentFirstName": Student.FIRST_NAME,
+        "studentFirstName": studentFirstName,
         "studentLastName": Student.LAST_NAME,
+        "positionType": LaborStatusForm.POSN_TITLE,
         "positionCode": LaborStatusForm.POSN_CODE,
         "positionWLS": LaborStatusForm.WLS,
         "hours": LaborStatusForm.weeklyHours,
@@ -128,8 +132,6 @@ def getDatatableData(request):
         "formStatus": FormHistory.status,
         "formType": FormHistory.historyType,
     }
-    
-    print(sortValueColumnMap[sortBy])
     
     termCode = queryFilterDict.get('termCode', "")
     if termCode == "currentTerm":
@@ -181,7 +183,9 @@ def getDatatableData(request):
     
     # Sorting a column in descending order when a specific column is chosen
     # Initially, it sorts by the Term column as specified in supervisorPortal.js
-    if order == "desc":
+
+    print(order, sortBy)
+    if order == "Desc":
         filteredSearchResults = formSearchResults.order_by(sortValueColumnMap[sortBy].desc()).limit(rowsPerPage).offset(rowNumber)
     # Sorting a column in ascending order when a specific column is chosen
     

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -104,7 +104,7 @@ def getDatatableData(request):
     draw = int(request.form.get('draw', -1))
     rowNumber = int(request.form.get('start', -1))
     rowsPerPage = int(request.form.get('length', -1))
-    sortColIndex = int(request.form.get("order[0][column]", -1))
+    sortColIndex = int(request.form.get("order[0][column]", 0)) # default to student if sorting a kajillion or more times.
     order = request.form.get('order[0][dir]')
     queryFilterData = request.form.get('data')
     queryFilterDict = json.loads(queryFilterData)
@@ -174,12 +174,12 @@ def getDatatableData(request):
     # Sorting a column in descending order when a specific column is chosen
     # Initially, it sorts by the Term column as specified in supervisorPortal.js
     if order == "desc":
-        filteredSearchResults = formSearchResults.order_by(-colIndexColNameMap[sortColIndex]).limit(rowsPerPage).offset(rowNumber)
+        filteredSearchResults = formSearchResults.order_by(colIndexColNameMap[sortColIndex].desc()).limit(rowsPerPage).offset(rowNumber)
     # Sorting a column in ascending order when a specific column is chosen
     
     else:
-        filteredSearchResults = formSearchResults.order_by(colIndexColNameMap[sortColIndex]).limit(rowsPerPage).offset(rowNumber)
-    formattedData = getFormattedData(formSearchResults)
+        filteredSearchResults = formSearchResults.order_by(colIndexColNameMap[sortColIndex].asc()).limit(rowsPerPage).offset(rowNumber)
+    formattedData = getFormattedData(filteredSearchResults)
     formsDict = {"draw": draw, "recordsTotal": recordsTotal, "recordsFiltered": recordsTotal, "data": formattedData}
 
     return jsonify(formsDict)

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -108,18 +108,18 @@ def getDatatableData(request):
     order = request.form.get('order[0][dir]')
     queryFilterData = request.form.get('data')
     queryFilterDict = json.loads(queryFilterData)
-
+    sortByOptions = queryFilterDict.get('sortBy', {})
     # Allows to switch between first and last names for the column filters
-
-    print(queryFilterDict.get('sortBy')[0])
+    print(queryFilterDict)
+    print(sortByOptions)
     print(datetime.now())
     # Dictionary to match column indices with column names in the DB
     # It is used for identifying the column that needs to be sorted
-    if queryFilterDict.get('sortBy')[0] == 'first name':
+    if sortByOptions.get('firstName', False) == True:
         colIndexColNameMap = {  0: Term.termCode,
                                 1: Department.DEPT_NAME,
-                                2: Supervisor.FIRST_NAME,
-                                3: Student.FIRST_NAME,
+                                2: Supervisor.FIRST_NAME.__str__(),
+                                3: Student.FIRST_NAME.__str__(),
                                 4: LaborStatusForm.POSN_CODE,
                                 5: LaborStatusForm.weeklyHours,
                                 6: LaborStatusForm.startDate,

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -158,19 +158,12 @@ def getDatatableData(request):
         formSearchResults = formSearchResults.where(FormHistory.formID.department.in_(supervisorDepartments)) 
 
     recordsTotal = len(formSearchResults)
-    
 
     # this checks and finds the first value that is not null of preferred_name, legal_name and last_name.
     # including last_name is necessary because there are like 4 cases where someone has no first name or last name, instead their full name is
     # stored in last_name
     supervisorFirstNameCase = fn.COALESCE(fn.NULLIF(Supervisor.preferred_name, ''), fn.NULLIF(Supervisor.legal_name, ''), Supervisor.LAST_NAME)
     studentFirstNameCase = fn.COALESCE(fn.NULLIF(Student.preferred_name, ''), fn.NULLIF(Student.legal_name, ''), Student.LAST_NAME)
-
-    # If the term is a break, it gives contracted hours. Otherwise, the hours are weekly
-    if Term.isBreak:
-        workHours = LaborStatusForm.contractHours
-    else:
-        workHours = LaborStatusForm.weeklyHours
 
     # this maps all of the values we expect to receive from the sorting dropdowns in the frontend 
     # to actual peewee objects we can sort by later
@@ -183,7 +176,6 @@ def getDatatableData(request):
         "studentLastName": Student.LAST_NAME,
         "positionCode": LaborStatusForm.POSN_CODE,
         "positionWLS": LaborStatusForm.WLS,
-        "hours": workHours,
         "length": LaborStatusForm.startDate,
         "createdBy": User.username, 
         "formStatus": FormHistory.status,
@@ -197,7 +189,6 @@ def getDatatableData(request):
     formattedData = getFormattedData(filteredSearchResults)
     formsDict = {"draw": draw, "recordsTotal": recordsTotal, "recordsFiltered": recordsTotal, "data": formattedData}
 
-    print(sortBy)
     return jsonify(formsDict)
 
 def getFormattedData(filteredSearchResults):

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -181,7 +181,6 @@ def getDatatableData(request):
         "supervisorLastName": Supervisor.LAST_NAME,
         "studentFirstName": studentFirstNameCase,
         "studentLastName": Student.LAST_NAME,
-        "positionType": LaborStatusForm.POSN_TITLE,
         "positionCode": LaborStatusForm.POSN_CODE,
         "positionWLS": LaborStatusForm.WLS,
         "hours": workHours,

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -166,6 +166,12 @@ def getDatatableData(request):
     supervisorFirstNameCase = fn.COALESCE(fn.NULLIF(Supervisor.preferred_name, ''), fn.NULLIF(Supervisor.legal_name, ''), Supervisor.LAST_NAME)
     studentFirstNameCase = fn.COALESCE(fn.NULLIF(Student.preferred_name, ''), fn.NULLIF(Student.legal_name, ''), Student.LAST_NAME)
 
+    # If the term is a break, it gives contracted hours. Otherwise, the hours are weekly
+    if Term.isBreak:
+        workHours = LaborStatusForm.contractHours
+    else:
+        workHours = LaborStatusForm.weeklyHours
+
     # this maps all of the values we expect to receive from the sorting dropdowns in the frontend 
     # to actual peewee objects we can sort by later
     sortValueColumnMap = {
@@ -178,7 +184,7 @@ def getDatatableData(request):
         "positionType": LaborStatusForm.POSN_TITLE,
         "positionCode": LaborStatusForm.POSN_CODE,
         "positionWLS": LaborStatusForm.WLS,
-        "hours": LaborStatusForm.weeklyHours,
+        "hours": workHours,
         "length": LaborStatusForm.startDate,
         "createdBy": User.username, 
         "formStatus": FormHistory.status,
@@ -192,6 +198,7 @@ def getDatatableData(request):
     formattedData = getFormattedData(filteredSearchResults)
     formsDict = {"draw": draw, "recordsTotal": recordsTotal, "recordsFiltered": recordsTotal, "data": formattedData}
 
+    print(sortBy)
     return jsonify(formsDict)
 
 def getFormattedData(filteredSearchResults):

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -23,9 +23,17 @@ $(document).ready(function () {
     if (!isDisabled && $('#fieldPicker').val() == '') {
       msgFlash("Cannot sort without selecting a field.", 'warning')
       return
-    } 
+    }
     runFormSearchQuery()
   })
+
+  if ($('#formSearchTable').is(':hidden')) {
+    $('#columnPicker').selectpicker('hide')
+    $('#fieldPicker').selectpicker('hide')
+    $('#orderPicker').selectpicker('hide')
+    $('#sortByButton').hide()
+  }
+
   $('#addUser').on('click', function () {
     let supervisorID = $('#supervisorModalSelect :selected').val()
     let departmentID = $('#departmentModalSelect :selected').val()
@@ -83,7 +91,7 @@ $(document).ready(function () {
       });
       $('#fieldPicker').append(option)
     })
-    
+
     // if there is only one field then that means we can disable the fieldPicker and rely
     // on the column instead
     if (fields.length === 1) {
@@ -189,10 +197,13 @@ function runFormSearchQuery(button) {
 }
 
 function createDataTable(data) {
-
   $("#formSearchAccordion").accordion({ collapsible: true, active: false });
   $("#download").prop('disabled', false);
   $('#formSearchTable').show();
+  $('#columnPicker').selectpicker('show')
+  $('#fieldPicker').selectpicker('show')
+  $('#orderPicker').selectpicker('show')
+  $('#sortByButton').show()
 
   // default ordering upon initialization is term
   $('#formSearchTable').DataTable({
@@ -207,7 +218,7 @@ function createDataTable(data) {
     columnDefs: [{
       // this disables built in ordering on columns with these IDs 
       // (may be a way to do without specifying each individually but idk)
-      targets: [0, 1, 2, 3, 4, 5, 6, 7, 8], 
+      targets: [0, 1, 2, 3, 4, 5, 6, 7, 8],
       orderable: false,
     }],
     ajax: {

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -70,7 +70,7 @@ function runFormSearchQuery(button) {
   let termCode, departmentID, supervisorID, studentID;
   let formStatusList = [];
   let formTypeList = [];
-  let sortByList = [];
+  let sortByMap = getSortOptions();
 
   switch (button) {
     case "mySupervisees":
@@ -79,7 +79,6 @@ function runFormSearchQuery(button) {
       supervisorID = "currentUser"
       studentID = ""
       formStatusList = []
-      sortByList = []
       break;
 
     case "pendingForms":
@@ -88,7 +87,6 @@ function runFormSearchQuery(button) {
       supervisorID = "currentUser"
       studentID = ""
       formStatusList = ["Pending", "Pre-Student Approval"]
-      sortByList = []
       break;
 
     case "currentTerm":
@@ -98,7 +96,6 @@ function runFormSearchQuery(button) {
       studentID = ""
       formStatusList = []
       formTypeList = []
-      sortByList = []
       break;
 
     default:
@@ -108,7 +105,6 @@ function runFormSearchQuery(button) {
       studentID = $("#studentSelect").val();
       formStatusList = $("input:checkbox[name='formStatus']:checked").map((i, el) => el.value).get();
       formTypeList = $("input:checkbox[name='formType']:checked").map((i, el) => el.value).get();
-      sortByList = $("input:checkbox[name='sortBy']:checked").map((i, el) => el.value).get();
   }
 
   queryDict = {
@@ -118,7 +114,7 @@ function runFormSearchQuery(button) {
     'studentID': studentID,
     'formStatus': formStatusList,
     'formType': formTypeList,
-    'sortBy': sortByList,
+    'sortBy': sortByMap,
   };
 
   setFormSearchValues(queryDict)
@@ -128,6 +124,16 @@ function runFormSearchQuery(button) {
   Cookies.set('lsfSearchResults', data, { expires: inAnHour })
 
   createDataTable(data)
+}
+
+function getSortOptions() {
+  sortingValuesList = $("input:checkbox[name='sortBy']").map(
+    (index, el) => {return {id: el.id, checked: el.checked }}).get();
+  const sortByMap = sortingValuesList.reduce((res, obj) => {
+    res.set(obj.id, obj.checked);
+    return res;
+  }, new Map());
+  return sortByMap
 }
 
 function createDataTable(data) {

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -65,6 +65,7 @@ $(document).ready(function () {
     runFormSearchQuery("currentTerm");
   });
   $('#columnPicker').on('change', function () {
+    $("#columnPicker").selectpicker("val", this.val);
     let column = $('#columnPicker :selected').text()
     let fields = columnFieldMap[column]
     $('#fieldPicker').empty();
@@ -85,7 +86,7 @@ $(document).ready(function () {
   })
 });
 const columnFieldMap = {
-  'Term': ['Term', 'term'],
+  'Term': [['Term', 'term']],
   'Department': [['Department', 'department']],
   'Supervisor': [['First name', 'supervisorFirstName'], ['Last Name', 'supervisorLastName']],
   'Student': [['First name', 'studentFirstName'], ['Last Name', 'studentLastName']],
@@ -111,16 +112,14 @@ function runFormSearchQuery(button) {
   let termCode, departmentID, supervisorID, studentID;
   let formStatusList = [];
   let formTypeList = [];
-  var isDisabled = $('fieldPicker').prop('disabled');
+  var isDisabled = $('#fieldPicker').prop('disabled');
   let sortBy
   if (isDisabled == true) {
-    sortBy = $('#columnPicker :selected').val()
+    sortBy = $('#columnPicker').val()
   } else {
-    sortBy = $('#fieldPicker :selected').val()
+    sortBy = $('#fieldPicker').val()
   }
-  let order = $('#orderPicker :selected').val()
-
-  console.log(order, sortBy)
+  let order = $('#orderPicker').val()
 
   switch (button) {
     case "mySupervisees":

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -1,54 +1,54 @@
-$(document).ready(function(){
+$(document).ready(function () {
   if ((document.cookie).includes("lsfSearchResults=")) {
     cookieStr = Cookies.get('lsfSearchResults')
     createDataTable(cookieStr)
     setFormSearchValues(JSON.parse(cookieStr))
 
   } else {
-      $('#formSearchTable').hide();
-      $("#download").prop('disabled', true);
-      $('#collapseSearch').collapse(false)
+    $('#formSearchTable').hide();
+    $("#download").prop('disabled', true);
+    $('#collapseSearch').collapse(false)
   }
 
-  $('#formSearchButton').on('click', function(){
+  $('#formSearchButton').on('click', function () {
     runFormSearchQuery();
 
   });
-  $('#addUserToDept').on('click', function() {
-      $("#addSupervisorToDeptModal").modal("show");
+  $('#addUserToDept').on('click', function () {
+    $("#addSupervisorToDeptModal").modal("show");
   })
 
-  $('#addUser').on('click', function() {
-      let supervisorID = $('#supervisorModalSelect :selected').val()
-      let departmentID = $('#departmentModalSelect :selected').val()
-      addSupervisorToDepartment(supervisorID, departmentID)
+  $('#addUser').on('click', function () {
+    let supervisorID = $('#supervisorModalSelect :selected').val()
+    let departmentID = $('#departmentModalSelect :selected').val()
+    addSupervisorToDepartment(supervisorID, departmentID)
   })
-  $('#clearSelectionsButton').on('click', function(){
+  $('#clearSelectionsButton').on('click', function () {
     $("input:checkbox").removeAttr("checked");
     clearDropdowns()
-    });
-    
-  $( function() {
-    $( "#formSearchAccordion" ).accordion({
+  });
+
+  $(function () {
+    $("#formSearchAccordion").accordion({
       collapsible: true
     });
   });
-  $(function() {
-    $( "#formSearchAccordion" ).accordion();
-  	$("#formSearchAccordion .ui-accordion-header").css({fontSize: 20});// width of the box content area
-});
-// listening for preset button clicks.
-$('#mySupervisees').on('click', function(){
-  $("input:checkbox").removeAttr("checked");
-  runFormSearchQuery("mySupervisees");
-});
-$('#superviseesPendingForms').on('click', function(){
-  $("input:checkbox").removeAttr("checked");
-  runFormSearchQuery("pendingForms");
-});
-$('#currentTerm').on('click', function(){
-  runFormSearchQuery("currentTerm");
-});
+  $(function () {
+    $("#formSearchAccordion").accordion();
+    $("#formSearchAccordion .ui-accordion-header").css({ fontSize: 20 });// width of the box content area
+  });
+  // listening for preset button clicks.
+  $('#mySupervisees').on('click', function () {
+    $("input:checkbox").removeAttr("checked");
+    runFormSearchQuery("mySupervisees");
+  });
+  $('#superviseesPendingForms').on('click', function () {
+    $("input:checkbox").removeAttr("checked");
+    runFormSearchQuery("pendingForms");
+  });
+  $('#currentTerm').on('click', function () {
+    runFormSearchQuery("currentTerm");
+  });
 });
 
 
@@ -58,70 +58,69 @@ function runFormSearchQuery(button) {
   let termCode, departmentID, supervisorID, studentID;
   let formStatusList = [];
   let formTypeList = [];
-  let evaluationList = [];
+  let sortByList = [];
 
-  switch(button) {
-      case "mySupervisees":
-          termCode = "currentTerm"
-          departmentID = ""
-          supervisorID = "currentUser"
-          studentID = ""
-          formStatusList = []
-          formType  = []
-          evaluationList = []
-          break;
+  switch (button) {
+    case "mySupervisees":
+      termCode = "currentTerm"
+      departmentID = ""
+      supervisorID = "currentUser"
+      studentID = ""
+      formStatusList = []
+      sortByList = []
+      break;
 
-      case "pendingForms":
-          termCode = "currentTerm"
-          departmentID = ""
-          supervisorID = "currentUser"
-          studentID = ""
-          formStatusList = ["Pending", "Pre-Student Approval"]
-          formType  = []
-          evaluationList = []
-          break;
+    case "pendingForms":
+      termCode = "currentTerm"
+      departmentID = ""
+      supervisorID = "currentUser"
+      studentID = ""
+      formStatusList = ["Pending", "Pre-Student Approval"]
+      sortByList = []
+      break;
 
-      case "currentTerm":
-          termCode = "currentTerm"
-          departmentID = ""
-          supervisorID = ""
-          studentID = ""
-          formStatusList = []
-          formType  = []
-          evaluationList = []
-          break;
+    case "currentTerm":
+      termCode = "currentTerm"
+      departmentID = ""
+      supervisorID = ""
+      studentID = ""
+      formStatusList = []
+      formTypeList = []
+      sortByList = []
+      break;
 
-      default:
-          termCode = $("#termSelect").val();
-          departmentID = $("#departmentSelect").val();
-          supervisorID = $("#supervisorSelect").val();
-          studentID = $("#studentSelect").val();
-          formStatusList = $("input:checkbox[name='formStatus']:checked").map((i,el) => el.value).get();
-          formTypeList = $("input:checkbox[name='formType']:checked").map((i,el) => el.value).get();
-          evaluationList = $("input:checkbox[name='evaluations']:checked").map((i,el) => el.value).get();      
+    default:
+      termCode = $("#termSelect").val();
+      departmentID = $("#departmentSelect").val();
+      supervisorID = $("#supervisorSelect").val();
+      studentID = $("#studentSelect").val();
+      formStatusList = $("input:checkbox[name='formStatus']:checked").map((i, el) => el.value).get();
+      formTypeList = $("input:checkbox[name='formType']:checked").map((i, el) => el.value).get();
+      sortByList = $("input:checkbox[name='sortBy']:checked").map((i, el) => el.value).get();
   }
-  
-  queryDict = {'termCode': termCode,
-               'departmentID': departmentID,
-               'supervisorID': supervisorID,
-               'studentID': studentID,
-               'formStatus': formStatusList,
-               'formType': formTypeList,
-               'evaluations': evaluationList
-             };
+
+  queryDict = {
+    'termCode': termCode,
+    'departmentID': departmentID,
+    'supervisorID': supervisorID,
+    'studentID': studentID,
+    'formStatus': formStatusList,
+    'formType': formTypeList,
+    'sortBy': sortByList,
+  };
 
   setFormSearchValues(queryDict)
   data = JSON.stringify(queryDict)
 
   var inAnHour = new Date(new Date().getTime() + 60 * 60 * 1000);
-  Cookies.set('lsfSearchResults', data, {expires: inAnHour})
+  Cookies.set('lsfSearchResults', data, { expires: inAnHour })
 
   createDataTable(data)
 }
 
-function createDataTable(data){
-  
-  $("#formSearchAccordion").accordion({ collapsible: true, active: false});
+function createDataTable(data) {
+
+  $("#formSearchAccordion").accordion({ collapsible: true, active: false });
   $("#download").prop('disabled', false);
   $('#formSearchTable').show();
   var formSearchInit = $('#formSearchTable').DataTable({
@@ -134,41 +133,34 @@ function createDataTable(data){
     lengthMenu: [[10, 25, 50, 100], [10, 25, 50, 100]],
     pageLength: 25,
     aaSorting: [[0, 'desc']],
-    columnDefs: [{
-      targets: -1,
-      orderable: false,
-    }],
     ajax: {
-            url: "/",
-            type: "POST",
-            data: {'data': data},
-            dataSrc: "data",
-          }
-        });
+      url: "/",
+      type: "POST",
+      data: { 'data': data },
+      dataSrc: "data",
+    }
+  });
 }
-      
-function setFormSearchValues(searchDict){
-  
-  if (searchDict.termCode == "currentTerm"){
+
+function setFormSearchValues(searchDict) {
+
+  if (searchDict.termCode == "currentTerm") {
     $("#termSelect").selectpicker("val", g_currentTerm);
   } else {
     $("#termSelect").selectpicker("val", searchDict.termCode);
   }
-  if (searchDict.supervisorID == "currentUser"){
+  if (searchDict.supervisorID == "currentUser") {
     $("#supervisorSelect").selectpicker("val", g_currentUser);
   } else {
     $("#supervisorSelect").selectpicker("val", searchDict.supervisorID);
-  }  
+  }
   $("#departmentSelect").selectpicker("val", searchDict.departmentID);
   $("#studentSelect").selectpicker("val", searchDict.studentID);
 
-  $(searchDict.evaluations).each(function(i, value){
+  $(searchDict.formType).each(function (i, value) {
     $(`input:checkbox[value='${value}']`).prop('checked', true);
   })
-  $(searchDict.formType).each(function(i, value){
-    $(`input:checkbox[value='${value}']`).prop('checked', true);
-  })
-  $(searchDict.formStatus).each(function(i, value){
+  $(searchDict.formStatus).each(function (i, value) {
     $(`input:checkbox[value='${value}']`).prop('checked', true);
   })
 }

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -35,7 +35,7 @@ $(document).ready(function () {
     runFormSearchQuery()
   })
 
-  $('#clearSelectionsButton').on('click', function(){
+  $('#clearSelectionsButton').on('click', function (){
     $("input:checkbox").removeAttr("checked");
     clearDropdowns()
   });
@@ -61,7 +61,23 @@ $(document).ready(function () {
   $('#currentTerm').on('click', function () {
     runFormSearchQuery("currentTerm");
   });
+  $('#columnPicker').on('change', function () {
+    let value = $('#columnPicker :selected').val()
+    console.log(value)
+  })
 });
+const columnFieldMap = {
+  'Term': ['Term'],
+  'Department': ['Department'], 
+  'Supervisor': ['First name', 'Last Name'],
+  'Student': ['First name', 'Last Name'],
+  'Position (WLS)': ['Position Type', 'WLS', 'Position Code'],
+  'Hrs.': ['Hours'],
+  'Length': ['Length'],
+  'Created By': ['Created By'],
+  'Form Type (Status)': ['Form Type', 'Status']
+};
+
 
 function disableButtonHandler() {
   if ($('#departmentModalSelect :selected').val() == "" ||  $('#supervisorModalSelect :selected').val() == "") {

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -73,7 +73,10 @@ $(document).ready(function () {
       $('#fieldPicker').append(option)
     })
     if (fields.length === 1) {
-      $('#fieldPicker').val(fields[0]).change()
+      $('#fieldPicker').prop('disabled', true);
+
+    } else {
+      $('#fieldPicker').prop('disabled', false);
     }
     $('.selectpicker').selectpicker('refresh')
   })
@@ -165,7 +168,6 @@ function getSortOptions() {
   $("input:checkbox[name='sortBy']").each(function () {
     sortingValuesDict[this.id] = this.checked;
   });
-  console.log(sortingValuesDict)
   return sortingValuesDict
 }
 
@@ -183,7 +185,10 @@ function createDataTable(data) {
     paging: true,
     lengthMenu: [[10, 25, 50, 100], [10, 25, 50, 100]],
     pageLength: 25,
-    aaSorting: [[0, 'desc']],
+    columnDefs: [{
+      targets: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+      orderable: false,
+    }],
     ajax: {
       url: "/",
       type: "POST",

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -119,6 +119,8 @@ function runFormSearchQuery(button) {
   }
   let order = $('#orderPicker :selected').val()
 
+  console.log(order, sortBy)
+
   switch (button) {
     case "mySupervisees":
       termCode = "currentTerm"

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -26,6 +26,9 @@ $(document).ready(function () {
   })
   $('#departmentModalSelect').on('change', disableButtonHandler)
   $('#supervisorModalSelect').on('change', disableButtonHandler)
+  $('#firstName').on('click', runFormSearchQuery)
+  $('#lastName').on('click', runFormSearchQuery)
+
   $('#clearSelectionsButton').on('click', function(){
     $("input:checkbox").removeAttr("checked");
     clearDropdowns()

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -17,7 +17,9 @@ $(document).ready(function () {
   $('#addUserToDept').on('click', function () {
     $("#addSupervisorToDeptModal").modal("show");
   })
-
+  $("#sortByButton").on('click', function () {
+    runFormSearchQuery()
+  })
   $('#addUser').on('click', function () {
     let supervisorID = $('#supervisorModalSelect :selected').val()
     let departmentID = $('#departmentModalSelect :selected').val()
@@ -67,8 +69,8 @@ $(document).ready(function () {
     $('#fieldPicker').empty();
     fields.forEach((field) => {
       var option = $('<option>', {
-        value: field,
-        text: field
+        value: field[1],
+        text: field[0]
       });
       $('#fieldPicker').append(option)
     })
@@ -82,15 +84,15 @@ $(document).ready(function () {
   })
 });
 const columnFieldMap = {
-  'Term': ['Term'],
-  'Department': ['Department'],
-  'Supervisor': ['First name', 'Last Name'],
-  'Student': ['First name', 'Last Name'],
-  'Position (WLS)': ['Position Type', 'WLS', 'Position Code'],
-  'Hrs.': ['Hours'],
-  'Length': ['Length'],
-  'Created By': ['Created By'],
-  'Form Type (Status)': ['Form Type', 'Status']
+  'Term': ['Term', 'term'],
+  'Department': [['Department', 'department']],
+  'Supervisor': [['First name', 'supervisorFirstName'], ['Last Name', 'supervisorLastName']],
+  'Student': [['First name', 'studentFirstName'], ['Last Name', 'studentLastName']],
+  'Position (WLS)': [['Position Type', 'positionType'], ['WLS', 'positionWLS'], ['Position Code', 'positionCode']],
+  'Hrs.': [['Hours', 'hours']],
+  'Length': [['Length', 'length']],
+  'Created By': [['Created By', 'createdBy']],
+  'Form Type (Status)': [['Form Type', 'formType'], ['Status', 'formStatus']]
 };
 
 
@@ -102,12 +104,13 @@ function disableButtonHandler() {
     $('#addUser').prop('disabled', false)
   }
 }
+
 function runFormSearchQuery(button) {
 
   let termCode, departmentID, supervisorID, studentID;
   let formStatusList = [];
   let formTypeList = [];
-  let sortByMap = getSortOptions();
+  let sortBy = $('#fieldPicker :selected').val() 
 
   switch (button) {
     case "mySupervisees":
@@ -151,9 +154,8 @@ function runFormSearchQuery(button) {
     'studentID': studentID,
     'formStatus': formStatusList,
     'formType': formTypeList,
-    'sortBy': sortByMap,
+    'sortBy': sortBy,
   };
-
   setFormSearchValues(queryDict)
   data = JSON.stringify(queryDict)
 
@@ -161,14 +163,6 @@ function runFormSearchQuery(button) {
   Cookies.set('lsfSearchResults', data, { expires: inAnHour })
 
   createDataTable(data)
-}
-
-function getSortOptions() {
-  sortingValuesDict = {}
-  $("input:checkbox[name='sortBy']").each(function () {
-    sortingValuesDict[this.id] = this.checked;
-  });
-  return sortingValuesDict
 }
 
 function createDataTable(data) {

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -110,7 +110,14 @@ function runFormSearchQuery(button) {
   let termCode, departmentID, supervisorID, studentID;
   let formStatusList = [];
   let formTypeList = [];
-  let sortBy = $('#fieldPicker :selected').val() 
+  var isDisabled = $('fieldPicker').prop('disabled');
+  let sortBy
+  if (isDisabled == true) {
+    sortBy = $('#columnPicker :selected').val() 
+  } else {
+    sortBy = $('#fieldPicker :selected').val() 
+  }
+  let order = $('#orderPicker :selected').val()
 
   switch (button) {
     case "mySupervisees":
@@ -155,6 +162,7 @@ function runFormSearchQuery(button) {
     'formStatus': formStatusList,
     'formType': formTypeList,
     'sortBy': sortBy,
+    'order': order
   };
   setFormSearchValues(queryDict)
   data = JSON.stringify(queryDict)

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -26,8 +26,14 @@ $(document).ready(function () {
   })
   $('#departmentModalSelect').on('change', disableButtonHandler)
   $('#supervisorModalSelect').on('change', disableButtonHandler)
-  $('#firstName').on('click', runFormSearchQuery)
-  $('#lastName').on('click', runFormSearchQuery)
+  $('#firstName').on('click', function () {
+    $("#lastName").removeAttr("checked");
+    runFormSearchQuery()
+  })
+  $('#lastName').on('click', function () {
+    $("#firstName").removeAttr("checked");
+    runFormSearchQuery()
+  })
 
   $('#clearSelectionsButton').on('click', function(){
     $("input:checkbox").removeAttr("checked");
@@ -127,13 +133,12 @@ function runFormSearchQuery(button) {
 }
 
 function getSortOptions() {
-  sortingValuesList = $("input:checkbox[name='sortBy']").map(
-    (index, el) => {return {id: el.id, checked: el.checked }}).get();
-  const sortByMap = sortingValuesList.reduce((res, obj) => {
-    res.set(obj.id, obj.checked);
-    return res;
-  }, new Map());
-  return sortByMap
+  sortingValuesDict = {}
+  $("input:checkbox[name='sortBy']").each(function() {
+    sortingValuesDict[this.id] = this.checked;
+  });
+  console.log(sortingValuesDict)
+  return sortingValuesDict
 }
 
 function createDataTable(data) {

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -18,11 +18,11 @@ $(document).ready(function () {
     $("#addSupervisorToDeptModal").modal("show");
   })
 
-  $('#addUser').on('click', function() {
-      let supervisorID = $('#supervisorModalSelect :selected').val()
-      let departmentID = $('#departmentModalSelect :selected').val()
+  $('#addUser').on('click', function () {
+    let supervisorID = $('#supervisorModalSelect :selected').val()
+    let departmentID = $('#departmentModalSelect :selected').val()
 
-      addSupervisorToDepartment(supervisorID, departmentID)
+    addSupervisorToDepartment(supervisorID, departmentID)
   })
   $('#departmentModalSelect').on('change', disableButtonHandler)
   $('#supervisorModalSelect').on('change', disableButtonHandler)
@@ -35,7 +35,7 @@ $(document).ready(function () {
     runFormSearchQuery()
   })
 
-  $('#clearSelectionsButton').on('click', function (){
+  $('#clearSelectionsButton').on('click', function () {
     $("input:checkbox").removeAttr("checked");
     clearDropdowns()
   });
@@ -62,13 +62,25 @@ $(document).ready(function () {
     runFormSearchQuery("currentTerm");
   });
   $('#columnPicker').on('change', function () {
-    let value = $('#columnPicker :selected').val()
-    console.log(value)
+    let column = $('#columnPicker :selected').text()
+    let fields = columnFieldMap[column]
+    $('#fieldPicker').empty();
+    fields.forEach((field) => {
+      var option = $('<option>', {
+        value: field,
+        text: field
+      });
+      $('#fieldPicker').append(option)
+    })
+    if (fields.length === 1) {
+      $('#fieldPicker').val(fields[0]).change()
+    }
+    $('.selectpicker').selectpicker('refresh')
   })
 });
 const columnFieldMap = {
   'Term': ['Term'],
-  'Department': ['Department'], 
+  'Department': ['Department'],
   'Supervisor': ['First name', 'Last Name'],
   'Student': ['First name', 'Last Name'],
   'Position (WLS)': ['Position Type', 'WLS', 'Position Code'],
@@ -80,7 +92,7 @@ const columnFieldMap = {
 
 
 function disableButtonHandler() {
-  if ($('#departmentModalSelect :selected').val() == "" ||  $('#supervisorModalSelect :selected').val() == "") {
+  if ($('#departmentModalSelect :selected').val() == "" || $('#supervisorModalSelect :selected').val() == "") {
     $('#addUser').prop('disabled', true)
   }
   else {
@@ -150,7 +162,7 @@ function runFormSearchQuery(button) {
 
 function getSortOptions() {
   sortingValuesDict = {}
-  $("input:checkbox[name='sortBy']").each(function() {
+  $("input:checkbox[name='sortBy']").each(function () {
     sortingValuesDict[this.id] = this.checked;
   });
   console.log(sortingValuesDict)

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -6,13 +6,14 @@ $(document).ready(function () {
 
   } else {
     $('#formSearchTable').hide();
+    $('#sortOptions').hide();
     $("#download").prop('disabled', true);
     $('#collapseSearch').collapse(false)
   }
 
   $('#formSearchButton').on('click', function () {
     runFormSearchQuery();
-
+    $('#sortOptions').show();
   });
   $('#addUserToDept').on('click', function () {
     $("#addSupervisorToDeptModal").modal("show");
@@ -110,7 +111,6 @@ const columnFieldMap = {
   'Supervisor': [['First name', 'supervisorFirstName'], ['Last Name', 'supervisorLastName']],
   'Student': [['First name', 'studentFirstName'], ['Last Name', 'studentLastName']],
   'Position (WLS)': [['WLS', 'positionWLS'], ['Position Code', 'positionCode']],
-  'Hrs.': [['Hours', 'hours']],
   'Length': [['Length', 'length']],
   'Created By': [['Created By', 'createdBy']],
   'Form Type (Status)': [['Form Type', 'formType'], ['Status', 'formStatus']]

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -27,11 +27,9 @@ $(document).ready(function () {
     runFormSearchQuery()
   })
 
-  if ($('#formSearchTable').is(':hidden')) {
-    $('#columnPicker').selectpicker('hide')
-    $('#fieldPicker').selectpicker('hide')
-    $('#orderPicker').selectpicker('hide')
-    $('#sortByButton').hide()
+  if ($('#formSearchTable').val() == true) {
+    $('#fieldPicker').prop('disabled', true)
+    $('.selectpicker').selectpicker('refresh')
   }
 
   $('#addUser').on('click', function () {

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -27,7 +27,7 @@ $(document).ready(function () {
     runFormSearchQuery()
   })
 
-  if ($('#formSearchTable').val() == true) {
+  if ($('#columnPicker').val() == '') {
     $('#fieldPicker').prop('disabled', true)
     $('.selectpicker').selectpicker('refresh')
   }

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -111,7 +111,7 @@ const columnFieldMap = {
   'Department': [['Department', 'department']],
   'Supervisor': [['First name', 'supervisorFirstName'], ['Last Name', 'supervisorLastName']],
   'Student': [['First name', 'studentFirstName'], ['Last Name', 'studentLastName']],
-  'Position (WLS)': [['Position Type', 'positionType'], ['WLS', 'positionWLS'], ['Position Code', 'positionCode']],
+  'Position (WLS)': [['WLS', 'positionWLS'], ['Position Code', 'positionCode']],
   'Hrs.': [['Hours', 'hours']],
   'Length': [['Length', 'length']],
   'Created By': [['Created By', 'createdBy']],

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -41,14 +41,6 @@ $(document).ready(function () {
   })
   $('#departmentModalSelect').on('change', disableButtonHandler)
   $('#supervisorModalSelect').on('change', disableButtonHandler)
-  $('#firstName').on('click', function () {
-    $("#lastName").removeAttr("checked");
-    runFormSearchQuery()
-  })
-  $('#lastName').on('click', function () {
-    $("#firstName").removeAttr("checked");
-    runFormSearchQuery()
-  })
 
   $('#clearSelectionsButton').on('click', function () {
     $("input:checkbox").removeAttr("checked");

--- a/app/templates/admin/allPendingForms.html
+++ b/app/templates/admin/allPendingForms.html
@@ -2,14 +2,14 @@
 
 {% block styles %}
 {{super()}}
-  <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs/dt-1.10.21/b-1.6.2/datatables.min.css"/>
+  <link href="https://cdn.datatables.net/v/dt/dt-2.1.6/datatables.min.css" rel="stylesheet">
   <link rel="stylesheet" type="text/css" href="{{url_for('static', filename ='css/allPendingForms.css')}}?u={{lastStaticUpdate}}">
   <link rel="stylesheet" type="text/css" href="{{url_for('static', filename ='css/pendingNotesModal.css')}}?u={{lastStaticUpdate}}">
 {% endblock %}
 
 {% block scripts %}
 {{super()}}
-  <script type="text/javascript" src="https://cdn.datatables.net/v/bs/dt-1.10.21/b-1.6.2/datatables.min.js"></script>
+  <script src="https://cdn.datatables.net/v/dt/dt-2.1.6/datatables.min.js"></script>
   <script type="text/javascript" src="{{url_for('static', filename='js/allPendingForms.js') }}?u={{lastStaticUpdate}}"></script>
 {% endblock %}
 

--- a/app/templates/admin/manageDepartments.html
+++ b/app/templates/admin/manageDepartments.html
@@ -2,13 +2,13 @@
 
 {% block styles %}
 {{super()}}
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs/jq-3.3.1/dt-1.10.18/r-2.2.2/datatables.min.css"/>
+    <link href="https://cdn.datatables.net/v/dt/dt-2.1.6/datatables.min.css" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="/static/css/manageDepartments.css?u={{lastStaticUpdate}}"/>
 {% endblock %}
 
 {% block scripts %}
 {{super()}}
-    <script type="text/javascript" src="https://cdn.datatables.net/v/bs/dt-1.10.21/b-1.6.2/datatables.min.js"></script>
+    <script src="https://cdn.datatables.net/v/dt/dt-2.1.6/datatables.min.js"></script>
     <script type="text/javascript" src="{{url_for('static', filename='js/manageDepartments.js') }}?u={{lastStaticUpdate}}"></script>
     <script type="text/javascript" src="{{url_for('static', filename='js/addSupervisorsToDepartment.js') }}?u={{lastStaticUpdate}}"></script>
 {% endblock %}

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -222,14 +222,37 @@
     </div>
   </div>
 <br>
-<input type="checkbox" value="first name" name="sortBy" id="firstName"/>
+
+<!-- <input type="checkbox" class=" form-check-input" value="first name" name="sortBy" id="firstName"/>
 <label class="form-check-label" for="firstName" value="first name">
   First Name  
 </label> 
 <input type="checkbox" value="last name" name="sortBy" id="lastName"/>
 <label class="form-check-label" for="lastName" value="last name">
   Last Name  
-</label> 
+</label>  -->
+<select class="selectpicker" title="Column">
+  <option value="0">Term</option>
+  <option value="1">Department</option>
+  <option value="2">Supervisor</option>
+  <option value="3">Student</option>
+  <option value="4">Position (WLS)</option>
+  <option value="5">Hrs.</option>
+  <option value="">Length</option>
+  <option value="">Created</option>
+  <option value="">Form Type (Status)</option>
+
+</select>
+<select class="selectpicker" title="Field">
+  <option>First Name</option>
+  <option>Last Name</option>
+</select>
+
+<select id="ordering" class="selectpicker" title="Order">
+  <option>Asc</option>
+  <option>Desc</option>
+</select>
+
 <table id="formSearchTable" class="table table-striped table-bordered pt-3" style="display:none" width="100%">
   <thead>
     <th>Term</th>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -2,31 +2,37 @@
 
 {% block styles %}
 {{super()}}
-  <link href="https://cdn.datatables.net/v/dt/dt-2.1.6/datatables.min.css" rel="stylesheet">
-  <link href="https://cdn.datatables.net/searchpanes/2.3.2/css/searchPanes.dataTables.css" rel="stylesheet">
-  <link href="https://cdn.datatables.net/select/2.1.0/css/select.dataTables.css" rel="stylesheet">
-  <!-- <link href="https://cdn.datatables.net/v/dt/dt-2.1.6/datatables.min.css" rel="stylesheet"> -->
- 
-  <link rel="stylesheet" type="text/css" href="{{url_for('static', filename ='css/allPendingForms.css')}}?u={{lastStaticUpdate}}">
-  <link rel="stylesheet" type="text/css" href="{{url_for('static', filename ='css/pendingNotesModal.css')}}?u={{lastStaticUpdate}}">
+<link href="https://cdn.datatables.net/v/dt/dt-2.1.6/datatables.min.css" rel="stylesheet">
+<link href="https://cdn.datatables.net/searchpanes/2.3.2/css/searchPanes.dataTables.css" rel="stylesheet">
+<link href="https://cdn.datatables.net/select/2.1.0/css/select.dataTables.css" rel="stylesheet">
+<!-- <link href="https://cdn.datatables.net/v/dt/dt-2.1.6/datatables.min.css" rel="stylesheet"> -->
+
+<link rel="stylesheet" type="text/css"
+  href="{{url_for('static', filename ='css/allPendingForms.css')}}?u={{lastStaticUpdate}}">
+<link rel="stylesheet" type="text/css"
+  href="{{url_for('static', filename ='css/pendingNotesModal.css')}}?u={{lastStaticUpdate}}">
 {% endblock %}
 
 {% block scripts %}
 {{super()}}
-  <script src="https://cdn.datatables.net/v/dt/dt-2.1.6/datatables.min.js"></script>
-  <script src="https://cdn.datatables.net/searchpanes/2.3.2/js/dataTables.searchPanes.js"></script>
-  <script src="https://cdn.datatables.net/searchpanes/2.3.2/js/searchPanes.dataTables.js"></script>
-  <script src="https://cdn.datatables.net/select/2.1.0/js/dataTables.select.js"></script>
-  <script src="https://cdn.datatables.net/select/2.1.0/js/select.dataTables.js"></script> 
-  <script type="text/javascript" src="{{url_for('static', filename='js/laborhistory.js')}}?u={{lastStaticUpdate}}"></script>
-  <script type="text/javascript" src="{{url_for('static', filename='js/allPendingForms.js')}}?u={{lastStaticUpdate}}"></script>
-  <script type="text/javascript" src="{{url_for('static', filename='js/supervisorPortal.js') }}?u={{lastStaticUpdate}}"></script>
-  <script type="text/javascript" src="{{url_for('static', filename='js/addSupervisorsToDepartment.js') }}?u={{lastStaticUpdate}}"></script>
-  <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
-  <script>
-      var g_currentTerm = {{g.openTerm}};
-      var g_currentUser = "{{g.currentUser.supervisor}}";
-  </script>
+<script src="https://cdn.datatables.net/v/dt/dt-2.1.6/datatables.min.js"></script>
+<script src="https://cdn.datatables.net/searchpanes/2.3.2/js/dataTables.searchPanes.js"></script>
+<script src="https://cdn.datatables.net/searchpanes/2.3.2/js/searchPanes.dataTables.js"></script>
+<script src="https://cdn.datatables.net/select/2.1.0/js/dataTables.select.js"></script>
+<script src="https://cdn.datatables.net/select/2.1.0/js/select.dataTables.js"></script>
+<script type="text/javascript"
+  src="{{url_for('static', filename='js/laborhistory.js')}}?u={{lastStaticUpdate}}"></script>
+<script type="text/javascript"
+  src="{{url_for('static', filename='js/allPendingForms.js')}}?u={{lastStaticUpdate}}"></script>
+<script type="text/javascript"
+  src="{{url_for('static', filename='js/supervisorPortal.js') }}?u={{lastStaticUpdate}}"></script>
+<script type="text/javascript"
+  src="{{url_for('static', filename='js/addSupervisorsToDepartment.js') }}?u={{lastStaticUpdate}}"></script>
+<script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
+<script>
+  var g_currentTerm = {{ g.openTerm }};
+  var g_currentUser = "{{g.currentUser.supervisor}}";
+</script>
 
 {% endblock %}
 
@@ -54,169 +60,188 @@
 <div class="container-fluid fs-1" align="center">
   <div id="formSearchAccordion">
     <h1 class="fs-1" data-toggle="collapse">Form Search</h1>
-      <div class="card-body" style="overflow:visible">
+    <div class="card-body" style="overflow:visible">
       <div class="row col-md-12" align="left">
         <br>
         <form id="supervisorPortalForm">
-            <div class="col-md-2"></div>  <!-- empty div used for positioning -->
-            <div class="col-md-5">
-              <div class="form-group">
-                <br>
-                <label for="termSelect">Term</label>
-                <div>
-                  <select class="selectpicker" name='term' id='termSelect' data-live-search='true' title="All terms">
-                    <option value="">All terms</option>
-                    <option value="activeTerms">All Active Terms</option>
-                    {% for term in terms %}
-                      <option value="{{term.termCode}}">
-                        {{term.termCode.termName}}
-                      </option>
-                    {% endfor %}
-                  </select>
-                </div>
+          <div class="col-md-2"></div> <!-- empty div used for positioning -->
+          <div class="col-md-5">
+            <div class="form-group">
+              <br>
+              <label for="termSelect">Term</label>
+              <div>
+                <select class="selectpicker" name='term' id='termSelect' data-live-search='true' title="All terms">
+                  <option value="">All terms</option>
+                  <option value="activeTerms">All Active Terms</option>
+                  {% for term in terms %}
+                  <option value="{{term.termCode}}">
+                    {{term.termCode.termName}}
+                  </option>
+                  {% endfor %}
+                </select>
               </div>
-              <div class="form-group">
-                <label for="departmentSelect">Department</label>
-                <div>
-                  <select class="selectpicker" id="departmentSelect" data-live-search='true' title="Department">
-                    {% if departments|count != 1 %}
-                      <option value="" selected>All departments</option>
-                    {% endif %}
-                    {% for department in departments %}
-                      <!-- We want to either select the first option, or the option that matches the department -->
-                      {% if department.isActive %}
-                        <option value="{{department.departmentID}}" data-content="{{department.DEPT_NAME}}">
-                      {% else %}
-                        <option value="{{department.departmentID}}" data-content="<div class='text-muted'>{{department.DEPT_NAME}} <small>--INACTIVE--</small></div>">
-                      {% endif %}
-                        </option>
-                    {% endfor %}
-                  </select>
-                </div>
-              </div>
-              <div class="form-group">
-                <label for="supervisorSelect">Supervisor</label>
-                <div class="dropdown">
-                  <select class="selectpicker" name='supervisor' id='supervisorSelect' data-live-search='true' title="All supervisors">
-                    <option value="">All supervisors</option>
-                    {% for supervisor in supervisors  %}
-                    {% if supervisor.isActive %}
-                      <option value="{{supervisor.ID}}" data-content="{{supervisor.FIRST_NAME}} {{supervisor.LAST_NAME}} <small class='text-muted'>  ({{supervisor.ID}})</small>">
+            </div>
+            <div class="form-group">
+              <label for="departmentSelect">Department</label>
+              <div>
+                <select class="selectpicker" id="departmentSelect" data-live-search='true' title="Department">
+                  {% if departments|count != 1 %}
+                  <option value="" selected>All departments</option>
+                  {% endif %}
+                  {% for department in departments %}
+                  <!-- We want to either select the first option, or the option that matches the department -->
+                  {% if department.isActive %}
+                  <option value="{{department.departmentID}}" data-content="{{department.DEPT_NAME}}">
                     {% else %}
-                      <option value="{{supervisor.ID}}" data-content="<div class='text-muted'>{{supervisor.FIRST_NAME}} {{supervisor.LAST_NAME}} <small>({{supervisor.ID}}) --INACTIVE-- </small></div>">
+                  <option value="{{department.departmentID}}"
+                    data-content="<div class='text-muted'>{{department.DEPT_NAME}} <small>--INACTIVE--</small></div>">
                     {% endif %}
-                        {{supervisor.FIRST_NAME}} {{supervisor.LAST_NAME}} 
-                      </option>
-                    {% endfor %}
-                  </select>
-                </div>
-              </div>
-              <div class="form-group">
-                <label for="studentSelect">Student</label>
-                <div>
-                  <select class="selectpicker"name='student' id='studentSelect' data-live-search='true' title="All students">
-                    <option value="">All students</option>
-                    {% for student in students %}
-                      <option value="{{student.ID}}" data-content="{{student.FIRST_NAME}} {{student.LAST_NAME}}<small class='text-muted'> ({{student.ID}})</small>">
-                        {{student.FIRST_NAME}} {{student.LAST_NAME}} ({{student.ID}})
-                      </option>
-                    {% endfor %}
-                  </select>
-                </div>
-              </div>
-              <button type="button" class="btn btn-primary" data-toggle="collapse" data-target="#collapseSearch" aria-expanded="true" aria-controls="collapseSearch" id="formSearchButton">Search</button>
-              <button type="button" class="btn btn-danger" id="clearSelectionsButton">Clear Selections</button>
-              <br><br>
-            </div>
-            <div class="col-md-5">
-              <div class="form-group">
-                <br>
-                <label for="">Limit Form Status</label>
-                <div class="form-check">
-                  <input class="form-check-input" name="formStatus" type="checkbox" value="Pending" id="pending">
-                  <label class="form-check-label" for="pending">
-                    Pending  
-                  </label> 
-                </div>
-                <div class="form-check">
-                  <input class="form-check-input" name="formStatus" type="checkbox" value="Approved" id="approved">
-                  <label class="form-check-label" for="approved">
-                    Approved  
-                    </label> 
-                </div>
-                <div class="form-check">
-                  <input class="form-check-input" name="formStatus" type="checkbox" value="Approved Reluctantly" id="approvedReluctantly">
-                  <label class="form-check-label" for="approvedReluctantly">
-                    Approved  Reluctantly
-                    </label> 
-                </div>
-                <div class="form-check">
-                  <input class="form-check-input" name="formStatus" type="checkbox" value="Denied" id="denied">
-                  <label class="form-check-label" for="denied">
-                    Denied
-                    </label> 
-                </div>
-                <div class="form-check">
-                  <input class="form-check-input" name="formStatus" type="checkbox" value="Pre-Student Approval" id="student">
-                  <label class="form-check-label" for="student">
-                    Pre-Student Approval
-                    </label> 
-                </div>
-              </div>
-              <div class="form-group">
-                <label for="">Limit Form Type</label>
-                <div class="form-check">
-                  <input class="form-check-input" name="formType" type="checkbox" value="Labor Status Form" id="original">
-                  <label class="form-check-label" for="original">
-                    <span class="tooltip-right" data-tooltip="A labor contract">Original
-                      <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16">
-                        <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/>
-                        <path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0"/>
-                      </svg>
-                    </span>  
-                  </label> 
-                </div>
-                <div class="form-check">
-                  <input class="form-check-input" name="formType" type="checkbox" value="Labor Adjustment Form" id="adjusted">
-                  <label class="form-check-label" for="adjusted">
-                    <span class="tooltip-right" data-tooltip="A change to a labor contract">Adjusted
-                      <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16">
-                        <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/>
-                        <path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0"/>
-                      </svg>
-                    </span>
-                  </label> 
-                </div>
-                <div class="form-check">
-                  <input class="form-check-input" name="formType" type="checkbox" value="Labor Release Form" id="release">
-                  <label class="form-check-label" for="release">
-                    <span class="tooltip-right flex" data-tooltip="A labor contract being ended early">Release
-                      <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16">
-                        <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/>
-                        <path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0"/>
-                      </svg>
-                    </span>
-                  </label> 
-                </div>
-                <div class="form-check">
-                  <input class="form-check-input" name="formType" type="checkbox" value="Labor Overload Form" id="overload">
-                  <label class="form-check-label" for="overload">
-                    <span class="tooltip-right" data-tooltip="A labor contract above 15 hours per week">Overload
-                      <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16">
-                        <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/>
-                        <path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0"/>
-                      </svg>
-                    </span>
-                  </label> 
-                </div>
+                  </option>
+                  {% endfor %}
+                </select>
               </div>
             </div>
-          </form>
-        </div>
-        <div style="clear:both"></div>
+            <div class="form-group">
+              <label for="supervisorSelect">Supervisor</label>
+              <div class="dropdown">
+                <select class="selectpicker" name='supervisor' id='supervisorSelect' data-live-search='true'
+                  title="All supervisors">
+                  <option value="">All supervisors</option>
+                  {% for supervisor in supervisors %}
+                  {% if supervisor.isActive %}
+                  <option value="{{supervisor.ID}}"
+                    data-content="{{supervisor.FIRST_NAME}} {{supervisor.LAST_NAME}} <small class='text-muted'>  ({{supervisor.ID}})</small>">
+                    {% else %}
+                  <option value="{{supervisor.ID}}"
+                    data-content="<div class='text-muted'>{{supervisor.FIRST_NAME}} {{supervisor.LAST_NAME}} <small>({{supervisor.ID}}) --INACTIVE-- </small></div>">
+                    {% endif %}
+                    {{supervisor.FIRST_NAME}} {{supervisor.LAST_NAME}}
+                  </option>
+                  {% endfor %}
+                </select>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="studentSelect">Student</label>
+              <div>
+                <select class="selectpicker" name='student' id='studentSelect' data-live-search='true'
+                  title="All students">
+                  <option value="">All students</option>
+                  {% for student in students %}
+                  <option value="{{student.ID}}"
+                    data-content="{{student.FIRST_NAME}} {{student.LAST_NAME}}<small class='text-muted'> ({{student.ID}})</small>">
+                    {{student.FIRST_NAME}} {{student.LAST_NAME}} ({{student.ID}})
+                  </option>
+                  {% endfor %}
+                </select>
+              </div>
+            </div>
+            <button type="button" class="btn btn-primary" data-toggle="collapse" data-target="#collapseSearch"
+              aria-expanded="true" aria-controls="collapseSearch" id="formSearchButton">Search</button>
+            <button type="button" class="btn btn-danger" id="clearSelectionsButton">Clear Selections</button>
+            <br><br>
+          </div>
+          <div class="col-md-5">
+            <div class="form-group">
+              <br>
+              <label for="">Limit Form Status</label>
+              <div class="form-check">
+                <input class="form-check-input" name="formStatus" type="checkbox" value="Pending" id="pending">
+                <label class="form-check-label" for="pending">
+                  Pending
+                </label>
+              </div>
+              <div class="form-check">
+                <input class="form-check-input" name="formStatus" type="checkbox" value="Approved" id="approved">
+                <label class="form-check-label" for="approved">
+                  Approved
+                </label>
+              </div>
+              <div class="form-check">
+                <input class="form-check-input" name="formStatus" type="checkbox" value="Approved Reluctantly"
+                  id="approvedReluctantly">
+                <label class="form-check-label" for="approvedReluctantly">
+                  Approved Reluctantly
+                </label>
+              </div>
+              <div class="form-check">
+                <input class="form-check-input" name="formStatus" type="checkbox" value="Denied" id="denied">
+                <label class="form-check-label" for="denied">
+                  Denied
+                </label>
+              </div>
+              <div class="form-check">
+                <input class="form-check-input" name="formStatus" type="checkbox" value="Pre-Student Approval"
+                  id="student">
+                <label class="form-check-label" for="student">
+                  Pre-Student Approval
+                </label>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="">Limit Form Type</label>
+              <div class="form-check">
+                <input class="form-check-input" name="formType" type="checkbox" value="Labor Status Form" id="original">
+                <label class="form-check-label" for="original">
+                  <span class="tooltip-right" data-tooltip="A labor contract">Original
+                    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor"
+                      class="bi bi-info-circle" viewBox="0 0 16 16">
+                      <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16" />
+                      <path
+                        d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0" />
+                    </svg>
+                  </span>
+                </label>
+              </div>
+              <div class="form-check">
+                <input class="form-check-input" name="formType" type="checkbox" value="Labor Adjustment Form"
+                  id="adjusted">
+                <label class="form-check-label" for="adjusted">
+                  <span class="tooltip-right" data-tooltip="A change to a labor contract">Adjusted
+                    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor"
+                      class="bi bi-info-circle" viewBox="0 0 16 16">
+                      <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16" />
+                      <path
+                        d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0" />
+                    </svg>
+                  </span>
+                </label>
+              </div>
+              <div class="form-check">
+                <input class="form-check-input" name="formType" type="checkbox" value="Labor Release Form" id="release">
+                <label class="form-check-label" for="release">
+                  <span class="tooltip-right flex" data-tooltip="A labor contract being ended early">Release
+                    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor"
+                      class="bi bi-info-circle" viewBox="0 0 16 16">
+                      <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16" />
+                      <path
+                        d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0" />
+                    </svg>
+                  </span>
+                </label>
+              </div>
+              <div class="form-check">
+                <input class="form-check-input" name="formType" type="checkbox" value="Labor Overload Form"
+                  id="overload">
+                <label class="form-check-label" for="overload">
+                  <span class="tooltip-right" data-tooltip="A labor contract above 15 hours per week">Overload
+                    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor"
+                      class="bi bi-info-circle" viewBox="0 0 16 16">
+                      <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16" />
+                      <path
+                        d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0" />
+                    </svg>
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </form>
       </div>
+      <div style="clear:both"></div>
     </div>
   </div>
+</div>
 <br>
 
 <!-- <input type="checkbox" class=" form-check-input" value="first name" name="sortBy" id="firstName"/>
@@ -227,7 +252,7 @@
 <label class="form-check-label" for="lastName" value="last name">
   Last Name  
 </label>  -->
-<select id="columnPicker" class="selectpicker" title="Column">
+<select id="columnPicker" class="selectpicker" title="Sort Column">
   <option value="term">Term</option>
   <option value="department">Department</option>
   <option value="supervisor">Supervisor</option>
@@ -247,6 +272,7 @@
   <option selected value="ASC">Asc</option>
   <option value="DESC">Desc</option>
 </select>
+
 <button class="btn btn-primary" id="sortByButton">Sort</button>
 <table id="formSearchTable" class="table table-striped table-bordered pt-3" style="display:none" width="100%">
   <thead>
@@ -263,14 +289,16 @@
 </table>
 
 <!-- Overload Modal -->
-<div class="modal fade" id="overloadModal" role="dialog" data-backdrop="true" tabindex="-1" aria-labelledby="overloadModalLabel" aria-describedby="overloadModalBody">
+<div class="modal fade" id="overloadModal" role="dialog" data-backdrop="true" tabindex="-1"
+  aria-labelledby="overloadModalLabel" aria-describedby="overloadModalBody">
   <div class="modal-dialog modal-dialog-scrollable" role="document">
     <div id="content" class="modal-content">
     </div>
   </div>
 </div>
 <!-- Release Modal -->
-<div class="modal fade" id="modalRelease" data-dismiss="modal" tabindex="-1" role="dialog" aria-labelledby="releaseModalLabel" aria-describedby="releaseModalBody">
+<div class="modal fade" id="modalRelease" data-dismiss="modal" tabindex="-1" role="dialog"
+  aria-labelledby="releaseModalLabel" aria-describedby="releaseModalBody">
   <div class="modal-dialog modal-dialog-scrollable" role="document">
     <div id="content" class="modal-content">
     </div>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -243,37 +243,35 @@
   </div>
 </div>
 <br>
+<div style="position: relative; z-index: 1;">
+  <div class="container-fluid" style="margin-bottom: -40px;" align="right">
+    <label for="columnPicker">Sorting Options:</label>
+    <select id="columnPicker" name="columnPicker" class="selectpicker" title="Column">
+      <option value="term">Term</option>
+      <option value="department">Department</option>
+      <option value="supervisor">Supervisor</option>
+      <option value="student">Student</option>
+      <option value="position">Position (WLS)</option>
+      <option value="hours">Hrs.</option>
+      <option value="length">Length</option>
+      <option value="createdBy">Created By</option>
+      <option value="form">Form Type (Status)</option>
+    </select>
 
-<!-- <input type="checkbox" class=" form-check-input" value="first name" name="sortBy" id="firstName"/>
-<label class="form-check-label" for="firstName" value="first name">
-  First Name  
-</label> 
-<input type="checkbox" value="last name" name="sortBy" id="lastName"/>
-<label class="form-check-label" for="lastName" value="last name">
-  Last Name  
-</label>  -->
-<select id="columnPicker" class="selectpicker" title="Sort Column">
-  <option value="term">Term</option>
-  <option value="department">Department</option>
-  <option value="supervisor">Supervisor</option>
-  <option value="student">Student</option>
-  <option value="position">Position (WLS)</option>
-  <option value="hours">Hrs.</option>
-  <option value="length">Length</option>
-  <option value="createdBy">Created By</option>
-  <option value="form">Form Type (Status)</option>
+    <select id="fieldPicker" class="selectpicker" title="Field">
+      <option value="term">Term</option>
+    </select>
 
-</select>
-<select id="fieldPicker" class="selectpicker" title="Field">
-  <option value="term">Term</option>
-</select>
+    <select id="orderPicker" class="selectpicker" title="Order">
+      <option selected value="ASC">Asc</option>
+      <option value="DESC">Desc</option>
+    </select>
 
-<select id="orderPicker" class="selectpicker" title="Order">
-  <option selected value="ASC">Asc</option>
-  <option value="DESC">Desc</option>
-</select>
+    <button class="btn btn-primary" id="sortByButton">Sort</button>
+  </div>
+</div>
 
-<button class="btn btn-primary" id="sortByButton">Sort</button>
+
 <table id="formSearchTable" class="table table-striped table-bordered pt-3" style="display:none" width="100%">
   <thead>
     <th>Term</th>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -251,7 +251,7 @@
   <option>Asc</option>
   <option>Desc</option>
 </select>
-
+<button class="btn btn-primary" id="sortByButton">Sort</button>
 <table id="formSearchTable" class="table table-striped table-bordered pt-3" style="display:none" width="100%">
   <thead>
     <th>Term</th>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -231,7 +231,7 @@
 <label class="form-check-label" for="lastName" value="last name">
   Last Name  
 </label>  -->
-<select class="selectpicker" title="Column">
+<select id="columnPicker" class="selectpicker" title="Column">
   <option value="0">Term</option>
   <option value="1">Department</option>
   <option value="2">Supervisor</option>
@@ -243,12 +243,12 @@
   <option value="">Form Type (Status)</option>
 
 </select>
-<select class="selectpicker" title="Field">
+<select id="fieldPicker" class="selectpicker" title="Field">
   <option>First Name</option>
   <option>Last Name</option>
 </select>
 
-<select id="ordering" class="selectpicker" title="Order">
+<select id="orderPicker" class="selectpicker" title="Order">
   <option>Asc</option>
   <option>Desc</option>
 </select>
@@ -262,7 +262,7 @@
     <th>Position (WLS)</th>
     <th>Hrs.</th>
     <th>Length</th>
-    <th>Created</th>
+    <th>Created By</th>
     <th>Form Type (Status)</th>
   </thead>
 </table>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -3,6 +3,10 @@
 {% block styles %}
 {{super()}}
   <link href="https://cdn.datatables.net/v/dt/dt-2.1.6/datatables.min.css" rel="stylesheet">
+  <link href="https://cdn.datatables.net/searchpanes/2.3.2/css/searchPanes.dataTables.css" rel="stylesheet">
+  <link href="https://cdn.datatables.net/select/2.1.0/css/select.dataTables.css" rel="stylesheet">
+  <!-- <link href="https://cdn.datatables.net/v/dt/dt-2.1.6/datatables.min.css" rel="stylesheet"> -->
+ 
   <link rel="stylesheet" type="text/css" href="{{url_for('static', filename ='css/allPendingForms.css')}}?u={{lastStaticUpdate}}">
   <link rel="stylesheet" type="text/css" href="{{url_for('static', filename ='css/pendingNotesModal.css')}}?u={{lastStaticUpdate}}">
 {% endblock %}
@@ -10,6 +14,10 @@
 {% block scripts %}
 {{super()}}
   <script src="https://cdn.datatables.net/v/dt/dt-2.1.6/datatables.min.js"></script>
+  <script src="https://cdn.datatables.net/searchpanes/2.3.2/js/dataTables.searchPanes.js"></script>
+  <script src="https://cdn.datatables.net/searchpanes/2.3.2/js/searchPanes.dataTables.js"></script>
+  <script src="https://cdn.datatables.net/select/2.1.0/js/dataTables.select.js"></script>
+  <script src="https://cdn.datatables.net/select/2.1.0/js/select.dataTables.js"></script> 
   <script type="text/javascript" src="{{url_for('static', filename='js/laborhistory.js')}}?u={{lastStaticUpdate}}"></script>
   <script type="text/javascript" src="{{url_for('static', filename='js/allPendingForms.js')}}?u={{lastStaticUpdate}}"></script>
   <script type="text/javascript" src="{{url_for('static', filename='js/supervisorPortal.js') }}?u={{lastStaticUpdate}}"></script>
@@ -214,7 +222,14 @@
     </div>
   </div>
 <br>
-
+<input type="checkbox" value="first name" name="sortBy" id="firstName"/>
+<label class="form-check-label" for="firstName" value="first name">
+  First Name  
+</label> 
+<input type="checkbox" value="last name" name="sortBy" id="lastName"/>
+<label class="form-check-label" for="lastName" value="last name">
+  Last Name  
+</label> 
 <table id="formSearchTable" class="table table-striped table-bordered pt-3" style="display:none" width="100%">
   <thead>
     <th>Term</th>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -2,14 +2,14 @@
 
 {% block styles %}
 {{super()}}
-  <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs/dt-1.10.21/b-1.6.2/datatables.min.css"/>
+  <link href="https://cdn.datatables.net/v/dt/dt-2.1.6/datatables.min.css" rel="stylesheet">
   <link rel="stylesheet" type="text/css" href="{{url_for('static', filename ='css/allPendingForms.css')}}?u={{lastStaticUpdate}}">
   <link rel="stylesheet" type="text/css" href="{{url_for('static', filename ='css/pendingNotesModal.css')}}?u={{lastStaticUpdate}}">
 {% endblock %}
 
 {% block scripts %}
 {{super()}}
-  <script type="text/javascript" src="https://cdn.datatables.net/v/bs/dt-1.10.21/b-1.6.2/datatables.min.js"></script>
+  <script src="https://cdn.datatables.net/v/dt/dt-2.1.6/datatables.min.js"></script>
   <script type="text/javascript" src="{{url_for('static', filename='js/laborhistory.js')}}?u={{lastStaticUpdate}}"></script>
   <script type="text/javascript" src="{{url_for('static', filename='js/allPendingForms.js')}}?u={{lastStaticUpdate}}"></script>
   <script type="text/javascript" src="{{url_for('static', filename='js/supervisorPortal.js') }}?u={{lastStaticUpdate}}"></script>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -228,15 +228,15 @@
   Last Name  
 </label>  -->
 <select id="columnPicker" class="selectpicker" title="Column">
-  <option value="0">Term</option>
-  <option value="1">Department</option>
-  <option value="2">Supervisor</option>
-  <option value="3">Student</option>
-  <option value="4">Position (WLS)</option>
-  <option value="5">Hrs.</option>
-  <option value="6">Length</option>
-  <option value="7">Created By</option>
-  <option value="8">Form Type (Status)</option>
+  <option value="term">Term</option>
+  <option value="department">Department</option>
+  <option value="supervisor">Supervisor</option>
+  <option value="student">Student</option>
+  <option value="position">Position (WLS)</option>
+  <option value="hours">Hrs.</option>
+  <option value="length">Length</option>
+  <option value="createdBy">Created By</option>
+  <option value="form">Form Type (Status)</option>
 
 </select>
 <select id="fieldPicker" class="selectpicker" title="Field">
@@ -244,8 +244,8 @@
 </select>
 
 <select id="orderPicker" class="selectpicker" title="Order">
-  <option>Asc</option>
-  <option>Desc</option>
+  <option value="ASC">Asc</option>
+  <option value="DESC">Desc</option>
 </select>
 <button class="btn btn-primary" id="sortByButton">Sort</button>
 <table id="formSearchTable" class="table table-striped table-bordered pt-3" style="display:none" width="100%">

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -238,14 +238,13 @@
   <option value="3">Student</option>
   <option value="4">Position (WLS)</option>
   <option value="5">Hrs.</option>
-  <option value="">Length</option>
-  <option value="">Created</option>
-  <option value="">Form Type (Status)</option>
+  <option value="6">Length</option>
+  <option value="7">Created By</option>
+  <option value="8">Form Type (Status)</option>
 
 </select>
 <select id="fieldPicker" class="selectpicker" title="Field">
-  <option>First Name</option>
-  <option>Last Name</option>
+  <option value="term">Term</option>
 </select>
 
 <select id="orderPicker" class="selectpicker" title="Order">

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -244,7 +244,7 @@
 </select>
 
 <select id="orderPicker" class="selectpicker" title="Order">
-  <option value="ASC">Asc</option>
+  <option selected value="ASC">Asc</option>
   <option value="DESC">Desc</option>
 </select>
 <button class="btn btn-primary" id="sortByButton">Sort</button>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -243,7 +243,7 @@
   </div>
 </div>
 <br>
-<div style="position: relative; z-index: 1;">
+<div style="position: relative; z-index: 1;" id="sortOptions">
   <div class="container-fluid" style="margin-bottom: -40px;" align="right">
     <label for="columnPicker">Sorting Options:</label>
     <select id="columnPicker" name="columnPicker" class="selectpicker" title="Column">
@@ -252,7 +252,6 @@
       <option value="supervisor">Supervisor</option>
       <option value="student">Student</option>
       <option value="position">Position (WLS)</option>
-      <option value="hours">Hrs.</option>
       <option value="length">Length</option>
       <option value="createdBy">Created By</option>
       <option value="form">Form Type (Status)</option>


### PR DESCRIPTION
## Issue
Fixes issue #442 

Right now sorting is not entirely intuitive, and if it is, it is not particularly dynamic. There may be 3 different fields stored in one column (what if I want to sort first name vs last name) but right now all we can do is sort by the text in column. We need to add our own ordering functionality so we can sort by whatever we deem necessary.

## Changes
- Disabled current built in sorting mechanisms because they will now break and are no longer needed
- Added 3 drop downs to select which column you want to sort by, what field in that column you want to sort by, and whether you want it ascending or descending.
- Pass back a string containing the field we want to order by to the backend
- Added in backend logic to sort by particular field instead of one field per column.
- Upgraded the current datatables package to the most up to date one.

## To Test
- Checkout `form_search_filters_442`
- Reset from backup data
- Go to the supervisor portal, experiment around with some queries and try and verify that every field and column work as expected.