### PR TITLE
Fixed links to labor history and form history

### DIFF
--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -206,19 +206,17 @@ def getFormattedData(filteredSearchResults, view ='simple'):
         for form in filteredSearchResults:
             # The order in which you append the items to 'record' matters and it should match the order of columns on the table!
             formattedData.append([f"""
-                <a>
-                    <span onclick=loadLaborHistoryModal({form.formID.laborStatusFormID}) value=0> 
-                        <span class="h4">{form.formID.studentSupervisee.FIRST_NAME} {form.formID.studentSupervisee.LAST_NAME} ({form.formID.studentSupervisee.ID})</span>
-                    </span>
+                <a href="/laborHistory/{form.formID.studentSupervisee.ID}">
+                    <span class="h4">{form.formID.studentSupervisee.FIRST_NAME} {form.formID.studentSupervisee.LAST_NAME} ({form.formID.studentSupervisee.ID})</span>
                 </a>
                 <span class="pushRight">{form.status}</span>
                 <br>
-                <span class="pushLeft h6"> {form.formID.termCode.termName} - {form.formID.POSN_TITLE} ({form.formID.jobType}) - {form.formID.department.DEPT_NAME}</span>
+                <span class="pushLeft h6"> {form.formID.termCode.termName} - <a><span onclick=loadLaborHistoryModal({form.formID.laborStatusFormID})>{form.formID.POSN_TITLE} ({form.formID.jobType})</span></a> - {form.formID.department.DEPT_NAME}</span>
             """])
         return formattedData
 
     supervisorHTML = '<span href="#" aria-label="{}">{} </span><a href="mailto:{}"><span class="glyphicon glyphicon-envelope mailtoIcon"></span></span>'
-    studentHTML = '<div><a><span onclick=loadLaborHistoryModal({}) aria-label="{}">{} </span></a><br>{} <a href="mailto:{}"><span class="glyphicon glyphicon-envelope mailtoIcon"></span></span></a></div>'
+    studentHTML = '<div><a href="/laborHistory/{}">{}</a><br>{} <a href="mailto:{}"><span class="glyphicon glyphicon-envelope mailtoIcon"></span></span></a></div>'
     departmentHTML = '<span href="#" aria-label="{}-{}"> {}</span>'
     positionHTML = '<span href="#" aria-label="{}"> {}</span>'
     formTypeStatus = '<span href="#" aria-label=""> {}</span>'
@@ -230,8 +228,7 @@ def getFormattedData(filteredSearchResults, view ='simple'):
         record.append(form.formID.termCode.termName)
         # Student
         record.append(studentHTML.format(
-                form.formID.laborStatusFormID,
-              form.formID.studentSupervisee.ID,
+                form.formID.studentSupervisee.ID,
               f'{form.formID.studentSupervisee.preferred_name if form.formID.studentSupervisee.preferred_name else form.formID.studentSupervisee.legal_name} {form.formID.studentSupervisee.LAST_NAME}',
               form.formID.studentSupervisee.ID,
               form.formID.studentSupervisee.STU_EMAIL))
@@ -277,7 +274,7 @@ def getFormattedData(filteredSearchResults, view ='simple'):
         
         
 
-        record.append(f'{form.formID.POSN_TITLE}<br>{positionField}')
+        record.append(f'<a><span onclick=loadLaborHistoryModal({form.formID.laborStatusFormID})>{form.formID.POSN_TITLE}</span></a><br>{positionField}')
         record.append(hoursField)
         # Contract Dates
         record.append("<br>".join([form.formID.startDate.strftime('%m/%d/%y'),

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -211,7 +211,7 @@ def getFormattedData(filteredSearchResults, view ='simple'):
                 </a>
                 <span class="pushRight">{form.status}</span>
                 <br>
-                <span class="pushLeft h6"> {form.formID.termCode.termName} - <a><span onclick=loadLaborHistoryModal({form.formID.laborStatusFormID})>{form.formID.POSN_TITLE} ({form.formID.jobType})</span></a> - {form.formID.department.DEPT_NAME}</span>
+                <span class="pushLeft h6"> {form.formID.termCode.termName} - <a><span onclick=loadFormHistoryModal({form.formID.laborStatusFormID})>{form.formID.POSN_TITLE} ({form.formID.jobType})</span></a> - {form.formID.department.DEPT_NAME}</span>
             """])
         return formattedData
 
@@ -274,7 +274,7 @@ def getFormattedData(filteredSearchResults, view ='simple'):
         
         
 
-        record.append(f'<a><span onclick=loadLaborHistoryModal({form.formID.laborStatusFormID})>{form.formID.POSN_TITLE}</span></a><br>{positionField}')
+        record.append(f'<a><span onclick=loadFormHistoryModal({form.formID.laborStatusFormID})>{form.formID.POSN_TITLE}</span></a><br>{positionField}')
         record.append(hoursField)
         # Contract Dates
         record.append("<br>".join([form.formID.startDate.strftime('%m/%d/%y'),

--- a/app/static/js/laborhistory.js
+++ b/app/static/js/laborhistory.js
@@ -11,11 +11,11 @@ $('#positionTable tbody tr td').on('click',function(){
    $("#flash_container").html('<div class="alert alert-danger" role="alert" id="flasher">You do not have access to this department\'s information.</div>');
    $("#flasher").delay(3000).fadeOut();
  } else {
-   loadLaborHistoryModal(this.id)
+   loadFormHistoryModal(this.id)
  }
 });
 
-function loadLaborHistoryModal(formHistory) {
+function loadFormHistoryModal(formHistory) {
   $("#modal").modal("show");
   $("#modal").find('.modal-content').load('/laborHistory/modal/' + formHistory);
   setTimeout(function(){ $(".loader").fadeOut("slow"); }, 500);


### PR DESCRIPTION
## Issue Description

Fixes issue #461 
- The link on the student name would link to the form history and there was no way to link to the labor history. We need to make the name link to the labor history and the position title link to form history.

## Changes
- Added a new <a> tag to the student names that links out to their labor history.
- Moved the modal call over to the position title as that is more intuitive.

## Testing
- Checkout `461_labor_history`
- Reset database (with or without backup data, ideally with backup, though)
- Execute a search and find a row with a particular student.
- Click on their name and verify it takes you to their labor history.
- Click on their position title and verify it takes them to the form's form history.
- Review code.