### PR TITLE
Add permission for admin students for New Labor Status Form

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       MYSQL_PASSWORD: 'password'
       MYSQL_ROOT_PASSWORD: 'root'
     ports:
-      - '3308:3306'
+      - '3308:3308'
     expose:
       - '3308'
     volumes:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       MYSQL_PASSWORD: 'password'
       MYSQL_ROOT_PASSWORD: 'root'
     ports:
-      - '3308:3308'
+      - '3308:3306'
     expose:
       - '3308'
     volumes:

--- a/app/controllers/main_routes/laborStatusForm.py
+++ b/app/controllers/main_routes/laborStatusForm.py
@@ -27,6 +27,7 @@ from app.controllers.admin_routes.allPendingForms import saveStatus
 def laborStatusForm(laborStatusKey = None):
     """ Render labor Status Form, and pre-populate LaborStatusForm page with the correct information when redirected from Labor History."""
     currentUser = require_login()
+    
     if not currentUser:        # Not logged in
         return render_template('errors/403.html'), 403
     if not currentUser.isLaborAdmin:

--- a/app/templates/sidebar.html
+++ b/app/templates/sidebar.html
@@ -24,13 +24,17 @@
                   </div>
               </a>
           </div>
+      {% endif %}
+      {% if currentUser.supervisor or (currentUser.student and currentUser.isLaborAdmin) %}
           <div class="panel panel-default">
             <a class="adminTest" href="/laborstatusform">
-                <div {% if request.path =="/laborstatusform" %} class="panel-heading active"{% endif %} class="panel-heading" tabindex="5">
+                <div {% if request.path == "/laborstatusform" %} class="panel-heading active"{% endif %} class="panel-heading" tabindex="5">
                       <h4>New Labor Status Form</h4>
                   </div>
               </a>
           </div>
+      {% endif %}
+      {% if currentUser.supervisor %}
           <div class="panel panel-default">
             <a class="adminTest" href="/main/search">
                 <div {% if request.path =="/main/search" %} class="panel-heading active"{% endif %} class="panel-heading" tabindex="7">
@@ -38,14 +42,6 @@
                   </div>
               </a>
           </div>
-        </div>
-      {% elif currentUser.student and currentUser.isLaborAdmin %}
-        <div class="panel panel-default">
-            <a class="adminTest" href="/laborstatusform">
-                <div {% if request.path == "/laborstatusform" %} class="panel-heading active"{% endif %} class="panel-heading" tabindex="5">
-                    <h4>New Labor Status Form</h4>
-                </div>
-            </a>
         </div>
       {% endif %}
       {% if currentUser.isLaborAdmin or currentUser.isFinancialAidAdmin or currentUser.isSaasAdmin %}

--- a/app/templates/sidebar.html
+++ b/app/templates/sidebar.html
@@ -39,6 +39,14 @@
               </a>
           </div>
         </div>
+      {% elif currentUser.student and currentUser.isLaborAdmin %}
+        <div class="panel panel-default">
+            <a class="adminTest" href="/laborstatusform">
+                <div {% if request.path == "/laborstatusform" %} class="panel-heading active"{% endif %} class="panel-heading" tabindex="5">
+                    <h4>New Labor Status Form</h4>
+                </div>
+            </a>
+        </div>
       {% endif %}
       {% if currentUser.isLaborAdmin or currentUser.isFinancialAidAdmin or currentUser.isSaasAdmin %}
       <!-- If the current user is an admin, then we want to


### PR DESCRIPTION
## Issue: 
Previously, students who are also Labor Admins did not have access to the New Labor Status Form page. That was considered as a bug given that these students have the permissions to add submit labor status forms for students. 

## Solution: 
Through exploration, we discovered that in the backend such a logic to allow labor admin students to see the New Labor Status Form was already implemented. However, the sidebar was not displaying the New Labor Status Form for these students. So, we made changes there to reflect the privileges of accessibility for these students. 

## Test:
Assuming you're in the LSF directory
- source setup.sh
- database/reset_database.sh from-backup
- change the login username into a student who is a Labor Admin (ex. floresd)
- export FLASK_ENV=staging
- flask run
Now open the application and verify if New Labor Status Form is present as an option in the sidebar. 

Fixes Issue #1321
https://github.com/BCStudentSoftwareDevTeam/celts/issues/1321