### PR TITLE
Modified the reset database script to use required args

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Python 3.7+
 4. If you have non-default root and application database credentials, match your MySQL configuration to the application config. You can either:
     - Update MySQL to use the database, username, and password in ```app/config/default.yml```. *OR*
     - Copy the ```db``` configuration lines from ```app/config/default.yml``` and paste them into ```app/config/local-override.yml```. Edit them to create custom database, username, and password configurations. They will need to match what is in your MySQL service.
-5. In the database directory, run ```./reset_database.sh```
+5. In the database directory, run ```./reset_database.sh test```
 6. Run the app with ```flask run``` in the root directory
 
 ## Using the Production database and real Tracy data

--- a/database/add_admins.py
+++ b/database/add_admins.py
@@ -1,7 +1,7 @@
 # Add admins for testing
 from app.logic.userInsertFunctions import *
 
-students = ['manalaih','mupotsal','escalerapadronl','cruzg','romanow','crafta','rieral','juem','jamalie']
+students = ['manalaih','mupotsal','escalerapadronl','cruzg','romanow','crafta','rieral','juem','jamalie', 'makindeo']
 staff = ['bryantal','ramsayb2','heggens','knowlesg', 'welshs', 'napoleonr2', 'buenrostroa', 'ashb', 'gosneyj', 'asantes']
 
 print("Adding staff admins")

--- a/database/demo_data.py
+++ b/database/demo_data.py
@@ -52,6 +52,21 @@ bothStudents = [
                 "LAST_POSN":"TA",
                 "LAST_SUP_PIDM":"7"
                 },
+                {
+                "ID":"B00791326",
+                "PIDM":"9",
+                "FIRST_NAME":"Oluwagbayi",
+                "LAST_NAME":"Makinde",
+                "CLASS_LEVEL":"Junior",
+                "ACADEMIC_FOCUS":"Computer Science",
+                "MAJOR":"Computer Science",
+                "PROBATION":"0",
+                "ADVISOR":"Jan Pearce",
+                "STU_EMAIL":"makindeo@berea.edu",
+                "STU_CPO":"883",
+                "LAST_POSN":"TA",
+                "LAST_SUP_PIDM":"7"
+                },
                 ]
 localStudents = [
                 {
@@ -375,6 +390,14 @@ users = [
         "student": "B00734292",
         "supervisor": None,
         "username": "cruzg",
+        "isLaborAdmin": None,
+        "isFinancialAidAdmin": None,
+        "isSaasAdmin": None
+        },
+        {
+        "student": "B00791326",
+        "supervisor": None,
+        "username": "makindeo",
         "isLaborAdmin": None,
         "isFinancialAidAdmin": None,
         "isSaasAdmin": None

--- a/database/reset_database.sh
+++ b/database/reset_database.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+## Check if argument was passed in
+if [ "$1" != "test" ] && [ "$1" != "from-backup" ]; then
+	echo "You must specify which data set you want to restore"
+    echo "Usage: ./reset_database.sh [test|from-backup]"
+	exit 1;
+fi
+
 cd database;
 
 PRODUCTION=0


### PR DESCRIPTION
In tinkering with LSF, I was trying to reset from backup, and I repeatedly inputted `from-backup` as the arg for `reset_database.sh`. Surprisingly, I got no feedback and the database would reset but default to our test data. I think it's much more intuitive if we use mandatory arguments and give feedback in trying to reset the database.

(Also added myself in the demo_data).