### PR TITLE
Simple View Update: Student Focused

### DIFF
--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -205,22 +205,29 @@ def getFormattedData(filteredSearchResults, view ='simple'):
     '''
     if view == "simple":
         formattedData = []
+        seenBNumbers = set()
         for form in filteredSearchResults:
             # The order in which you append the items to 'record' matters and it should match the order of columns on the table!
-            print(form.createdDate, "here")
             # here's where the magic needs to happen.
             # for each form, we can see the student's B-No.
-            # create another dict for B-No.
+            # create another dict for B-No. 
+            #            -> Honestly I thought that a set for the b-numbers, 
+            #               or if its a dictionary have Bnumber: most recent approved form (Finn suggestion)
             # if we've seen a B-No before, we ignore. If not, we create a unique entry
             # that should be all?
-            formattedData.append([f"""
+            print(form.createdDate, "here")
+            
+            if form.formID.studentSupervisee.ID not in seenBNumbers:
+                formattedData.append([f"""
                 <a href="/laborHistory/{form.formID.studentSupervisee.ID}">
                     <span class="h4">{form.formID.studentSupervisee.FIRST_NAME} {form.formID.studentSupervisee.LAST_NAME} ({form.formID.studentSupervisee.ID})</span>
                 </a>
                 <span class="pushRight">{form.status}</span>
                 <br>
                 <span class="pushLeft h6"> {form.formID.termCode.termName} - <a><span onclick=loadFormHistoryModal({form.formID.laborStatusFormID})>{form.formID.POSN_TITLE} ({form.formID.jobType})</span></a> - {form.formID.department.DEPT_NAME}</span>
-            """])
+                """]) 
+                seenBNumbers.add(form.formID.studentSupervisee.ID)
+        
         return formattedData
 
     supervisorHTML = '<span href="#" aria-label="{}">{} </span><a href="mailto:{}"><span class="glyphicon glyphicon-envelope mailtoIcon"></span></span>'

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -206,34 +206,18 @@ def getFormattedData(filteredSearchResults, view ='simple'):
     if view == "simple":
         formattedData = {}
         todaysDate = date.today()
-        print("the-type", type(todaysDate))
+        filteredSearchResults.order_by(FormHistory.formID.startDate.desc())
         for form in filteredSearchResults:
             startDate = form.formID.startDate
             endDate = form.formID.endDate
             bNumber = form.formID.studentSupervisee.ID
-            shouldAdd, inCurrentDateWindow = False, False
-
             if bNumber not in formattedData:
-                shouldAdd = True
-
-            inCurrentDateWindow = (startDate <= todaysDate and todaysDate <= endDate)
-
-            if shouldAdd:
-                # add the event
-                pass
+                absentInFormatting = True
+                isMostCurrent = True
             else:
-                pass
-            
-            # break down the logic and make it more straightforward
-
-            isClosestToCurrentDate = (startDate >= formattedData[bNumber][1] and endDate <= formattedData[bNumber][2])
-
-            # if date in current window, then we check if the date is a closer fit to our current date
-            if (inCurrentDateWindow and isClosestToCurrentDate) or shouldAdd:
-                # do the logic for adding
-                pass
-
-            if bNumber not in formattedData or ((startDate <= todaysDate and todaysDate <= endDate) and (startDate >= formattedData[bNumber][1] and endDate <= formattedData[bNumber][2])):
+                absentInFormatting = False 
+                isMostCurrent = (startDate > formattedData[bNumber][1] and endDate > formattedData[bNumber][2])
+            if (startDate <= todaysDate <= endDate) and absentInFormatting or isMostCurrent:
                 
                 # html fields
                 firstName, lastName = form.formID.studentSupervisee.FIRST_NAME, form.formID.studentSupervisee.LAST_NAME
@@ -347,6 +331,10 @@ def getFormattedData(filteredSearchResults, view ='simple'):
 
         formattedData.append(record)
     return formattedData
+
+def new_func(filteredSearchResults):
+    filteredSearchResults = sorted(filteredSearchResults, key=lambda x: x.formID.startDate)
+    return filteredSearchResults
 
 @main_bp.route('/supervisorPortal/addUserToDept', methods=['GET', 'POST'])
 def addUserToDept():

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -207,6 +207,12 @@ def getFormattedData(filteredSearchResults, view ='simple'):
         formattedData = []
         for form in filteredSearchResults:
             # The order in which you append the items to 'record' matters and it should match the order of columns on the table!
+            print(form.createdDate, "here")
+            # here's where the magic needs to happen.
+            # for each form, we can see the student's B-No.
+            # create another dict for B-No.
+            # if we've seen a B-No before, we ignore. If not, we create a unique entry
+            # that should be all?
             formattedData.append([f"""
                 <a href="/laborHistory/{form.formID.studentSupervisee.ID}">
                     <span class="h4">{form.formID.studentSupervisee.FIRST_NAME} {form.formID.studentSupervisee.LAST_NAME} ({form.formID.studentSupervisee.ID})</span>

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -3,7 +3,7 @@ import operator
 from flask import render_template, request, json, jsonify, redirect, url_for, send_file, flash, g
 from functools import reduce
 from peewee import fn, Case
-from datetime import datetime
+from datetime import datetime, date
 from app.models.term import Term
 from app.models.department import Department
 from app.models.supervisor import Supervisor
@@ -205,17 +205,36 @@ def getFormattedData(filteredSearchResults, view ='simple'):
     '''
     if view == "simple":
         formattedData = {}
-        todaysDate = datetime.today().strftime('%Y-%m-%d')
+        todaysDate = date.today()
+        print("the-type", type(todaysDate))
         for form in filteredSearchResults:
             startDate = form.formID.startDate
             endDate = form.formID.endDate
-            if form.formID.studentSupervisee.ID in formattedData:
-                print(startDate, formattedData[bNumber][1], startDate >= formattedData[bNumber][1]
-                    , endDate, formattedData[bNumber][2], endDate <= formattedData[bNumber][2], "Some ID")
             bNumber = form.formID.studentSupervisee.ID
+            shouldAdd, inCurrentDateWindow = False, False
 
-            if bNumber not in formattedData or ((startDate <= todaysDate and todaysDate >= endDate) and (startDate >= formattedData[bNumber][1] and endDate <= formattedData[bNumber][2])):
+            if bNumber not in formattedData:
+                shouldAdd = True
 
+            inCurrentDateWindow = (startDate <= todaysDate and todaysDate <= endDate)
+
+            if shouldAdd:
+                # add the event
+                pass
+            else:
+                pass
+            
+            # break down the logic and make it more straightforward
+
+            isClosestToCurrentDate = (startDate >= formattedData[bNumber][1] and endDate <= formattedData[bNumber][2])
+
+            # if date in current window, then we check if the date is a closer fit to our current date
+            if (inCurrentDateWindow and isClosestToCurrentDate) or shouldAdd:
+                # do the logic for adding
+                pass
+
+            if bNumber not in formattedData or ((startDate <= todaysDate and todaysDate <= endDate) and (startDate >= formattedData[bNumber][1] and endDate <= formattedData[bNumber][2])):
+                
                 # html fields
                 firstName, lastName = form.formID.studentSupervisee.FIRST_NAME, form.formID.studentSupervisee.LAST_NAME
                 term = form.formID.termCode.termName
@@ -236,6 +255,7 @@ def getFormattedData(filteredSearchResults, view ='simple'):
                 """
 
                 formattedData[bNumber] = (html, startDate, endDate)
+                print("saved these", startDate, endDate, formattedData[bNumber][1], formattedData[bNumber][2])
 
         formattedDataList = [[value] for value, _, _ in formattedData.values()]
 

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -205,35 +205,39 @@ def getFormattedData(filteredSearchResults, view ='simple'):
     '''
     if view == "simple":
         formattedData = {}
+        todaysDate = datetime.today().strftime('%Y-%m-%d')
         for form in filteredSearchResults:
             startDate = form.formID.startDate
+            endDate = form.formID.endDate
+            if form.formID.studentSupervisee.ID in formattedData:
+                print(startDate, formattedData[bNumber][1], startDate >= formattedData[bNumber][1]
+                    , endDate, formattedData[bNumber][2], endDate <= formattedData[bNumber][2], "Some ID")
             bNumber = form.formID.studentSupervisee.ID
 
-            if bNumber in formattedData and startDate <= formattedData[bNumber][1]:
-                continue
-            
-            # html fields
-            firstName, lastName = form.formID.studentSupervisee.FIRST_NAME, form.formID.studentSupervisee.LAST_NAME
-            term = form.formID.termCode.termName
-            positionTitle = form.formID.POSN_TITLE
-            jobType = form.formID.jobType
-            departmentName = form.formID.department.DEPT_NAME
-            statusFormId = form.formID.laborStatusFormID
+            if bNumber not in formattedData or ((startDate <= todaysDate and todaysDate >= endDate) and (startDate >= formattedData[bNumber][1] and endDate <= formattedData[bNumber][2])):
 
-            html = f"""
-            <a href="/laborHistory/{bNumber}">
-                <span class="h4">{firstName} {lastName} ({bNumber})</span>
-            </a>
-            <span class="pushRight">{form.status}</span>
-            <br>
-            <span class="pushLeft h6">
-                {term} - <a><span onclick=loadFormHistoryModal({statusFormId})>{positionTitle} ({jobType})</span></a> - {departmentName}
-            </span>
-            """
+                # html fields
+                firstName, lastName = form.formID.studentSupervisee.FIRST_NAME, form.formID.studentSupervisee.LAST_NAME
+                term = form.formID.termCode.termName
+                positionTitle = form.formID.POSN_TITLE
+                jobType = form.formID.jobType
+                departmentName = form.formID.department.DEPT_NAME
+                statusFormId = form.formID.laborStatusFormID
 
-            formattedData[bNumber] = (html, startDate)
+                html = f"""
+                <a href="/laborHistory/{bNumber}">
+                    <span class="h4">{firstName} {lastName} ({bNumber})</span>
+                </a>
+                <span class="pushRight">{form.status}</span>
+                <br>
+                <span class="pushLeft h6">
+                    {term} - <a><span onclick=loadFormHistoryModal({statusFormId})>{positionTitle} ({jobType})</span></a> - {departmentName}
+                </span>
+                """
 
-        formattedDataList = [[value] for value,_ in formattedData.values()]
+                formattedData[bNumber] = (html, startDate, endDate)
+
+        formattedDataList = [[value] for value, _, _ in formattedData.values()]
 
         return formattedDataList
 

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -207,17 +207,17 @@ def getFormattedData(filteredSearchResults, view ='simple'):
         formattedData = {}
         todaysDate = date.today()
         filteredSearchResults.order_by(FormHistory.formID.startDate.desc())
+        isMostCurrent = False
         for form in filteredSearchResults:
             startDate = form.formID.startDate
             endDate = form.formID.endDate
             bNumber = form.formID.studentSupervisee.ID
             if bNumber not in formattedData:
                 absentInFormatting = True
-                isMostCurrent = True
             else:
                 absentInFormatting = False 
-                isMostCurrent = (startDate > formattedData[bNumber][1] and endDate > formattedData[bNumber][2])
-            if (startDate <= todaysDate <= endDate) and absentInFormatting or isMostCurrent:
+                isMostCurrent = (startDate > formattedData[bNumber][1]) or (startDate <= todaysDate <= endDate)
+            if absentInFormatting or isMostCurrent:
                 
                 # html fields
                 firstName, lastName = form.formID.studentSupervisee.FIRST_NAME, form.formID.studentSupervisee.LAST_NAME

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -239,7 +239,6 @@ def getFormattedData(filteredSearchResults, view ='simple'):
                 """
 
                 formattedData[bNumber] = (html, startDate, endDate)
-                print("saved these", startDate, endDate, formattedData[bNumber][1], formattedData[bNumber][2])
 
         formattedDataList = [[value] for value, _, _ in formattedData.values()]
 
@@ -331,10 +330,6 @@ def getFormattedData(filteredSearchResults, view ='simple'):
 
         formattedData.append(record)
     return formattedData
-
-def new_func(filteredSearchResults):
-    filteredSearchResults = sorted(filteredSearchResults, key=lambda x: x.formID.startDate)
-    return filteredSearchResults
 
 @main_bp.route('/supervisorPortal/addUserToDept', methods=['GET', 'POST'])
 def addUserToDept():

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -233,7 +233,7 @@ def getFormattedData(filteredSearchResults, view ='simple'):
 
             formattedData[bNumber] = (html, startDate)
 
-        formattedDataList = [value for value,_ in formattedData.values()]
+        formattedDataList = [[value] for value,_ in formattedData.values()]
 
         return formattedDataList
 

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -204,31 +204,39 @@ def getFormattedData(filteredSearchResults, view ='simple'):
     the HTML for the datatables are also formatted here.
     '''
     if view == "simple":
-        formattedData = []
-        seenBNumbers = set()
+        formattedData = {}
         for form in filteredSearchResults:
             # The order in which you append the items to 'record' matters and it should match the order of columns on the table!
             # here's where the magic needs to happen.
             # for each form, we can see the student's B-No.
             # create another dict for B-No. 
-            #            -> Honestly I thought that a set for the b-numbers, 
-            #               or if its a dictionary have Bnumber: most recent approved form (Finn suggestion)
             # if we've seen a B-No before, we ignore. If not, we create a unique entry
             # that should be all?
+            formStartDate = form.formID.startDate.strftime('%%d/%y')
             print(form.createdDate, "here")
-            
-            if form.formID.studentSupervisee.ID not in seenBNumbers:
-                formattedData.append([f"""
-                <a href="/laborHistory/{form.formID.studentSupervisee.ID}">
-                    <span class="h4">{form.formID.studentSupervisee.FIRST_NAME} {form.formID.studentSupervisee.LAST_NAME} ({form.formID.studentSupervisee.ID})</span>
+            BNumber = form.formID.studentSupervisee.ID
+            if BNumber not in formattedData:
+                formattedData[BNumber] = ([f"""
+                <a href="/laborHistory/{BNumber}">
+                    <span class="h4">{form.formID.studentSupervisee.FIRST_NAME} {form.formID.studentSupervisee.LAST_NAME} ({BNumber})</span>
                 </a>
                 <span class="pushRight">{form.status}</span>
                 <br>
                 <span class="pushLeft h6"> {form.formID.termCode.termName} - <a><span onclick=loadFormHistoryModal({form.formID.laborStatusFormID})>{form.formID.POSN_TITLE} ({form.formID.jobType})</span></a> - {form.formID.department.DEPT_NAME}</span>
-                """]) 
-                seenBNumbers.add(form.formID.studentSupervisee.ID)
-        
-        return formattedData
+                """], form.formID.startDate)
+            elif form.formID.startDate > formattedData[BNumber][1]:
+                formattedData[BNumber] = ([f"""
+                <a href="/laborHistory/{BNumber}">
+                    <span class="h4">{form.formID.studentSupervisee.FIRST_NAME} {form.formID.studentSupervisee.LAST_NAME} ({BNumber})</span>
+                </a>
+                <span class="pushRight">{form.status}</span>
+                <br>
+                <span class="pushLeft h6"> {form.formID.termCode.termName} - <a><span onclick=loadFormHistoryModal({form.formID.laborStatusFormID})>{form.formID.POSN_TITLE} ({form.formID.jobType})</span></a> - {form.formID.department.DEPT_NAME}</span>
+                """], form.formID.startDate)
+            print(form.formID.termCode, "WAAAAA")
+            formatedDataList = [value for value,_ in formattedData.values()]
+
+        return formatedDataList
 
     supervisorHTML = '<span href="#" aria-label="{}">{} </span><a href="mailto:{}"><span class="glyphicon glyphicon-envelope mailtoIcon"></span></span>'
     studentHTML = '<div><a href="/laborHistory/{}">{}</a><br>{} <a href="mailto:{}"><span class="glyphicon glyphicon-envelope mailtoIcon"></span></span></a></div>'

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -206,37 +206,36 @@ def getFormattedData(filteredSearchResults, view ='simple'):
     if view == "simple":
         formattedData = {}
         for form in filteredSearchResults:
-            # The order in which you append the items to 'record' matters and it should match the order of columns on the table!
-            # here's where the magic needs to happen.
-            # for each form, we can see the student's B-No.
-            # create another dict for B-No. 
-            # if we've seen a B-No before, we ignore. If not, we create a unique entry
-            # that should be all?
-            formStartDate = form.formID.startDate.strftime('%%d/%y')
-            print(form.createdDate, "here")
-            BNumber = form.formID.studentSupervisee.ID
-            if BNumber not in formattedData:
-                formattedData[BNumber] = ([f"""
-                <a href="/laborHistory/{BNumber}">
-                    <span class="h4">{form.formID.studentSupervisee.FIRST_NAME} {form.formID.studentSupervisee.LAST_NAME} ({BNumber})</span>
-                </a>
-                <span class="pushRight">{form.status}</span>
-                <br>
-                <span class="pushLeft h6"> {form.formID.termCode.termName} - <a><span onclick=loadFormHistoryModal({form.formID.laborStatusFormID})>{form.formID.POSN_TITLE} ({form.formID.jobType})</span></a> - {form.formID.department.DEPT_NAME}</span>
-                """], form.formID.startDate)
-            elif form.formID.startDate > formattedData[BNumber][1]:
-                formattedData[BNumber] = ([f"""
-                <a href="/laborHistory/{BNumber}">
-                    <span class="h4">{form.formID.studentSupervisee.FIRST_NAME} {form.formID.studentSupervisee.LAST_NAME} ({BNumber})</span>
-                </a>
-                <span class="pushRight">{form.status}</span>
-                <br>
-                <span class="pushLeft h6"> {form.formID.termCode.termName} - <a><span onclick=loadFormHistoryModal({form.formID.laborStatusFormID})>{form.formID.POSN_TITLE} ({form.formID.jobType})</span></a> - {form.formID.department.DEPT_NAME}</span>
-                """], form.formID.startDate)
-            print(form.formID.termCode, "WAAAAA")
-            formatedDataList = [value for value,_ in formattedData.values()]
+            startDate = form.formID.startDate
+            bNumber = form.formID.studentSupervisee.ID
 
-        return formatedDataList
+            if bNumber in formattedData and startDate <= formattedData[bNumber][1]:
+                continue
+            
+            # html fields
+            firstName, lastName = form.formID.studentSupervisee.FIRST_NAME, form.formID.studentSupervisee.LAST_NAME
+            term = form.formID.termCode.termName
+            positionTitle = form.formID.POSN_TITLE
+            jobType = form.formID.jobType
+            departmentName = form.formID.department.DEPT_NAME
+            statusFormId = form.formID.laborStatusFormID
+
+            html = f"""
+            <a href="/laborHistory/{bNumber}">
+                <span class="h4">{firstName} {lastName} ({bNumber})</span>
+            </a>
+            <span class="pushRight">{form.status}</span>
+            <br>
+            <span class="pushLeft h6">
+                {term} - <a><span onclick=loadFormHistoryModal({statusFormId})>{positionTitle} ({jobType})</span></a> - {departmentName}
+            </span>
+            """
+
+            formattedData[bNumber] = (html, startDate)
+
+        formattedDataList = [value for value,_ in formattedData.values()]
+
+        return formattedDataList
 
     supervisorHTML = '<span href="#" aria-label="{}">{} </span><a href="mailto:{}"><span class="glyphicon glyphicon-envelope mailtoIcon"></span></span>'
     studentHTML = '<div><a href="/laborHistory/{}">{}</a><br>{} <a href="mailto:{}"><span class="glyphicon glyphicon-envelope mailtoIcon"></span></span></a></div>'


### PR DESCRIPTION
## Issue Description

Fixes #476

"Simple view should be oriented around students instead of forms"

- In both Simple and Advanced View, students would often show up more than once, since the data table presents every form within the search.

- Make the simple view only present the students within the search filters. (Also provide more minimal information about forms)

## Changes

- Simplified the simple view in the form search to the one of the most recent start date

## Testing

- `git fetch`
- `git checkout Simple-View-Update`
- search for a specific student
- go for check in their labor history to determine if the most recent form is the same under simple view
- attempt to sort the simple view columns 