### PR TITLE
Fix Tracy Connection in the Devcontainer

### DIFF
--- a/db_test.py
+++ b/db_test.py
@@ -32,7 +32,7 @@ import sqlalchemy
 
 # No driver name specified
 #uri = "mssql+pyodbc://{}:{}@{}/{}?DRIVER=FreeTDS".format(details['user'], details['password'], details['server'], details['db'])
-uri = "mssql+pyodbc:///?odbc_connect=" + quote('DRIVER=FreeTDS;SERVER={};PORT=1433;DATABASE={};UID={};PWD={};TDS_Version=8.0;'.format(details['server'],  details['db'], details['user'], details['password']))
+uri = "mssql+pyodbc:///?odbc_connect=" + quote(f"DRIVER=FreeTDS;SERVER={details['mssql_host']};PORT=1433;DATABASE={details['db_name']};UID={details['mssql_user']};PWD={details['mssql_password']};TDS_Version=8.0;")
 
 engine = sqlalchemy.create_engine(uri)
 for row in engine.execute('select * from STUPOSN'):
@@ -48,7 +48,7 @@ from app.logic.tracy import Tracy
 cfg = load_config('app/config/secret_config.yaml')
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
-uri = "mssql+pyodbc:///?odbc_connect=" + quote('DRIVER=FreeTDS;SERVER={};PORT=1433;DATABASE={};UID={};PWD={};TDS_Version=8.0;'.format(details['server'],  details['db'], details['user'], details['password']))
+uri = "mssql+pyodbc:///?odbc_connect=" + quote(f"DRIVER=FreeTDS;SERVER={details['mssql_host']};PORT=1433;DATABASE={details['db_name']};UID={details['mssql_user']};PWD={details['mssql_password']};TDS_Version=8.0;")
 
 app.config['SQLALCHEMY_DATABASE_URI'] = uri
 db = SQLAlchemy(app)

--- a/db_test.py
+++ b/db_test.py
@@ -1,14 +1,19 @@
 import pyodbc
+from app import load_config
 
-details = {
-    "user": "ute_limited",
-    "password": "REPLACE",
-    "server": "timemachine1sql.berea.edu",
-    "db": "UTE"
-}
+cfg = load_config('app/config/secret_config.yaml')
+details = cfg['tracy']
+
+# details = {
+#     "user": "ute_limited",
+#     "password": "REPLACE",
+#     "server": "timemachine1sql.berea.edu",
+#     "db": "UTE"
+# }
 
 # works
-pyodbc_uri = 'DRIVER=FreeTDS;SERVER={};PORT=1433;DATABASE={};UID={};PWD={};TDS_Version=8.0;'.format(details['server'],details['db'],details['user'],details['password'])
+pyodbc_uri = f"DRIVER=FreeTDS;SERVER={details['mssql_host']};PORT=1433;DATABASE={details['db_name']};UID={details['mssql_user']};PWD={details['mssql_password']};TDS_Version=8.0;"
+             
 # works
 #pyodbc_uri = 'DRIVER=FreeTDS;DSN=tracyDSN;UID={};PWD={};'.format(details['user'], details['password'])
 pyconn = pyodbc.connect(pyodbc_uri)


### PR DESCRIPTION
# Issue
Resolves Issue #465

When we try to connect to Tracy in our application we get a connection error:

`pyodbc.OperationalError: ('08S01', '[08S01] [FreeTDS][SQL Server]Unable to connect: Adaptive Server is unavailable or does not exist (20009) (SQLDriverConnect)')`

![image](https://github.com/user-attachments/assets/53b74603-34d3-4191-9aa9-6a8e5b7b6f88)

# Solution
Some simple code refactoring for clarity (not integral to the solution) as well as connecting your laptop to ethernet before attempting to connect to Tracy from within a devcontainer. In testing, our Tracy connection fails whenever we're connected to either BCSecure or BereaBYOD but when we plug our laptops into ethernet, the connection works with no issues:

![image](https://github.com/user-attachments/assets/45db65ab-0e5d-4994-8cb7-6eff887a368f)

<span style="color: green;">Tests passed!</span> The file executes as intended without error.

# To Test
Swap to our branch `devcontainer_tracy_connection`, open VS Code in the LSF devcontainer, connect to Ethernet, put the Tracy password in the secret_config.yaml file and then run `python db_test.py` and ensure that it exits with no errors.