### PR TITLE
Create simple and advanced views for supervisor portal

### DIFF
--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -204,13 +204,14 @@ def getFormattedData(filteredSearchResults, view ='advanced'):
         formattedData = ""
         for form in filteredSearchResults:
             # The order in which you append the items to 'record' matters and it should match the order of columns on the table!
-            formattedData += f"""<td> <a href="/laborHistory/{form.formID.studentSupervisee.ID}" value=0> 
+            formattedData += f"""<tr> <td> <a href="/laborHistory/{form.formID.studentSupervisee.ID}" value=0> 
                             <span class="h4">{form.formID.studentSupervisee.FIRST_NAME}{form.formID.studentSupervisee.LAST_NAME}({form.formID.studentSupervisee.ID})</span>
                             </a>
                             <span class="pushRight h5">{form.status}</span>
                             <br>
                             <span class="pushLeft h6"> {form.formID.termCode.termName} - {form.formID.POSN_TITLE} - {form.formID.department.DEPT_NAME}</span>
-                            </td>"""
+                            </td> </tr>"""
+            print(form)
         return formattedData
 
     supervisorHTML = '<span href="#" aria-label="{}">{} </span><a href="mailto:{}"><span class="glyphicon glyphicon-envelope mailtoIcon"></span></span>'

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -189,10 +189,69 @@ def getDatatableData(request):
         filteredSearchRcesults = formSearchResults.order_by(sortValueColumnMap[sortBy].desc()).limit(rowsPerPage).offset(rowNumber)
     else:
         filteredSearchResults = formSearchResults.order_by(sortValueColumnMap[sortBy].asc()).limit(rowsPerPage).offset(rowNumber)
-    formattedData = getFormattedData(filteredSearchResults)
+    formattedData = getSimpleFormattedData(filteredSearchResults)
     formsDict = {"draw": draw, "recordsTotal": recordsTotal, "recordsFiltered": recordsTotal, "data": formattedData}
 
     return jsonify(formsDict)
+def getSimpleFormattedData(filteredSearchResults):
+    '''
+    Putting the data in the correct format to be used by the JS file.
+    Because this implementation is using server-side processing of datatables,
+    the HTML for the datatables are also formatted here.
+    '''
+
+    studentHTML = '<div><a><span onclick=loadLaborHistoryModal({}) aria-label="{}">{} </span></a><br>{} <a href="mailto:{}"><span class="glyphicon glyphicon-envelope mailtoIcon"></span></span></a></div>'
+    positionHTML = '<span href="#" aria-label="{}"> {}</span>'
+    formTypeStatus = '<span href="#" aria-label=""> {}</span>'
+    formattedData = []
+    for form in filteredSearchResults:
+        # The order in which you append the items to 'record' matters and it should match the order of columns on the table!
+        record = []
+        
+        # Student
+        record.append(studentHTML.format( 
+              form.formID.laborStatusFormID,
+              form.formID.studentSupervisee.ID,
+              f'{form.formID.studentSupervisee.preferred_name if form.formID.studentSupervisee.preferred_name else form.formID.studentSupervisee.legal_name} {form.formID.studentSupervisee.LAST_NAME}',
+              form.formID.studentSupervisee.ID,
+              form.formID.studentSupervisee.STU_EMAIL))
+        
+        # Term
+        record.append(form.formID.termCode.termName)
+
+        # Position
+        positionField = positionHTML.format(form.formID.POSN_TITLE, f'{form.formID.POSN_CODE} ({form.formID.WLS})')
+
+        # Adjustment Form Specific Data
+        checkAdjustment(form)
+        if (form.adjustedForm):
+            if form.adjustedForm.fieldAdjusted == "position":
+                newPosition = positionHTML.format(
+                              form.adjustedForm.oldValue,
+                              form.adjustedForm.newValue)
+                positionField = f'<s aria-label="true">{positionField}</s><br>{newPosition}'
+
+            if form.adjustedForm.fieldAdjusted == "weeklyHours"  or  form.adjustedForm.fieldAdjusted == "contractHours":
+                newHours = form.adjustedForm.newValue
+                hoursField = f'<s aria-label="true">{hoursField}</s><br>{newHours}'
+
+        record.append(f'{form.formID.termCode.termName} - {form.formID.jobType}<br>{positionField}')
+
+        # Form Type
+        formTypeNameMapping = {
+            "Labor Status Form": "Original",
+            "Labor Adjustment Form": "Adjusted",
+            "Labor Overload Form": "Overload",
+            "Labor Release Form": "Release"}
+        originalFormTypeName = form.historyType.historyTypeName
+        mappedFormTypeName = formTypeNameMapping[originalFormTypeName]
+        # formType(Status)
+        formTypeStatusField = record.append(formTypeStatus.format(f'{mappedFormTypeName} ({form.status.statusName})'))
+
+        formattedData.append(record)
+
+    return formattedData
+
 
 def getFormattedData(filteredSearchResults):
     '''

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -186,7 +186,7 @@ def getDatatableData(request):
     }
 
     if order == "DESC":
-        filteredSearchRcesults = formSearchResults.order_by(sortValueColumnMap[sortBy].desc()).limit(rowsPerPage).offset(rowNumber)
+        filteredSearchResults = formSearchResults.order_by(sortValueColumnMap[sortBy].desc()).limit(rowsPerPage).offset(rowNumber)
     else:
         filteredSearchResults = formSearchResults.order_by(sortValueColumnMap[sortBy].asc()).limit(rowsPerPage).offset(rowNumber)
     formattedData = getFormattedData(filteredSearchResults, queryFilterDict['view'])

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -201,21 +201,18 @@ def getFormattedData(filteredSearchResults, view ='simple'):
     the HTML for the datatables are also formatted here.
     '''
     if view == "simple":
-        formattedData = ""
+        formattedData = []
         for form in filteredSearchResults:
             # The order in which you append the items to 'record' matters and it should match the order of columns on the table!
-            formattedData += f"""
-                <tr> 
-                    <td> 
-                        <a href="/laborHistory/{form.formID.studentSupervisee.ID}" value=0> 
-                            <span class="h4">{form.formID.studentSupervisee.FIRST_NAME} {form.formID.studentSupervisee.LAST_NAME} ({form.formID.studentSupervisee.ID})</span>
-                        </a>
-                        <span class="pushRight">{form.status}</span>
-                        <br>
-                        <span class="pushLeft h6"> {form.formID.termCode.termName} - {form.formID.POSN_TITLE} - {form.formID.department.DEPT_NAME}</span>
-                    </td>
-                </tr>
-            """
+            formattedData.append([f"""
+                <a href="/laborHistory/{form.formID.studentSupervisee.ID}" value=0> 
+                    <span class="h4">{form.formID.studentSupervisee.FIRST_NAME} {form.formID.studentSupervisee.LAST_NAME} ({form.formID.studentSupervisee.ID})</span>
+                </a>
+                <span class="pushRight">{form.status}</span>
+                <br>
+                <span class="pushLeft h6"> {form.formID.termCode.termName} - {form.formID.POSN_TITLE} - {form.formID.department.DEPT_NAME}</span>
+            """])
+        print(formattedData)
         return formattedData
 
     supervisorHTML = '<span href="#" aria-label="{}">{} </span><a href="mailto:{}"><span class="glyphicon glyphicon-envelope mailtoIcon"></span></span>'
@@ -304,7 +301,6 @@ def getFormattedData(filteredSearchResults, view ='simple'):
         # TODO: Skipping adding to the table. Requires database work to get SLE out from form (formHistory, to be precise)
 
         formattedData.append(record)
-
     return formattedData
 
 @main_bp.route('/supervisorPortal/addUserToDept', methods=['GET', 'POST'])

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -210,9 +210,8 @@ def getFormattedData(filteredSearchResults, view ='simple'):
                 </a>
                 <span class="pushRight">{form.status}</span>
                 <br>
-                <span class="pushLeft h6"> {form.formID.termCode.termName} - {form.formID.POSN_TITLE} - {form.formID.department.DEPT_NAME}</span>
+                <span class="pushLeft h6"> {form.formID.termCode.termName} - {form.formID.POSN_TITLE} ({form.formID.jobType}) - {form.formID.department.DEPT_NAME}</span>
             """])
-        print(formattedData)
         return formattedData
 
     supervisorHTML = '<span href="#" aria-label="{}">{} </span><a href="mailto:{}"><span class="glyphicon glyphicon-envelope mailtoIcon"></span></span>'

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -224,6 +224,8 @@ def getFormattedData(filteredSearchResults):
                             form.formID.supervisor.ID,
                             f'{form.formID.supervisor.preferred_name if form.formID.supervisor.preferred_name else form.formID.supervisor.legal_name } {form.formID.supervisor.LAST_NAME}',
                             form.formID.supervisor.EMAIL)
+        record.append(supervisorField)
+        
         # Department
         record.append(departmentHTML.format(
               form.formID.department.ORG,
@@ -256,7 +258,7 @@ def getFormattedData(filteredSearchResults):
                 newHours = form.adjustedForm.newValue
                 hoursField = f'<s aria-label="true">{hoursField}</s><br>{newHours}'
 
-        record.append(supervisorField)
+        
         
 
         record.append(f'{form.formID.jobType}<br>{positionField}')

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -184,7 +184,7 @@ def getDatatableData(request):
     }
 
     if order == "DESC":
-        filteredSearchResults = formSearchResults.order_by(sortValueColumnMap[sortBy].desc()).limit(rowsPerPage).offset(rowNumber)
+        filteredSearchRcesults = formSearchResults.order_by(sortValueColumnMap[sortBy].desc()).limit(rowsPerPage).offset(rowNumber)
     else:
         filteredSearchResults = formSearchResults.order_by(sortValueColumnMap[sortBy].asc()).limit(rowsPerPage).offset(rowNumber)
     formattedData = getFormattedData(filteredSearchResults)
@@ -210,16 +210,24 @@ def getFormattedData(filteredSearchResults):
         record = []
         # Term
         record.append(form.formID.termCode.termName)
-        # Department
-        record.append(departmentHTML.format(
-              form.formID.department.ORG,
-              form.formID.department.ACCOUNT,
-              form.formID.department.DEPT_NAME))
+        # Student
+        record.append(studentHTML.format(
+                form.formID.laborStatusFormID,
+              form.formID.studentSupervisee.ID,
+              f'{form.formID.studentSupervisee.preferred_name if form.formID.studentSupervisee.preferred_name else form.formID.studentSupervisee.legal_name} {form.formID.studentSupervisee.LAST_NAME}',
+              form.formID.studentSupervisee.ID,
+              form.formID.studentSupervisee.STU_EMAIL))
         # Supervisor
         supervisorField = supervisorHTML.format(
                             form.formID.supervisor.ID,
                             f'{form.formID.supervisor.preferred_name if form.formID.supervisor.preferred_name else form.formID.supervisor.legal_name } {form.formID.supervisor.LAST_NAME}',
                             form.formID.supervisor.EMAIL)
+        # Department
+        record.append(departmentHTML.format(
+              form.formID.department.ORG,
+              form.formID.department.ACCOUNT,
+              form.formID.department.DEPT_NAME))
+        
         # Position
         positionField = positionHTML.format(
                         form.formID.POSN_TITLE,
@@ -247,13 +255,7 @@ def getFormattedData(filteredSearchResults):
                 hoursField = f'<s aria-label="true">{hoursField}</s><br>{newHours}'
 
         record.append(supervisorField)
-        # Student
-        record.append(studentHTML.format(
-                form.formID.laborStatusFormID,
-              form.formID.studentSupervisee.ID,
-              f'{form.formID.studentSupervisee.preferred_name if form.formID.studentSupervisee.preferred_name else form.formID.studentSupervisee.legal_name} {form.formID.studentSupervisee.LAST_NAME}',
-              form.formID.studentSupervisee.ID,
-              form.formID.studentSupervisee.STU_EMAIL))
+        
 
         record.append(f'{form.formID.jobType}<br>{positionField}')
         record.append(hoursField)

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -101,9 +101,9 @@ def getDatatableData(request):
         sleJoin = False
     
     currentUser = require_login()
-    draw = int(request.form.get('draw', 10))
-    rowNumber = int(request.form.get('start', 10))
-    rowsPerPage = int(request.form.get('length', 10))
+    draw = int(request.form.get('draw', 0))
+    rowNumber = int(request.form.get('start', 0))
+    rowsPerPage = int(request.form.get('length', 25))
     queryFilterData = request.form.get('data')
     queryFilterDict = json.loads(queryFilterData)
     sortBy = queryFilterDict.get('sortBy', "term")
@@ -194,24 +194,28 @@ def getDatatableData(request):
 
     return jsonify(formsDict)
 
-def getFormattedData(filteredSearchResults, view ='advanced'):
+def getFormattedData(filteredSearchResults, view ='simple'):
     '''
     Putting the data in the correct format to be used by the JS file.
     Because this implementation is using server-side processing of datatables,
     the HTML for the datatables are also formatted here.
     '''
-    print('RAHHHH', filteredSearchResults)
     if view == "simple":
         formattedData = ""
         for form in filteredSearchResults:
             # The order in which you append the items to 'record' matters and it should match the order of columns on the table!
-            formattedData += f"""<tr> <td> <a href="/laborHistory/{form.formID.studentSupervisee.ID}" value=0> 
-                            <span class="h4">{form.formID.studentSupervisee.FIRST_NAME}{form.formID.studentSupervisee.LAST_NAME}({form.formID.studentSupervisee.ID})</span>
-                            </a>
-                            <span class="pushRight h5">{form.status}</span>
-                            <br>
-                            <span class="pushLeft h6"> {form.formID.termCode.termName} - {form.formID.POSN_TITLE} - {form.formID.department.DEPT_NAME}</span>
-                            </td> </tr>"""
+            formattedData += f"""
+                <tr> 
+                    <td> 
+                        <a href="/laborHistory/{form.formID.studentSupervisee.ID}" value=0> 
+                            <span class="h4">{form.formID.studentSupervisee.FIRST_NAME} {form.formID.studentSupervisee.LAST_NAME} ({form.formID.studentSupervisee.ID})</span>
+                        </a>
+                        <span class="pushRight">{form.status}</span>
+                        <br>
+                        <span class="pushLeft h6"> {form.formID.termCode.termName} - {form.formID.POSN_TITLE} - {form.formID.department.DEPT_NAME}</span>
+                    </td>
+                </tr>
+            """
         return formattedData
 
     supervisorHTML = '<span href="#" aria-label="{}">{} </span><a href="mailto:{}"><span class="glyphicon glyphicon-envelope mailtoIcon"></span></span>'

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -101,9 +101,9 @@ def getDatatableData(request):
         sleJoin = False
     
     currentUser = require_login()
-    draw = int(request.form.get('draw', -1))
-    rowNumber = int(request.form.get('start', -1))
-    rowsPerPage = int(request.form.get('length', -1))
+    draw = int(request.form.get('draw', 10))
+    rowNumber = int(request.form.get('start', 10))
+    rowsPerPage = int(request.form.get('length', 10))
     queryFilterData = request.form.get('data')
     queryFilterDict = json.loads(queryFilterData)
     sortBy = queryFilterDict.get('sortBy', "term")
@@ -200,10 +200,11 @@ def getFormattedData(filteredSearchResults, view ='advanced'):
     Because this implementation is using server-side processing of datatables,
     the HTML for the datatables are also formatted here.
     '''
+    print('RAHHHH', filteredSearchResults)
     if view == "simple":
         formattedData = ""
         for form in filteredSearchResults:
-            # The order in which you append the items to 'record' matters and it should match the order of columns on the table!
+             # The order in which you append the items to 'record' matters and it should match the order of columns on the table!
             formattedData += f"""<td> <a href="/laborHistory/{form.formID.studentSupervisee.ID}" value=0> 
                             <span class="h4">{form.formID.studentSupervisee.FIRST_NAME}{form.formID.studentSupervisee.LAST_NAME}({form.formID.studentSupervisee.ID})</span>
                             </a>

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -184,8 +184,9 @@ def getDatatableData(request):
         "supervisorLastName": Supervisor.LAST_NAME,
         "studentFirstName": studentFirstNameCase,
         "studentLastName": Student.LAST_NAME,
-        "positionCode": LaborStatusForm.POSN_CODE,
         "positionWLS": LaborStatusForm.WLS,
+        "positionTitle": LaborStatusForm.POSN_TITLE,
+        "positionType": LaborStatusForm.jobType,
         "hours": workHours,
         "length": LaborStatusForm.startDate,
         "createdBy": User.username, 
@@ -258,8 +259,8 @@ def getFormattedData(filteredSearchResults, view ='simple'):
         
         # Position
         positionField = positionHTML.format(
-                        form.formID.POSN_TITLE,
-                        f'{form.formID.POSN_CODE} ({form.formID.WLS})')
+                        form.formID.jobType,
+                        f'{form.formID.jobType} ({form.formID.WLS})')
         # Hours
         hoursField = form.formID.weeklyHours if form.formID.weeklyHours else form.formID.contractHours
         # Adjustment Form Specific Data
@@ -285,7 +286,7 @@ def getFormattedData(filteredSearchResults, view ='simple'):
         
         
 
-        record.append(f'{form.formID.jobType}<br>{positionField}')
+        record.append(f'{form.formID.POSN_TITLE}<br>{positionField}')
         record.append(hoursField)
         # Contract Dates
         record.append("<br>".join([form.formID.startDate.strftime('%m/%d/%y'),

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -172,8 +172,8 @@ def getDatatableData(request):
     # to actual peewee objects we can sort by later
     # the casing is weird because the columns that don't have any fields are are not capitalized
     sortValueColumnMap = {
-        "Term": Term.termCode,
-        "Department": Department.DEPT_NAME,
+        "term": Term.termCode,
+        "department": Department.DEPT_NAME,
         "supervisorFirstName": supervisorFirstNameCase,
         "supervisorLastName": Supervisor.LAST_NAME,
         "studentFirstName": studentFirstNameCase,
@@ -181,9 +181,9 @@ def getDatatableData(request):
         "positionType": LaborStatusForm.POSN_TITLE,
         "positionCode": LaborStatusForm.POSN_CODE,
         "positionWLS": LaborStatusForm.WLS,
-        "Hrs.": LaborStatusForm.weeklyHours,
+        "hours": LaborStatusForm.weeklyHours,
         "length": LaborStatusForm.startDate,
-        "Created By": User.username, 
+        "createdBy": User.username, 
         "formStatus": FormHistory.status,
         "formType": FormHistory.historyType,
     }

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -110,7 +110,7 @@ def getDatatableData(request):
     queryFilterDict = json.loads(queryFilterData)
     sortBy = queryFilterDict.get('sortBy', "term")
     if sortBy == "":
-        sortBy = "Term"
+        sortBy = "term"
     order = queryFilterDict.get('order', "ASC")
     
     termCode = queryFilterDict.get('termCode', "")

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -187,9 +187,9 @@ def getDatatableData(request):
     }
 
     if order == "DESC":
-        filteredSearchResults = formSearchResults.order_by(sortValueColumnMap[sortBy].desc()).limit(rowsPerPage).offset(rowNumber)
+        filteredSearchResults = formSearchResults.order_by(fn.TRIM(sortValueColumnMap[sortBy]).desc()).limit(rowsPerPage).offset(rowNumber)
     else:
-        filteredSearchResults = formSearchResults.order_by(sortValueColumnMap[sortBy].asc()).limit(rowsPerPage).offset(rowNumber)
+        filteredSearchResults = formSearchResults.order_by(fn.TRIM(sortValueColumnMap[sortBy]).asc()).limit(rowsPerPage).offset(rowNumber)
     formattedData = getFormattedData(filteredSearchResults, queryFilterDict['view'])
     formsDict = {"draw": draw, "recordsTotal": recordsTotal, "recordsFiltered": recordsTotal, "data": formattedData}
 

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -12,7 +12,16 @@ $(document).ready(function () {
 
   $('#formSearchButton').on('click', function () {
     runFormSearchQuery();
-
+  });
+  $('#switchViewButton').on('click', function () {
+    let buttonVal = this.val()
+    if (buttonVal == 'advanced') {
+      this.val('simple')
+      this.html('Switch To Advanced View')
+    } else {
+      
+    }
+    runFormSearchQuery();
   });
   $('#addUserToDept').on('click', function () {
     $("#addSupervisorToDeptModal").modal("show");
@@ -129,6 +138,7 @@ function disableButtonHandler() {
 }
 
 function runFormSearchQuery(button) {
+  let view = $('#switchViewButton').val()
   let termCode, departmentID, supervisorID, studentID;
   let formStatusList = [];
   let formTypeList = [];
@@ -178,6 +188,7 @@ function runFormSearchQuery(button) {
   }
 
   queryDict = {
+    'view': view,
     'termCode': termCode,
     'departmentID': departmentID,
     'supervisorID': supervisorID,
@@ -192,8 +203,30 @@ function runFormSearchQuery(button) {
 
   var inAnHour = new Date(new Date().getTime() + 60 * 60 * 1000);
   Cookies.set('lsfSearchResults', data, { expires: inAnHour })
+  if (view == 'advanced') {
+    createDataTable(data)
+  } {
+    fetchSimpleView(data)
+  }
+}
 
-  createDataTable(data)
+function fetchSimpleView(data) {
+  data = JSON.stringify(queryDict)
+  return $.ajax({
+    method: "POST",
+    url: `/`,
+    data: data,
+    success: function (response) {
+      renderSimpleView(response)
+    },
+    error: function () {
+    },
+  })
+}
+
+function renderSimpleView(html) {
+  $('#formSearchTable').hide();
+  $('#simpleView').html(html)
 }
 
 function createDataTable(data) {

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -173,7 +173,7 @@ function runFormSearchQuery(button) {
       departmentID = ""
       supervisorID = "currentUser"
       studentID = ""
-      formStatusList = []
+      formStatusList = ["Approved", "Approved Reluctantly"]
       break;
 
     case "pendingForms":

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -14,12 +14,13 @@ $(document).ready(function () {
     runFormSearchQuery();
   });
   $('#switchViewButton').on('click', function () {
-    let buttonVal = this.val()
+    let buttonVal = $('#switchViewButton').val()
     if (buttonVal == 'advanced') {
-      this.val('simple')
-      this.html('Switch To Advanced View')
+      $('#switchViewButton').val('simple')
+      $('#switchViewButton').html('Switch To Advanced View')
     } else {
-      
+      $('#switchViewButton').val('advanced')
+      $('#switchViewButton').html('Switch To Simple View')
     }
     runFormSearchQuery();
   });
@@ -188,6 +189,8 @@ function runFormSearchQuery(button) {
   }
 
   queryDict = {
+    // this may seem counterintuitive but since the value
+    // switches on button press it is technically the opposite of the current view
     'view': view,
     'termCode': termCode,
     'departmentID': departmentID,
@@ -206,7 +209,7 @@ function runFormSearchQuery(button) {
   if (view == 'advanced') {
     createDataTable(data)
   } {
-    fetchSimpleView(data)
+    // fetchSimpleView(data)
   }
 }
 
@@ -233,6 +236,7 @@ function createDataTable(data) {
   $("#formSearchAccordion").accordion({ collapsible: true, active: false });
   $("#download").prop('disabled', false);
   $('#formSearchTable').show();
+  $('#simpleView').hide()
   $('#columnPicker').selectpicker('show')
   $('#fieldPicker').selectpicker('show')
   $('#orderPicker').selectpicker('show')

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -103,15 +103,13 @@ $(document).ready(function () {
     } else {
       fields = simpleColumnFieldMap[column]
     }
-
     // clear the options from the current field picker and replace 
     // them with the ones from the columnFieldMap 
     $('#fieldPicker').empty();
     fields.forEach((field) => {
-      console.log('field')
       var option = $('<option>', {
-        value: field[1],
-        text: field[0]
+        value: field[0],
+        text: field[1]
       });
       $('#fieldPicker').append(option)
     })

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -220,30 +220,45 @@ function runFormSearchQuery(button) {
 function fetchSimpleView(data) {
   $('#formSearchTable').hide();
   $('#formSearchTable_wrapper').hide();
- 
-  return $.ajax({
-    method: "POST",
-    url: `/`,
-    data: { 'data': data }, 
-    success: function (response) {
-      console.log(response)
-      renderSimpleView(response)
-    },
-    error: function () {
-    },
-  })
+  $('#simpleView').show();
+
+  $('#simpleView').DataTable({
+    responsive: true,
+    destroy: true,
+    searching: false, // we may want to enable this at some point, think it may require custom logic on our end, though.
+    processing: true,
+    serverSide: true,
+    paging: true,
+    lengthMenu: [[10, 25, 50, 100], [10, 25, 50, 100]],
+    pageLength: 25,
+    columnDefs: [{
+      // this disables built in ordering on columns with these IDs 
+      // (may be a way to do without specifying each individually but idk)
+      targets: [0],
+      orderable: false,
+    }],
+    ajax: {
+      // we fetch the data and do the ordering server side which means all logic is done
+      // in Python and the datatable just displays the results
+      url: "/",
+      type: "POST",
+      data: { 'data': data },
+      dataSrc: "data",
+    }
+  });
 }
 
-function renderSimpleView(html) {
-  $('#simpleView').show();
-  $('#simpleViewBody').html(html.data)
-}
+// function renderSimpleView(html) {
+//   $('#simpleView').show();
+//   $('#simpleViewBody').html(html.data)
+// }
 
 function createDataTable(data) {
   $("#formSearchAccordion").accordion({ collapsible: true, active: false });
   $("#download").prop('disabled', false);
   $('#formSearchTable').show();
   $('#simpleView').hide()
+  $('#simpleView_wrapper').hide();
   $('#columnPicker').selectpicker('show')
   $('#fieldPicker').selectpicker('show')
   $('#orderPicker').selectpicker('show')

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -206,20 +206,21 @@ function runFormSearchQuery(button) {
 
   var inAnHour = new Date(new Date().getTime() + 60 * 60 * 1000);
   Cookies.set('lsfSearchResults', data, { expires: inAnHour })
-  if (view == 'advanced') {
+  if (view === 'advanced') {
     createDataTable(data)
-  } {
-    // fetchSimpleView(data)
+  } else {
+    fetchSimpleView(data)
   }
 }
 
 function fetchSimpleView(data) {
-  data = JSON.stringify(queryDict)
+  console.log("simple", data)
   return $.ajax({
     method: "POST",
     url: `/`,
-    data: data,
+    data: { 'data': data }, 
     success: function (response) {
+      console.log(response)
       renderSimpleView(response)
     },
     error: function () {
@@ -229,7 +230,7 @@ function fetchSimpleView(data) {
 
 function renderSimpleView(html) {
   $('#formSearchTable').hide();
-  $('#simpleView').html(html)
+  $('#simpleViewBody').html(html)
 }
 
 function createDataTable(data) {

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -95,12 +95,20 @@ $(document).ready(function () {
   });
   $('#columnPicker').on('change', function () {
     let column = $('#columnPicker :selected').text()
-    let fields = columnFieldMap[column]
+    buttonVal = $("#switchViewButton").val()
+    let fields
+    if (buttonVal == "advanced") {
+      fields = advancedColumnFieldMap[column]
+
+    } else {
+      fields = simpleColumnFieldMap[column]
+    }
 
     // clear the options from the current field picker and replace 
     // them with the ones from the columnFieldMap 
     $('#fieldPicker').empty();
     fields.forEach((field) => {
+      console.log('field')
       var option = $('<option>', {
         value: field[1],
         text: field[0]

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -1,7 +1,11 @@
 $(document).ready(function () {
   if ((document.cookie).includes("lsfSearchResults=")) {
     cookieStr = Cookies.get('lsfSearchResults')
-    createDataTable(cookieStr)
+    if ($('#switchViewButton').val() == 'advanced') {
+      createDataTable(cookieStr)
+    } else {
+      fetchSimpleView(cookieStr)
+    }
     setFormSearchValues(JSON.parse(cookieStr))
 
   } else {
@@ -232,7 +236,6 @@ function fetchSimpleView(data) {
 
 function renderSimpleView(html) {
   $('#simpleView').show();
-  console.log(html)
   $('#simpleViewBody').html(html.data)
 }
 

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -214,7 +214,9 @@ function runFormSearchQuery(button) {
 }
 
 function fetchSimpleView(data) {
-  console.log("simple", data)
+  $('#formSearchTable').hide();
+  $('#formSearchTable_wrapper').hide();
+ 
   return $.ajax({
     method: "POST",
     url: `/`,
@@ -229,8 +231,9 @@ function fetchSimpleView(data) {
 }
 
 function renderSimpleView(html) {
-  $('#formSearchTable').hide();
-  $('#simpleViewBody').html(html)
+  $('#simpleView').show();
+  console.log(html)
+  $('#simpleViewBody').html(html.data)
 }
 
 function createDataTable(data) {

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -21,6 +21,7 @@ $(document).ready(function () {
 
   $('#formSearchButton').on('click', function () {
     runFormSearchQuery();
+    $('#sortOptions').show();
   });
 
   $('#switchViewButton').on('click', function () {
@@ -153,6 +154,7 @@ function runFormSearchQuery(button) {
   let formTypeList = [];
   var isDisabled = $('#fieldPicker').prop('disabled');
   let sortBy = $('#fieldPicker').val()
+  
 
   // if the fieldPicker is disabled that means we should take the value
   // from the columnPicker instead

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -221,31 +221,30 @@ function runFormSearchQuery(button) {
   }
 }
 
+function resetColumns(columnFieldMap) {
+  // clear the current columnPicker options and populate it with new ones
+  // from either the simple or advanced columnFieldMap
+  $('#columnPicker').empty();
+  let columns = Object.keys(columnFieldMap)
+  columns.forEach((column) => {
+    var option = $('<option>', {
+      value: columnFieldMap[column][0][1],
+      text: column
+    });
+    $('#columnPicker').append(option)
+  })
+}
+
 function switchViewButton(view) {
   if (view == 'advanced') {
     $('#switchViewButton').val('simple')
     $('#switchViewButton').html('Switch To Advanced View')
-    $('#columnPicker').empty();
-    let columns = Object.keys(simpleColumnFieldMap)
-    columns.forEach((column) => {
-      var option = $('<option>', {
-        value: simpleColumnFieldMap[column][0][1],
-        text: column
-      });
-      $('#columnPicker').append(option)
-    })
+    resetColumns(simpleColumnFieldMap) 
+
   } else {
     $('#switchViewButton').val('advanced')
     $('#switchViewButton').html('Switch To Simple View')
-    $('#columnPicker').empty();
-    let columns = Object.keys(advancedColumnFieldMap)
-    columns.forEach((column) => {
-      var option = $('<option>', {
-        value: advancedColumnFieldMap[column][0][1],
-        text: column
-      });
-      $('#columnPicker').append(option)
-    })
+    resetColumns(advancedColumnFieldMap) 
   }
   $('.selectpicker').selectpicker('refresh')
 }

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -96,13 +96,8 @@ $(document).ready(function () {
   $('#columnPicker').on('change', function () {
     let column = $('#columnPicker :selected').text()
     buttonVal = $("#switchViewButton").val()
-    let fields
-    if (buttonVal == "advanced") {
-      fields = advancedColumnFieldMap[column]
-
-    } else {
-      fields = simpleColumnFieldMap[column]
-    }
+    let fields = buttonVal == "advanced" ? advancedColumnFieldMap[column] : simpleColumnFieldMap[column];
+    
     // clear the options from the current field picker and replace 
     // them with the ones from the columnFieldMap 
     $('#fieldPicker').empty();
@@ -209,8 +204,6 @@ function runFormSearchQuery(button) {
   }
 
   queryDict = {
-    // this may seem counterintuitive but since the value
-    // switches on button press it is technically the opposite of the current view
     'view': view,
     'termCode': termCode,
     'departmentID': departmentID,

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -131,7 +131,7 @@ const advancedColumnFieldMap = {
   'Department': [['Department', 'department']],
   'Supervisor': [['First name', 'supervisorFirstName'], ['Last Name', 'supervisorLastName']],
   'Student': [['First name', 'studentFirstName'], ['Last Name', 'studentLastName']],
-  'Position (WLS)': [['WLS', 'positionWLS'], ['Position Code', 'positionCode']],
+  'Position (WLS)': [['WLS', 'positionWLS'], ['Position Type', 'positionType'], ['Position Title', 'positionTitle']],
   'Hrs.': [['Hours', 'hours']],
   'Length': [['Length', 'length']],
   'Created By': [['Created By', 'createdBy']],
@@ -142,7 +142,7 @@ const simpleColumnFieldMap = {
   'Term': [['Term', 'term']],
   'Department': [['Department', 'department']],
   'Student': [['First name', 'studentFirstName'], ['Last Name', 'studentLastName']],
-  'Position Type': [['Position Type', 'positionType']],
+  'Position': [['Position Type', 'positionType'], ['Position Title', 'positionTitle']],
   'Form Status': [['Status', 'formStatus']]
 };
 

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -43,12 +43,10 @@ $(document).ready(function () {
     runFormSearchQuery()
   })
 
-  // if ($('#formSearchTable').is(':hidden')) {
-  //   $('#columnPicker').selectpicker('hide')
-  //   $('#fieldPicker').selectpicker('hide')
-  //   $('#orderPicker').selectpicker('hide')
-  //   $('#sortByButton').hide()
-  // }
+  if ($('#columnPicker').val() == '') {
+    $('#fieldPicker').prop('disabled', true)
+    $('.selectpicker').selectpicker('refresh')
+  }
 
   $('#addUser').on('click', function () {
     let supervisorID = $('#supervisorModalSelect :selected').val()

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -108,8 +108,8 @@ $(document).ready(function () {
     $('#fieldPicker').empty();
     fields.forEach((field) => {
       var option = $('<option>', {
-        value: field[0],
-        text: field[1]
+        value: field[1],
+        text: field[0]
       });
       $('#fieldPicker').append(option)
     })

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -253,7 +253,7 @@ function switchViewButton(view) {
     let columns = Object.keys(advancedColumnFieldMap)
     columns.forEach((column) => {
       var option = $('<option>', {
-        value: column,
+        value: advancedColumnFieldMap[column][0][1],
         text: column
       });
       $('#columnPicker').append(option)

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -144,7 +144,7 @@ const simpleColumnFieldMap = {
   'Term': [['Term', 'term']],
   'Department': [['Department', 'department']],
   'Student': [['First name', 'studentFirstName'], ['Last Name', 'studentLastName']],
-  'Position (WLS)': [['Position Type', 'positionType']],
+  'Position Type': [['Position Type', 'positionType']],
   'Form Status': [['Status', 'formStatus']]
 };
 
@@ -241,7 +241,7 @@ function switchViewButton(view) {
     let columns = Object.keys(simpleColumnFieldMap)
     columns.forEach((column) => {
       var option = $('<option>', {
-        value: column,
+        value: simpleColumnFieldMap[column][0][1],
         text: column
       });
       $('#columnPicker').append(option)

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -290,14 +290,10 @@ href="{{url_for('static', filename ='css/formHistory.css')}}?u={{lastStaticUpdat
 </table>
 
 <!-- Placeholder div for simple view -->
-<table id="simpleView" class="table" style="margin-top: 40px;" width="100%">
+<table id="simpleView" class="table" width="100%">
   <thead>
-    <tr>
-      <th></th>
-    </tr>
+    <th></th>
   </thead>
-  <tbody class="" id="simpleViewBody">
-
   </tbody>
 </table>
 

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -48,11 +48,12 @@
     <button class="btn btn-primary" type="button" id="mySupervisees">My Current Supervisees</button>
     <button class="btn btn-primary" type="button" id="superviseesPendingForms">My Pending Forms</button>
   </div>
-  <div class="row col-md-8" align="right">
+  <div class="container-fluid" align="right">
     <form method="POST" action="/supervisorPortal/download" style="margin: 0; display: inline;">
       <button class="btn btn-success" type="submit" id="download">Download Results</button>
     </form>
     <button class="btn btn-info" type="button" id="addUserToDept">Add User to Dept.</button>
+    <button id="switchViewButton" class="btn btn-primary" value="advanced">Switch To Simple View</button>
   </div>
 </div>
 <br>
@@ -271,7 +272,7 @@
   </div>
 </div>
 
-
+<!-- Placeholder div for advanced view -->
 <table id="formSearchTable" class="table table-striped table-bordered pt-3" style="display:none" width="100%">
   <thead>
     <th>Term</th>
@@ -285,6 +286,9 @@
     <th>Form Type (Status)</th>
   </thead>
 </table>
+
+<!-- Placeholder div for simple view -->
+<table id="simpleView" style="display:none" width="100%"></table> 
 
 <!-- Overload Modal -->
 <div class="modal fade" id="overloadModal" role="dialog" data-backdrop="true" tabindex="-1"

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -53,7 +53,7 @@
       <button class="btn btn-success" type="submit" id="download">Download Results</button>
     </form>
     <button class="btn btn-info" type="button" id="addUserToDept">Add User to Dept.</button>
-    <button id="switchViewButton" class="btn btn-primary" value="advanced">Switch To Simple View</button>
+    <button id="switchViewButton" class="btn btn-primary" value="simple">Switch To Advanced View</button>
   </div>
 </div>
 <br>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -53,7 +53,7 @@
       <button class="btn btn-success" type="submit" id="download">Download Results</button>
     </form>
     <button class="btn btn-info" type="button" id="addUserToDept">Add User to Dept.</button>
-    <button id="switchViewButton" class="btn btn-primary" value="simple">Switch To Advanced View</button>
+    <button id="switchViewButton" class="btn btn-primary" value="advanced">Switch To Simple View</button>
   </div>
 </div>
 <br>
@@ -288,14 +288,16 @@
 </table>
 
 <!-- Placeholder div for simple view -->
-<table id="simpleView" style="display:none" width="100%">
+<table id="simpleView" class="table " width="100%">
   <thead>
-    <th></th>
+    <tr>
+      <th></th>
+    </tr>
   </thead>
   <tbody class="" id="simpleViewBody">
 
   </tbody>
-</table> 
+</table>
 
 <!-- Overload Modal -->
 <div class="modal fade" id="overloadModal" role="dialog" data-backdrop="true" tabindex="-1"

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -10,7 +10,7 @@
 <link rel="stylesheet" type="text/css"
   href="{{url_for('static', filename ='css/allPendingForms.css')}}?u={{lastStaticUpdate}}">
 <link rel="stylesheet" type="text/css"
-href="{{url_for('static', filename ='css/formHistory.css')}}?u={{lastStaticUpdate}}">
+  href="{{url_for('static', filename ='css/formHistory.css')}}?u={{lastStaticUpdate}}">
 <link rel="stylesheet" type="text/css"
   href="{{url_for('static', filename ='css/pendingNotesModal.css')}}?u={{lastStaticUpdate}}">
 {% endblock %}
@@ -45,17 +45,17 @@ href="{{url_for('static', filename ='css/formHistory.css')}}?u={{lastStaticUpdat
 </div>
 <br>
 <br>
-<div style="display: flex;">
-  <div class="row col-md-12">
+<div style="display: flex; justify-content: space-between;">
+  <div class="row" style="margin-left: 2px;">
     <button class="btn btn-primary" type="button" id="mySupervisees">My Current Supervisees</button>
     <button class="btn btn-primary" type="button" id="superviseesPendingForms">My Pending Forms</button>
   </div>
-  <div class="container-fluid" align="right">
+  <div class="" align="right">
     <form method="POST" action="/supervisorPortal/download" style="margin: 0; display: inline;">
       <button class="btn btn-success" type="submit" id="download">Download Results</button>
     </form>
-    <button class="btn btn-info" type="button" id="addUserToDept">Add User to Dept.</button>
     <button id="switchViewButton" class="btn btn-primary" value="simple">Switch To Advanced View</button>
+    <button class="btn btn-info" type="button" id="addUserToDept">Add User to Dept.</button>
   </div>
 </div>
 <br>
@@ -247,7 +247,7 @@ href="{{url_for('static', filename ='css/formHistory.css')}}?u={{lastStaticUpdat
 </div>
 <br>
 <div style="position: relative; z-index: 1;">
-  <div class="container-fluid" style="margin-bottom: -40px;" align="right">
+  <div class="container-fluid" style="margin-bottom: -40px; float: right;">
     <label for="columnPicker">Sorting Options:</label>
     <select id="columnPicker" name="columnPicker" class="selectpicker" title="Column">
       <option value="term">Term</option>
@@ -290,7 +290,7 @@ href="{{url_for('static', filename ='css/formHistory.css')}}?u={{lastStaticUpdat
 </table>
 
 <!-- Placeholder div for simple view -->
-<table id="simpleView" class="table" width="100%">
+<table id="simpleView" class="table" width="60%">
   <thead>
     <th></th>
   </thead>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -251,9 +251,9 @@
 <table id="formSearchTable" class="table table-striped table-bordered pt-3" style="display:none" width="100%">
   <thead>
     <th>Term</th>
-    <th>Department</th>
-    <th>Supervisor</th>
     <th>Student</th>
+    <th>Supervisor</th>
+    <th>Department</th>
     <th>Position (WLS)</th>
     <th>Hrs.</th>
     <th>Length</th>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -10,6 +10,8 @@
 <link rel="stylesheet" type="text/css"
   href="{{url_for('static', filename ='css/allPendingForms.css')}}?u={{lastStaticUpdate}}">
 <link rel="stylesheet" type="text/css"
+href="{{url_for('static', filename ='css/formHistory.css')}}?u={{lastStaticUpdate}}">
+<link rel="stylesheet" type="text/css"
   href="{{url_for('static', filename ='css/pendingNotesModal.css')}}?u={{lastStaticUpdate}}">
 {% endblock %}
 
@@ -53,7 +55,7 @@
       <button class="btn btn-success" type="submit" id="download">Download Results</button>
     </form>
     <button class="btn btn-info" type="button" id="addUserToDept">Add User to Dept.</button>
-    <button id="switchViewButton" class="btn btn-primary" value="advanced">Switch To Simple View</button>
+    <button id="switchViewButton" class="btn btn-primary" value="simple">Switch To Advanced View</button>
   </div>
 </div>
 <br>
@@ -288,7 +290,7 @@
 </table>
 
 <!-- Placeholder div for simple view -->
-<table id="simpleView" class="table " width="100%">
+<table id="simpleView" class="table" style="margin-top: 40px;" width="100%">
   <thead>
     <tr>
       <th></th>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -288,7 +288,14 @@
 </table>
 
 <!-- Placeholder div for simple view -->
-<table id="simpleView" style="display:none" width="100%"></table> 
+<table id="simpleView" style="display:none" width="100%">
+  <thead>
+    <th></th>
+  </thead>
+  <tbody class="" id="simpleViewBody">
+
+  </tbody>
+</table> 
 
 <!-- Overload Modal -->
 <div class="modal fade" id="overloadModal" role="dialog" data-backdrop="true" tabindex="-1"


### PR DESCRIPTION
## Issue
Fixes issue #441 

We created a new supervisor portal, and that is great, but we took it from a user friendly (albeit a very crappily designed) experience to a big table with a ton of info. We should give them the option to view in a clearer "simpler" view while maintaining all the same functionality and features of the more advanced view.

## Changes
- Created a button in the top right that allows you to toggle between a simple and advanced view.
- Created a new datatable that renders when Switch To Simple View is toggled that limits the information and presents it in a slightly more user friendly way.
- Added new logic in Flask to handle the rendering of a simple view.
- Modified the cookie handling logic so when the data is pulled in from the session cookies it renders the correct view.

## To Test
- Checkout `441simple_view`
- Run `./database/reset_database.sh from-backup` and `export FLASK_ENV=staging`
- `flask run`
- Upon load you should see the supervisor portal.
- Execute a search and verify that it displays properly on the simple view.
- Try sorting and make sure you can only sort by columns and fields that are directly visible to the user.
- Click "Switch to Advanced View" and verify that the data is the same but just displayed differently.
- Try sorting and make sure you can sort by all columns and fields
- Execute a search with advanced view and close the window
- Reload the window and make sure that all data is automatically loaded in properly.