### PR TITLE
Fix for LSF Downloads + QOL Improvements

### DIFF
--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -208,17 +208,21 @@ def checkAdjustment(allForms):
 
 @admin.route('/admin/pendingForms/download', methods=['POST'])
 def downloadAllPendingForms():
+    allPendingFormsSelectObject = request.form.get('formList')
+    print(allPendingFormsSelectObject, type(allPendingFormsSelectObject), "the-type")
+    allPendingForms = allPendingFormsSelectObject.order_by(-FormHistory.createdDate)
+    print(allPendingForms, "some bs forms?")
+    print("all pending list", allPendingForms)
     currentUser = require_login()
 
-    allPendingForms = FormHistory.select().order_by(-FormHistory.createdDate)
     downloadType = "allPending"
-    if currentUser.isLaborAdmin:
-        allPendingForms = allPendingForms.where(FormHistory.status.in_(["Pending", "Pre-Student Approval"]))
-    elif currentUser.isFinancialAidAdmin or currentUser.isSaasAdmin:
-        downloadType = "includeOverloads"
-        allPendingForms = allPendingForms.join(OverloadForm).where(FormHistory.status != "Pre-Student Approval", FormHistory.historyType == "Labor Overload Form")
-    else:
-        abort(403)
+    # if currentUser.isLaborAdmin:
+    #     allPendingForms = allPendingForms.where(FormHistory.status.in_(["Pending", "Pre-Student Approval"]))
+    # elif currentUser.isFinancialAidAdmin or currentUser.isSaasAdmin:
+    #     downloadType = "includeOverloads"
+    #     allPendingForms = allPendingForms.join(OverloadForm).where(FormHistory.status != "Pre-Student Approval", FormHistory.historyType == "Labor Overload Form")
+    # else:
+    #     abort(403)
 
     excel = CSVMaker(downloadType, allPendingForms)
     return send_file(excel.relativePath, as_attachment=True, attachment_filename=excel.relativePath.split('/').pop())

--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -1,4 +1,4 @@
-from flask import flash, send_file, json, jsonify, redirect, url_for, abort
+from flask import abort, flash, jsonify, redirect, session, send_file
 from peewee import JOIN
 from app.login_manager import *
 from app.controllers.admin_routes import admin
@@ -16,7 +16,6 @@ from app.models.term import Term
 from app.logic.banner import Banner
 from app.logic.tracy import Tracy
 from datetime import datetime, date
-from flask import Flask, redirect, url_for, flash
 from app.models.Tracy.stuposn import STUPOSN
 from app.models.supervisor import Supervisor
 from app.models.historyType import HistoryType
@@ -140,7 +139,7 @@ def allPendingForms(formType):
                 baseQuery = baseQuery.where(FormHistory.status == "Pending", FormHistory.historyType == historyType)
 
         formList = baseQuery.order_by(-FormHistory.createdDate).distinct()
-
+        session['formIds'] = [form.formHistoryID for form in formList]      # storing the form id's in a session instead of global variable for safety and consistency.
         # only if a form is adjusted
         pendingOverloadFormPairs = {}
         # or allForms.adjustedForm.fieldAdjusted == "Weekly Hours":
@@ -208,11 +207,10 @@ def checkAdjustment(allForms):
 
 @admin.route('/admin/pendingForms/download', methods=['POST'])
 def downloadAllPendingForms():
-    allPendingFormsSelectObject = request.form.get('formList')
+    formIds = session.get('formIds') # add some simple exception logic here.
+    allPendingFormsSelectObject = FormHistory.select().where(FormHistory.formHistoryID.in_(formIds))
     print(allPendingFormsSelectObject, type(allPendingFormsSelectObject), "the-type")
-    allPendingForms = allPendingFormsSelectObject.order_by(-FormHistory.createdDate)
-    print(allPendingForms, "some bs forms?")
-    print("all pending list", allPendingForms)
+    # allPendingForms = allPendingFormsSelectObject.order_by(-FormHistory.createdDate)
     currentUser = require_login()
 
     downloadType = "allPending"
@@ -224,7 +222,7 @@ def downloadAllPendingForms():
     # else:
     #     abort(403)
 
-    excel = CSVMaker(downloadType, allPendingForms)
+    excel = CSVMaker(downloadType, allPendingFormsSelectObject)
     return send_file(excel.relativePath, as_attachment=True, attachment_filename=excel.relativePath.split('/').pop())
 
 @admin.route('/admin/checkedForms', methods=['POST'])

--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -175,7 +175,6 @@ def allPendingForms(formType):
             pendingOverloadFormPairs = pendingOverloadFormPairs
         ))
         if formIds:
-            print(f"downloadName_{cookieId}", f"formIds_{cookieId}", cookieId, "it shoudl all be hereeeee")
             result.set_cookie(
                 key=f'downloadName_{cookieId}',
                 value=pageTitle,

--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -73,32 +73,32 @@ def allPendingForms(formType):
         if formType == "pendingLabor":
             historyType = "Labor Status Form"
             approvalTarget = "denyLaborStatusFormsModal"
-            pageTitle = "Pending Labor Status Forms"
+            pageTitle = session[f'downloadName_{sessionId}'] = "Pending Labor Status Forms"
 
         elif formType == "pendingAdjustment":
             historyType = "Labor Adjustment Form"
             approvalTarget = "denyAdjustedFormsModal"
-            pageTitle = "Pending Adjustment Forms"
+            pageTitle = session[f'downloadName_{sessionId}'] = "Pending Adjustment Forms"
 
         elif formType == "pendingOverload":
             historyType = "Labor Overload Form"
             approvalTarget = "denyOverloadFormsModal"
-            pageTitle = "Pending Overload Forms"
+            pageTitle = session[f'downloadName_{sessionId}'] = "Pending Overload Forms"
 
         elif formType == "pendingRelease":
             historyType = "Labor Release Form"
             approvalTarget = "denyReleaseformSModal"
-            pageTitle = "Pending Release Forms"
+            pageTitle = session[f'downloadName_{sessionId}'] = "Pending Release Forms"
 
         elif formType == "completedOverload":
             historyType = "Labor Overload Form"
             approvalTarget = ""
-            pageTitle = "Approved Overload Forms"
+            pageTitle = session[f'downloadName_{sessionId}'] = "Approved Overload Forms"
 
         elif formType == "preStudentApproval":
             historyType = "Labor Status Form"
             approvalTarget = ""
-            pageTitle = "Pre-Student Approval"
+            pageTitle = session[f'downloadName_{sessionId}'] = "Pre-Student Approval"
             
 
         # We are adding all of these joins so we don't do 10 queries later for every form
@@ -219,27 +219,28 @@ def downloadAllPendingForms():
         return render_template('errors/500.html'), 500
     
     formIds = session.get(f'formIds_{sessionId}')
+    downloadName = session.get(f'downloadName_{sessionId}')
     if not sessionId:
         print(f"[ERROR] Missing session ID for request to {request.path}. Possible tampered form or expired session.")
         return render_template('errors/500.html'), 500
     
     allPendingFormsSelectObject = FormHistory.select().where(FormHistory.formHistoryID.in_(formIds)).order_by(-FormHistory.createdDate)
-    # allPendingForms = allPendingFormsSelectObject.order_by(-FormHistory.createdDate)
     currentUser = require_login()
 
-    downloadType = "allPending"
-    # if currentUser.isLaborAdmin:
-    #     allPendingForms = allPendingForms.where(FormHistory.status.in_(["Pending", "Pre-Student Approval"]))
-    # elif currentUser.isFinancialAidAdmin or currentUser.isSaasAdmin:
-    #     downloadType = "includeOverloads"
-    #     allPendingForms = allPendingForms.join(OverloadForm).where(FormHistory.status != "Pre-Student Approval", FormHistory.historyType == "Labor Overload Form")
-    # else:
-    #     abort(403)
+    additionalSpreadsheetFields = []
+    if currentUser.isFinancialAidAdmin or currentUser.isSaasAdmin:
+        additionalSpreadsheetFields.append("overloads")
+    elif not currentUser.isLaborAdmin:
+        abort(403)
 
     # from what it looks like, the downloadType + ModelSelect object just recreate what's on the page
     
+    excel = CSVMaker(
+        downloadName, 
+        requestedLSFs = allPendingFormsSelectObject, 
+        additionalSpreadsheetFields=additionalSpreadsheetFields
+    )
 
-    excel = CSVMaker(downloadType, allPendingFormsSelectObject)
     return send_file(excel.relativePath, as_attachment=True, attachment_filename=excel.relativePath.split('/').pop())
 
 @admin.route('/admin/checkedForms', methods=['POST'])

--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -1,5 +1,6 @@
-from flask import abort, flash, jsonify, redirect, session, send_file
+from flask import abort, flash, jsonify, redirect, send_file, make_response
 import uuid
+import json
 from peewee import JOIN
 from app.login_manager import *
 from app.controllers.admin_routes import admin
@@ -27,12 +28,7 @@ from app.controllers.main_routes.download import CSVMaker
 @admin.route('/admin/pendingForms/<formType>',  methods=['GET'])
 def allPendingForms(formType):
     try:
-        # if the user has multiple tabs open, session data will continually overwrite
-        # itself. unique identifiers are required.
-
-        sessionId = str(uuid.uuid4())
-        session[f'formType_{sessionId}'] = formType
-
+        cookieId = str(uuid.uuid4())
         currentUser = require_login()
         if not currentUser:                    # Not logged in
             return render_template('errors/403.html'), 403
@@ -73,33 +69,34 @@ def allPendingForms(formType):
         if formType == "pendingLabor":
             historyType = "Labor Status Form"
             approvalTarget = "denyLaborStatusFormsModal"
-            pageTitle = session[f'downloadName_{sessionId}'] = "Pending Labor Status Forms"
+            pageTitle = "Pending Labor Status Forms"
 
         elif formType == "pendingAdjustment":
             historyType = "Labor Adjustment Form"
             approvalTarget = "denyAdjustedFormsModal"
-            pageTitle = session[f'downloadName_{sessionId}'] = "Pending Adjustment Forms"
+            pageTitle = "Pending Adjustment Forms"
 
         elif formType == "pendingOverload":
             historyType = "Labor Overload Form"
             approvalTarget = "denyOverloadFormsModal"
-            pageTitle = session[f'downloadName_{sessionId}'] = "Pending Overload Forms"
+            pageTitle = "Pending Overload Forms"
 
         elif formType == "pendingRelease":
             historyType = "Labor Release Form"
             approvalTarget = "denyReleaseformSModal"
-            pageTitle = session[f'downloadName_{sessionId}'] = "Pending Release Forms"
+            pageTitle = "Pending Release Forms"
 
         elif formType == "completedOverload":
             historyType = "Labor Overload Form"
             approvalTarget = ""
-            pageTitle = session[f'downloadName_{sessionId}'] = "Approved Overload Forms"
+            pageTitle = "Approved Overload Forms"
 
         elif formType == "preStudentApproval":
             historyType = "Labor Status Form"
             approvalTarget = ""
-            pageTitle = session[f'downloadName_{sessionId}'] = "Pre-Student Approval"
+            pageTitle = "Pre-Student Approval"
             
+
 
         # We are adding all of these joins so we don't do 10 queries later for every form
         CreatorSup = Supervisor.alias()
@@ -144,7 +141,7 @@ def allPendingForms(formType):
                 baseQuery = baseQuery.where(FormHistory.status == "Pending", FormHistory.historyType == historyType)
 
         formList = baseQuery.order_by(-FormHistory.createdDate).distinct()
-        session[f'formIds_{sessionId}'] = [form.formHistoryID for form in formList]      # storing the form id's in the current session for safety and consistency.
+        formIds = [form.formHistoryID for form in formList]
         # only if a form is adjusted
         pendingOverloadFormPairs = {}
         # or allForms.adjustedForm.fieldAdjusted == "Weekly Hours":
@@ -160,21 +157,45 @@ def allPendingForms(formType):
                     print(e)
 
             checkAdjustment(allForms)
-        return render_template( 'admin/allPendingForms.html',
-                                title=pageTitle,
-                                username=currentUser.username,
-                                sessionId=sessionId,
-                                formList = formList,
-                                formType= formType,
-                                modalTarget = approvalTarget,
-                                overloadFormCounter = overloadFormCounter,
-                                laborStatusFormCounter = laborStatusFormCounter,
-                                adjustedFormCounter  = adjustedFormCounter,
-                                releaseFormCounter = releaseFormCounter,
-                                preStudentApprovalCounter = preStudentApprovalCounter,
-                                completedOverloadFormCounter = completedOverloadFormCounter,
-                                pendingOverloadFormPairs = pendingOverloadFormPairs
-                              )
+        result = make_response(render_template(
+            'admin/allPendingForms.html',
+            title=pageTitle,
+            username=currentUser.username,
+            cookieId=cookieId,
+            pageTitle=pageTitle,
+            formList = formList,
+            formType= formType,
+            modalTarget = approvalTarget,
+            overloadFormCounter = overloadFormCounter,
+            laborStatusFormCounter = laborStatusFormCounter,
+            adjustedFormCounter  = adjustedFormCounter,
+            releaseFormCounter = releaseFormCounter,
+            preStudentApprovalCounter = preStudentApprovalCounter,
+            completedOverloadFormCounter = completedOverloadFormCounter,
+            pendingOverloadFormPairs = pendingOverloadFormPairs
+        ))
+        if formIds:
+            print(f"downloadName_{cookieId}", f"formIds_{cookieId}", cookieId, "it shoudl all be hereeeee")
+            result.set_cookie(
+                key=f'downloadName_{cookieId}',
+                value=pageTitle,
+                max_age=3600,
+                httponly=True,
+            )
+            result.set_cookie(
+                key=f'formIds_{cookieId}',
+                value=json.dumps(formIds),
+                max_age=3600,
+                httponly=True,
+            )
+            result.set_cookie(
+                key=f'formType_{cookieId}',
+                value=formType,
+                max_age=3600,
+                httponly=True,
+            )
+        return result
+    
     except Exception as e:
         print("Error Loading all Pending Forms:", e)
         return render_template('errors/500.html'), 500
@@ -213,15 +234,15 @@ def checkAdjustment(allForms):
 
 @admin.route('/admin/pendingForms/download', methods=['POST'])
 def downloadAllPendingForms():
-    sessionId = request.form.get('sessionId')
-    if not sessionId:
-        print("session id not found.")
+    cookieId = request.form.get('cookieId')
+    if not cookieId:
+        print(f"[ERROR] Missing cookie for request to {request.path}. Possible tampered or expired cookie.")
         return render_template('errors/500.html'), 500
     
-    formIds = session.get(f'formIds_{sessionId}')
-    downloadName = session.get(f'downloadName_{sessionId}')
-    if not sessionId:
-        print(f"[ERROR] Missing session ID for request to {request.path}. Possible tampered form or expired session.")
+    formIds = json.loads(request.cookies.get(f'formIds_{cookieId}'))
+    downloadName = request.cookies.get(f'downloadName_{cookieId}')
+    if not formIds:
+        print(f"[ERROR] Missing forms for download. There are either no results to be downloaded or another error has occured.")
         return render_template('errors/500.html'), 500
     
     allPendingFormsSelectObject = FormHistory.select().where(FormHistory.formHistoryID.in_(formIds)).order_by(-FormHistory.createdDate)
@@ -232,8 +253,6 @@ def downloadAllPendingForms():
         additionalSpreadsheetFields.append("overloads")
     elif not currentUser.isLaborAdmin:
         abort(403)
-
-    # from what it looks like, the downloadType + ModelSelect object just recreate what's on the page
     
     excel = CSVMaker(
         downloadName, 
@@ -537,10 +556,10 @@ def getOverloadModalData(formHistoryID):
                             'FinancialAidApprover': FinancialAidApprover,
                             })
         noteTotal = Notes.select().where(Notes.formID == historyForm[0].formID.laborStatusFormID).count()
-        sessionId = request.args.get('sessionId')
+        cookieId = request.args.get('cookieId')
         returnToTab = None
         try:
-            returnToTab = session.get(f'formType_{sessionId}')
+            returnToTab = request.cookies.get(f'formType_{cookieId}')
         except Exception as e:
             pass
         return render_template('snips/pendingOverloadModal.html',

--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -1,4 +1,5 @@
 from flask import abort, flash, jsonify, redirect, session, send_file
+import uuid
 from peewee import JOIN
 from app.login_manager import *
 from app.controllers.admin_routes import admin
@@ -26,8 +27,12 @@ from app.controllers.main_routes.download import CSVMaker
 @admin.route('/admin/pendingForms/<formType>',  methods=['GET'])
 def allPendingForms(formType):
     try:
-        global globalFormType
-        globalFormType = formType
+        # if the user has multiple tabs open, session data will continually overwrite
+        # itself. unique identifiers are required.
+
+        sessionId = str(uuid.uuid4())
+        session[f'formType_{sessionId}'] = formType
+
         currentUser = require_login()
         if not currentUser:                    # Not logged in
             return render_template('errors/403.html'), 403
@@ -139,7 +144,7 @@ def allPendingForms(formType):
                 baseQuery = baseQuery.where(FormHistory.status == "Pending", FormHistory.historyType == historyType)
 
         formList = baseQuery.order_by(-FormHistory.createdDate).distinct()
-        session['formIds'] = [form.formHistoryID for form in formList]      # storing the form id's in a session instead of global variable for safety and consistency.
+        session[f'formIds_{sessionId}'] = [form.formHistoryID for form in formList]      # storing the form id's in the current session for safety and consistency.
         # only if a form is adjusted
         pendingOverloadFormPairs = {}
         # or allForms.adjustedForm.fieldAdjusted == "Weekly Hours":
@@ -158,6 +163,7 @@ def allPendingForms(formType):
         return render_template( 'admin/allPendingForms.html',
                                 title=pageTitle,
                                 username=currentUser.username,
+                                sessionId=sessionId,
                                 formList = formList,
                                 formType= formType,
                                 modalTarget = approvalTarget,
@@ -207,9 +213,17 @@ def checkAdjustment(allForms):
 
 @admin.route('/admin/pendingForms/download', methods=['POST'])
 def downloadAllPendingForms():
-    formIds = session.get('formIds') # add some simple exception logic here.
-    allPendingFormsSelectObject = FormHistory.select().where(FormHistory.formHistoryID.in_(formIds))
-    print(allPendingFormsSelectObject, type(allPendingFormsSelectObject), "the-type")
+    sessionId = request.form.get('sessionId')
+    if not sessionId:
+        print("session id not found.")
+        return render_template('errors/500.html'), 500
+    
+    formIds = session.get(f'formIds_{sessionId}')
+    if not sessionId:
+        print(f"[ERROR] Missing session ID for request to {request.path}. Possible tampered form or expired session.")
+        return render_template('errors/500.html'), 500
+    
+    allPendingFormsSelectObject = FormHistory.select().where(FormHistory.formHistoryID.in_(formIds)).order_by(-FormHistory.createdDate)
     # allPendingForms = allPendingFormsSelectObject.order_by(-FormHistory.createdDate)
     currentUser = require_login()
 
@@ -221,6 +235,9 @@ def downloadAllPendingForms():
     #     allPendingForms = allPendingForms.join(OverloadForm).where(FormHistory.status != "Pre-Student Approval", FormHistory.historyType == "Labor Overload Form")
     # else:
     #     abort(403)
+
+    # from what it looks like, the downloadType + ModelSelect object just recreate what's on the page
+    
 
     excel = CSVMaker(downloadType, allPendingFormsSelectObject)
     return send_file(excel.relativePath, as_attachment=True, attachment_filename=excel.relativePath.split('/').pop())
@@ -519,9 +536,10 @@ def getOverloadModalData(formHistoryID):
                             'FinancialAidApprover': FinancialAidApprover,
                             })
         noteTotal = Notes.select().where(Notes.formID == historyForm[0].formID.laborStatusFormID).count()
+        sessionId = request.args.get('sessionId')
         returnToTab = None
         try:
-            returnToTab = globalFormType
+            returnToTab = session.get(f'formType_{sessionId}')
         except Exception as e:
             pass
         return render_template('snips/pendingOverloadModal.html',

--- a/app/controllers/main_routes/download.py
+++ b/app/controllers/main_routes/download.py
@@ -39,7 +39,6 @@ class CSVMaker:
                 studentFormHistories = FormHistory.select().where(FormHistory.formID == statusForm)
             elif self.downloadType == "studentList":
                 studentFormHistories = FormHistory.select().where(FormHistory.formID == statusForm, FormHistory.historyType == 'Labor Status Form')
-                print(studentFormHistories, "???", statusForm)
             elif self.downloadType == "allPending":
                 studentFormHistories = FormHistory.select().where(FormHistory.formID == statusForm, FormHistory.status.in_(["Pending", "Pre-Student Approval"]))
             elif self.downloadType == "includeOverride":
@@ -131,7 +130,6 @@ class CSVMaker:
                     row = self.addOverloadData(form, row)
                     self.filewriter.writerow(row)
                 else:
-                    print(form, "the-download")
                     self.filewriter.writerow(row)
 
 

--- a/app/controllers/main_routes/download.py
+++ b/app/controllers/main_routes/download.py
@@ -13,7 +13,7 @@ class CSVMaker:
         self.relativePath = 'static/files/LaborStudents.csv'
         self.completePath = 'app/' + self.relativePath
         self.downloadType = self._verifyDownloadType(downloadType)
-        self.formHistories = self.retrieveFormHistories(requestedLSFs)
+        self.formHistories = requestedLSFs      # probably should change this name since its a FormHistory object not an LSF
         self.includeEvals = includeEvals
 
         self.makeCSV()
@@ -39,6 +39,7 @@ class CSVMaker:
                 studentFormHistories = FormHistory.select().where(FormHistory.formID == statusForm)
             elif self.downloadType == "studentList":
                 studentFormHistories = FormHistory.select().where(FormHistory.formID == statusForm, FormHistory.historyType == 'Labor Status Form')
+                print(studentFormHistories, "???", statusForm)
             elif self.downloadType == "allPending":
                 studentFormHistories = FormHistory.select().where(FormHistory.formID == statusForm, FormHistory.status.in_(["Pending", "Pre-Student Approval"]))
             elif self.downloadType == "includeOverride":
@@ -130,6 +131,7 @@ class CSVMaker:
                     row = self.addOverloadData(form, row)
                     self.filewriter.writerow(row)
                 else:
+                    print(form, "the-download")
                     self.filewriter.writerow(row)
 
 

--- a/app/controllers/main_routes/download.py
+++ b/app/controllers/main_routes/download.py
@@ -1,54 +1,27 @@
-from enum import Enum
+from peewee import ModelSelect
 from app.models.formHistory import *
 import csv
 from app.controllers.main_routes.main_routes import *
-from app.models.formHistory import FormHistory
 from app.models.studentLaborEvaluation import StudentLaborEvaluation
 
 class CSVMaker:
     '''
     Create the CSV for the download bottons
     '''
-    def __init__(self, downloadType, requestedLSFs, includeEvals = False):
-        self.relativePath = 'static/files/LaborStudents.csv'
+    def __init__(self, downloadName, requestedLSFs: ModelSelect, includeEvals = False, additionalSpreadsheetFields: list[str] = []):
+        self.relativePath = f'static/files/{downloadName}.csv'
         self.completePath = 'app/' + self.relativePath
-        self.downloadType = self._verifyDownloadType(downloadType)
-        self.formHistories = requestedLSFs      # probably should change this name since its a FormHistory object not an LSF
+        self.additionalSpreadsheetFields = (self._validateAdditionalSpreadsheetFields(additionalSpreadsheetFields))
+        self.formHistories = requestedLSFs 
         self.includeEvals = includeEvals
-
         self.makeCSV()
-
-    @staticmethod
-    def _verifyDownloadType(downloadType):
-        if downloadType not in {'studentHistory', 'studentList', 'allPending'}:
-            raise ValueError(f'Invalid download type: {downloadType}')
-        return downloadType
         
-
-    def retrieveFormHistories(self, requestedLSFs):
-        '''
-        Removes any duplicate formHistory IDs
-        '''
-
-        allForms = list(set(requestedLSFs)) # remove duplicates
-        allFormHistories = []
-
-        for statusForm in allForms:
-            studentFormHistories = []
-            if self.downloadType == "studentHistory":
-                studentFormHistories = FormHistory.select().where(FormHistory.formID == statusForm)
-            elif self.downloadType == "studentList":
-                studentFormHistories = FormHistory.select().where(FormHistory.formID == statusForm, FormHistory.historyType == 'Labor Status Form')
-            elif self.downloadType == "allPending":
-                studentFormHistories = FormHistory.select().where(FormHistory.formID == statusForm, FormHistory.status.in_(["Pending", "Pre-Student Approval"]))
-            elif self.downloadType == "includeOverride":
-                studentFormHistories = FormHistory.select().join(OverloadForm).where(FormHistory.formID == statusForm, FormHistory.status != "Pre-Student Approval", FormHistory.historyType == "Labor Overload Form")
-
-            for historyForm in studentFormHistories:
-                allFormHistories.append(historyForm)
-
-        return allFormHistories
-
+    @staticmethod
+    def _validateAdditionalSpreadsheetFields(additionalFields):
+        for additionalField in additionalFields:
+            if additionalField not in {'overloads', 'finalEvaluations', 'midYearEvaluations', 'allEvaluations'}:
+                raise ValueError(f'Invalid spreadsheet fields: {additionalField}')
+        return additionalFields
 
     def makeCSV(self):
         '''
@@ -95,7 +68,7 @@ class CSVMaker:
                                 'SLE Overall Score'
                                 ])
             
-            if self.downloadType == 'includeOverloads':
+            if 'overloads' in self.additionalSpreadsheetFields:
                 headers.extend(['Student Overload Reason',
                                 'Financial Aid Status',
                                 'Financial Aid Approver',
@@ -126,7 +99,7 @@ class CSVMaker:
                             row.extend(evaluation)
                             self.filewriter.writerow(row)
 
-                elif self.downloadType == "includeOverloads":
+                elif 'overloads' in self.additionalSpreadsheetFields:
                     row = self.addOverloadData(form, row)
                     self.filewriter.writerow(row)
                 else:
@@ -185,11 +158,11 @@ class CSVMaker:
         Adds data for SLE
         '''
         multipleRows = []
-        if self.includeEvals == "Final":
+        if "finalEvaluations" in self.additionalSpreadsheetFields:
             finalEvaluation = StudentLaborEvaluation.get_or_none(StudentLaborEvaluation.formHistoryID == formID, StudentLaborEvaluation.is_midyear_evaluation == 0, StudentLaborEvaluation.is_submitted == True)
             if finalEvaluation:
                 multipleRows.append(self.insertEvaluationData(finalEvaluation, "Final"))
-        elif self.includeEvals == "Midyear":
+        elif "midYearEvaluations" in self.additionalSpreadsheetFields:
             midyearEvaluation = StudentLaborEvaluation.get_or_none(StudentLaborEvaluation.formHistoryID == formID, StudentLaborEvaluation.is_midyear_evaluation == 1, StudentLaborEvaluation.is_submitted == True)
             if midyearEvaluation:
                 multipleRows.append(self.insertEvaluationData(midyearEvaluation, "Midyear"))

--- a/app/controllers/main_routes/download.py
+++ b/app/controllers/main_routes/download.py
@@ -1,13 +1,9 @@
-from flask import flash
-from app.models.laborStatusForm import LaborStatusForm
+from enum import Enum
 from app.models.formHistory import *
 import csv
 from app.controllers.main_routes.main_routes import *
-from app.models.supervisor import Supervisor
-from app.logic.tracy import Tracy
 from app.models.formHistory import FormHistory
 from app.models.studentLaborEvaluation import StudentLaborEvaluation
-
 
 class CSVMaker:
     '''
@@ -16,12 +12,18 @@ class CSVMaker:
     def __init__(self, downloadType, requestedLSFs, includeEvals = False):
         self.relativePath = 'static/files/LaborStudents.csv'
         self.completePath = 'app/' + self.relativePath
-        self.downloadType = downloadType          #studentHistory, allPending, studentList
+        self.downloadType = self._verifyDownloadType(downloadType)
         self.formHistories = self.retrieveFormHistories(requestedLSFs)
         self.includeEvals = includeEvals
 
         self.makeCSV()
 
+    @staticmethod
+    def _verifyDownloadType(downloadType):
+        if downloadType not in {'studentHistory', 'studentList', 'allPending'}:
+            raise ValueError(f'Invalid download type: {downloadType}')
+        return downloadType
+        
 
     def retrieveFormHistories(self, requestedLSFs):
         '''
@@ -37,6 +39,10 @@ class CSVMaker:
                 studentFormHistories = FormHistory.select().where(FormHistory.formID == statusForm)
             elif self.downloadType == "studentList":
                 studentFormHistories = FormHistory.select().where(FormHistory.formID == statusForm, FormHistory.historyType == 'Labor Status Form')
+            elif self.downloadType == "allPending":
+                studentFormHistories = FormHistory.select().where(FormHistory.formID == statusForm, FormHistory.status.in_(["Pending", "Pre-Student Approval"]))
+            elif self.downloadType == "includeOverride":
+                studentFormHistories = FormHistory.select().join(OverloadForm).where(FormHistory.formID == statusForm, FormHistory.status != "Pre-Student Approval", FormHistory.historyType == "Labor Overload Form")
 
             for historyForm in studentFormHistories:
                 allFormHistories.append(historyForm)

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -311,20 +311,26 @@ def downloadSupervisorPortalResults():
     generate a CSV file of datatable data.
     '''
     sessionId = request.form.get('sessionId')
-    print("blaaaa", sessionId)
+    additionalSpreadsheetFields = []
+    includeEvals = False
     if not sessionId:
         pass    # add the fail flash here
     sleJoin = session.get(f'sleJoin_{sessionId}')
     if sleJoin == "evalComplete":
-        includeEvals = "Final"
+        additionalSpreadsheetFields = ["finalEvaluations"]
+        includeEvals = True
     elif sleJoin == "evalMidyearComplete":
-        includeEvals = "Midyear"
-    else:
-        includeEvals = False
+        additionalSpreadsheetFields = ["midYearEvaluations"]
+        includeEvals = True
 
     formSearchResultIds = session[f'formSearchResultIds_{sessionId}']
     if not formSearchResultIds:
         pass        # add another fail flash if it makes it this far
     formSearchResultsSelectObject = FormHistory.select().where(FormHistory.formHistoryID.in_(formSearchResultIds)).order_by(-FormHistory.createdDate)
-    excel = CSVMaker("studentList", formSearchResultsSelectObject, includeEvals = includeEvals)
+    excel = CSVMaker(
+        "LSF Search",
+        requestedLSFs=formSearchResultsSelectObject, 
+        additionalSpreadsheetFields=additionalSpreadsheetFields,
+        includeEvals=includeEvals
+    )
     return send_file(excel.relativePath, as_attachment=True, attachment_filename=excel.relativePath.split('/').pop())

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -2,6 +2,7 @@ import operator
 from flask import render_template, request, json, jsonify, redirect, url_for, send_file, flash, g, session
 from functools import reduce
 from peewee import fn
+import uuid
 from datetime import datetime
 from app.models.term import Term
 from app.models.department import Department
@@ -88,6 +89,7 @@ def getDatatableData(request):
     # 'draw', 'start', 'length', 'order[0][column]', 'order[0][dir]' are built-in parameters, i.e.,
     # they are implicitly passed as part of the AJAX request when using datatable server-side processing
     
+    sessionId = str(uuid.uuid4())
     currentUser = require_login()
     draw = int(request.form.get('draw', 0))
     rowNumber = int(request.form.get('start', 0))
@@ -127,7 +129,7 @@ def getDatatableData(request):
             if type(value) is list:
                 clauses.append(field.in_(value))
             elif field is StudentLaborEvaluation.ID:
-                session['sleJoin'] = value[0]       # use the session to store the sle??
+                session[f'sleJoin_{sessionId}'] = value[0]       # use the session to store the sle??
             else:
                 clauses.append(field == value)
     # This expression creates SQL AND operator between the conditions added to 'clauses' list
@@ -143,7 +145,7 @@ def getDatatableData(request):
     if not currentUser.isLaborAdmin:
         supervisorDepartments = [d.departmentID for d in getDepartmentsForSupervisor(currentUser)]
         formSearchResults = formSearchResults.where(FormHistory.formID.department.in_(supervisorDepartments)) 
-    session['formSearchResultIds'] = [formSearchResult.formHistoryID for formSearchResult in formSearchResults]
+    session[f'formSearchResultIds_{sessionId}'] = [formSearchResult.formHistoryID for formSearchResult in formSearchResults]
     recordsTotal = len(formSearchResults)
 
     # this checks and finds the first value that is not null of preferred_name, legal_name and last_name.
@@ -176,7 +178,7 @@ def getDatatableData(request):
     else:
         filteredSearchResults = formSearchResults.order_by(fn.TRIM(sortValueColumnMap[sortBy]).asc()).limit(rowsPerPage).offset(rowNumber)
     formattedData = getFormattedData(filteredSearchResults, queryFilterDict.get('view'))
-    formsDict = {"draw": draw, "recordsTotal": recordsTotal, "recordsFiltered": recordsTotal, "data": formattedData}
+    formsDict = {"draw": draw, "recordsTotal": recordsTotal, "recordsFiltered": recordsTotal, "data": formattedData, "sessionId": sessionId}
 
     return jsonify(formsDict)
 
@@ -308,8 +310,11 @@ def downloadSupervisorPortalResults():
     This function uses the general search results, stored in a global variable, to
     generate a CSV file of datatable data.
     '''
-
-    sleJoin = session.get('sleJoin')
+    sessionId = request.form.get('sessionId')
+    print("blaaaa", sessionId)
+    if not sessionId:
+        pass    # add the fail flash here
+    sleJoin = session.get(f'sleJoin_{sessionId}')
     if sleJoin == "evalComplete":
         includeEvals = "Final"
     elif sleJoin == "evalMidyearComplete":
@@ -317,7 +322,9 @@ def downloadSupervisorPortalResults():
     else:
         includeEvals = False
 
-    formSearchResultIds = session['formSearchResultIds']
+    formSearchResultIds = session[f'formSearchResultIds_{sessionId}']
+    if not formSearchResultIds:
+        pass        # add another fail flash if it makes it this far
     formSearchResultsSelectObject = FormHistory.select().where(FormHistory.formHistoryID.in_(formSearchResultIds)).order_by(-FormHistory.createdDate)
     excel = CSVMaker("studentList", formSearchResultsSelectObject, includeEvals = includeEvals)
     return send_file(excel.relativePath, as_attachment=True, attachment_filename=excel.relativePath.split('/').pop())

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -1,5 +1,5 @@
 import operator
-from flask import render_template, request, json, jsonify, redirect, url_for, send_file, flash, g, make_response
+from flask import render_template, request, json, jsonify, redirect, url_for, send_file, g, make_response
 from functools import reduce
 from peewee import fn
 import uuid
@@ -183,7 +183,6 @@ def getDatatableData(request):
     result = make_response(jsonify(formsDict))
     formIds = [formSearchResult.formHistoryID for formSearchResult in formSearchResults]
     if formIds:
-        print("Okay, here", f"formSearchResultIds_{cookieId}", "what is going on?")
         jsonFormIds = json.dumps(formIds)
         result.set_cookie(
             key=f'formSearchResultIds_{cookieId}',

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -336,5 +336,5 @@ def downloadSupervisorPortalResults():
         includeEvals = False
 
     formSearchResults = formSearchResults.order_by(-FormHistory.createdDate)
-    excel = CSVMaker("supervisorPortal", formSearchResults, includeEvals = includeEvals)
+    excel = CSVMaker("studentList", formSearchResults, includeEvals = includeEvals)
     return send_file(excel.relativePath, as_attachment=True, attachment_filename=excel.relativePath.split('/').pop())

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -145,8 +145,10 @@ def getDatatableData(request):
     if not currentUser.isLaborAdmin:
         supervisorDepartments = [d.departmentID for d in getDepartmentsForSupervisor(currentUser)]
         formSearchResults = formSearchResults.where(FormHistory.formID.department.in_(supervisorDepartments)) 
-    session[f'formSearchResultIds_{sessionId}'] = [formSearchResult.formHistoryID for formSearchResult in formSearchResults]
     recordsTotal = len(formSearchResults)
+    if len(formSearchResults):
+        session[f'formSearchResultIds_{sessionId}'] = [formSearchResult.formHistoryID for formSearchResult in formSearchResults]
+
 
     # this checks and finds the first value that is not null of preferred_name, legal_name and last_name.
     # including last_name is necessary because there are like 4 cases where someone has no first name or last name, instead their full name is
@@ -314,7 +316,8 @@ def downloadSupervisorPortalResults():
     additionalSpreadsheetFields = []
     includeEvals = False
     if not sessionId:
-        pass    # add the fail flash here
+        print(f"[ERROR] Missing session ID for request to {request.path}.")
+        return "", 500
     sleJoin = session.get(f'sleJoin_{sessionId}')
     if sleJoin == "evalComplete":
         additionalSpreadsheetFields = ["finalEvaluations"]
@@ -323,9 +326,10 @@ def downloadSupervisorPortalResults():
         additionalSpreadsheetFields = ["midYearEvaluations"]
         includeEvals = True
 
-    formSearchResultIds = session[f'formSearchResultIds_{sessionId}']
+    formSearchResultIds = session.get(f'formSearchResultIds_{sessionId}')
     if not formSearchResultIds:
-        pass        # add another fail flash if it makes it this far
+        print(f"[ERROR] The key, formSearchResultIds_{sessionId}, does not exist in the session dictionary.")
+        return "", 500
     formSearchResultsSelectObject = FormHistory.select().where(FormHistory.formHistoryID.in_(formSearchResultIds)).order_by(-FormHistory.createdDate)
     excel = CSVMaker(
         "LSF Search",

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -1,8 +1,7 @@
-import sys
 import operator
-from flask import render_template, request, json, jsonify, redirect, url_for, send_file, flash, g
+from flask import render_template, request, json, jsonify, redirect, url_for, send_file, flash, g, session
 from functools import reduce
-from peewee import fn, Case
+from peewee import fn
 from datetime import datetime
 from app.models.term import Term
 from app.models.department import Department
@@ -11,8 +10,6 @@ from app.models.supervisorDepartment import SupervisorDepartment
 from app.models.student import Student
 from app.models.laborStatusForm import LaborStatusForm
 from app.models.formHistory import FormHistory
-from app.models.historyType import HistoryType
-from app.models.status import Status
 from app.models.user import User
 from app.models.studentLaborEvaluation import StudentLaborEvaluation
 from app.controllers.admin_routes.allPendingForms import checkAdjustment
@@ -22,18 +19,9 @@ from app.logic.search import getDepartmentsForSupervisor
 from app.login_manager import require_login, logout
 
 
-@main_bp.before_app_request
-def before_request():
-    pass # TODO Do we need to do anything here? User stuff?
-
 @main_bp.route('/logout', methods=['GET'])
 def logout():
     return redirect(logout())
-
-# Global variable that will store the query result.
-# It is made global to be used later in creating CSV file.
-formSearchResults = None
-sleJoin = False
 
 @main_bp.route('/', methods=['GET', 'POST'])
 def supervisorPortal():
@@ -99,9 +87,6 @@ def getDatatableData(request):
     '''
     # 'draw', 'start', 'length', 'order[0][column]', 'order[0][dir]' are built-in parameters, i.e.,
     # they are implicitly passed as part of the AJAX request when using datatable server-side processing
-    global sleJoin
-    if sleJoin:
-        sleJoin = False
     
     currentUser = require_login()
     draw = int(request.form.get('draw', 0))
@@ -142,11 +127,10 @@ def getDatatableData(request):
             if type(value) is list:
                 clauses.append(field.in_(value))
             elif field is StudentLaborEvaluation.ID:
-                sleJoin = value[0]       
+                session['sleJoin'] = value[0]       # use the session to store the sle??
             else:
                 clauses.append(field == value)
     # This expression creates SQL AND operator between the conditions added to 'clauses' list
-    global formSearchResults
     formSearchResults = (FormHistory.select()
                                     .join(LaborStatusForm, on=(FormHistory.formID == LaborStatusForm.laborStatusFormID))
                                     .join(Department, on=(LaborStatusForm.department == Department.departmentID))
@@ -159,8 +143,7 @@ def getDatatableData(request):
     if not currentUser.isLaborAdmin:
         supervisorDepartments = [d.departmentID for d in getDepartmentsForSupervisor(currentUser)]
         formSearchResults = formSearchResults.where(FormHistory.formID.department.in_(supervisorDepartments)) 
-
-    print(formSearchResults)
+    session['formSearchResultIds'] = [formSearchResult.formHistoryID for formSearchResult in formSearchResults]
     recordsTotal = len(formSearchResults)
 
     # this checks and finds the first value that is not null of preferred_name, legal_name and last_name.
@@ -326,8 +309,7 @@ def downloadSupervisorPortalResults():
     generate a CSV file of datatable data.
     '''
 
-    global formSearchResults
-    global sleJoin
+    sleJoin = session.get('sleJoin')
     if sleJoin == "evalComplete":
         includeEvals = "Final"
     elif sleJoin == "evalMidyearComplete":
@@ -335,6 +317,7 @@ def downloadSupervisorPortalResults():
     else:
         includeEvals = False
 
-    formSearchResults = formSearchResults.order_by(-FormHistory.createdDate)
-    excel = CSVMaker("studentList", formSearchResults, includeEvals = includeEvals)
+    formSearchResultIds = session['formSearchResultIds']
+    formSearchResultsSelectObject = FormHistory.select().where(FormHistory.formHistoryID.in_(formSearchResultIds)).order_by(-FormHistory.createdDate)
+    excel = CSVMaker("studentList", formSearchResultsSelectObject, includeEvals = includeEvals)
     return send_file(excel.relativePath, as_attachment=True, attachment_filename=excel.relativePath.split('/').pop())

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -1,5 +1,5 @@
 import operator
-from flask import render_template, request, json, jsonify, redirect, url_for, send_file, flash, g, session
+from flask import render_template, request, json, jsonify, redirect, url_for, send_file, flash, g, make_response
 from functools import reduce
 from peewee import fn
 import uuid
@@ -89,7 +89,8 @@ def getDatatableData(request):
     # 'draw', 'start', 'length', 'order[0][column]', 'order[0][dir]' are built-in parameters, i.e.,
     # they are implicitly passed as part of the AJAX request when using datatable server-side processing
     
-    sessionId = str(uuid.uuid4())
+    cookieId = str(uuid.uuid4())
+    sleJoin = ""
     currentUser = require_login()
     draw = int(request.form.get('draw', 0))
     rowNumber = int(request.form.get('start', 0))
@@ -129,7 +130,7 @@ def getDatatableData(request):
             if type(value) is list:
                 clauses.append(field.in_(value))
             elif field is StudentLaborEvaluation.ID:
-                session[f'sleJoin_{sessionId}'] = value[0]       # use the session to store the sle??
+                sleJoin=value[0]
             else:
                 clauses.append(field == value)
     # This expression creates SQL AND operator between the conditions added to 'clauses' list
@@ -146,9 +147,6 @@ def getDatatableData(request):
         supervisorDepartments = [d.departmentID for d in getDepartmentsForSupervisor(currentUser)]
         formSearchResults = formSearchResults.where(FormHistory.formID.department.in_(supervisorDepartments)) 
     recordsTotal = len(formSearchResults)
-    if len(formSearchResults):
-        session[f'formSearchResultIds_{sessionId}'] = [formSearchResult.formHistoryID for formSearchResult in formSearchResults]
-
 
     # this checks and finds the first value that is not null of preferred_name, legal_name and last_name.
     # including last_name is necessary because there are like 4 cases where someone has no first name or last name, instead their full name is
@@ -180,9 +178,27 @@ def getDatatableData(request):
     else:
         filteredSearchResults = formSearchResults.order_by(fn.TRIM(sortValueColumnMap[sortBy]).asc()).limit(rowsPerPage).offset(rowNumber)
     formattedData = getFormattedData(filteredSearchResults, queryFilterDict.get('view'))
-    formsDict = {"draw": draw, "recordsTotal": recordsTotal, "recordsFiltered": recordsTotal, "data": formattedData, "sessionId": sessionId}
+    formsDict = {"draw": draw, "recordsTotal": recordsTotal, "recordsFiltered": recordsTotal, "data": formattedData, "cookieId": cookieId}
 
-    return jsonify(formsDict)
+    result = make_response(jsonify(formsDict))
+    formIds = [formSearchResult.formHistoryID for formSearchResult in formSearchResults]
+    if formIds:
+        print("Okay, here", f"formSearchResultIds_{cookieId}", "what is going on?")
+        jsonFormIds = json.dumps(formIds)
+        result.set_cookie(
+            key=f'formSearchResultIds_{cookieId}',
+            value=jsonFormIds,
+            max_age=3600,
+            httponly=True,
+        )
+        result.set_cookie(
+            key=f'sleJoin_{cookieId}',
+            value=json.dumps(sleJoin),
+            max_age=3600,
+            httponly=True,
+        )
+
+    return result
 
 def getFormattedData(filteredSearchResults, view ='simple'):
     '''
@@ -312,13 +328,13 @@ def downloadSupervisorPortalResults():
     This function uses the general search results, stored in a global variable, to
     generate a CSV file of datatable data.
     '''
-    sessionId = request.form.get('sessionId')
+    cookieId = request.form.get('cookieId')
     additionalSpreadsheetFields = []
     includeEvals = False
-    if not sessionId:
-        print(f"[ERROR] Missing session ID for request to {request.path}.")
+    if not cookieId:
+        print(f"[ERROR] Missing cookie ID for request to {request.path}.")
         return "", 500
-    sleJoin = session.get(f'sleJoin_{sessionId}')
+    sleJoin = request.cookies.get(f'sleJoin_{cookieId}')
     if sleJoin == "evalComplete":
         additionalSpreadsheetFields = ["finalEvaluations"]
         includeEvals = True
@@ -326,9 +342,9 @@ def downloadSupervisorPortalResults():
         additionalSpreadsheetFields = ["midYearEvaluations"]
         includeEvals = True
 
-    formSearchResultIds = session.get(f'formSearchResultIds_{sessionId}')
+    formSearchResultIds = json.loads(request.cookies.get(f'formSearchResultIds_{cookieId}'))
     if not formSearchResultIds:
-        print(f"[ERROR] The key, formSearchResultIds_{sessionId}, does not exist in the session dictionary.")
+        print(f"[ERROR] The cookie formSearchResultIds_{cookieId} does not exist.")
         return "", 500
     formSearchResultsSelectObject = FormHistory.select().where(FormHistory.formHistoryID.in_(formSearchResultIds)).order_by(-FormHistory.createdDate)
     excel = CSVMaker(

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -291,7 +291,7 @@ function fetchSimpleView(data) {
       type: "POST",
       data: { 'data': data },
       dataSrc: function(response) {
-        $('#sessionId').val(response.sessionId);
+        $('#cookieId').val(response.cookieId);
         return response.data;
       }
     }

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -290,7 +290,10 @@ function fetchSimpleView(data) {
       url: "/",
       type: "POST",
       data: { 'data': data },
-      dataSrc: "data",
+      dataSrc: function(response) {
+        $('#sessionId').val(response.sessionId);
+        return response.data;
+      }
     }
   });
 }

--- a/app/templates/admin/allPendingForms.html
+++ b/app/templates/admin/allPendingForms.html
@@ -52,7 +52,7 @@
         {% endif %}
         <li class="pull-right">
             <form method="POST" action="/admin/pendingForms/download">
-              <input type="hidden" name="formList" value="{{ formList }}">
+              <input type="hidden" name="sessionId" value="{{ sessionId }}">
               <button class="btn btn-success" id="download">Download</button>
             </form>
         </li>

--- a/app/templates/admin/allPendingForms.html
+++ b/app/templates/admin/allPendingForms.html
@@ -52,6 +52,7 @@
         {% endif %}
         <li class="pull-right">
             <form method="POST" action="/admin/pendingForms/download">
+              <input type="hidden" name="formList" value="{{ formList }}">
               <button class="btn btn-success" id="download">Download</button>
             </form>
         </li>

--- a/app/templates/admin/allPendingForms.html
+++ b/app/templates/admin/allPendingForms.html
@@ -52,7 +52,7 @@
         {% endif %}
         <li class="pull-right">
             <form method="POST" action="/admin/pendingForms/download">
-              <input type="hidden" name="sessionId" value="{{ sessionId }}">
+              <input type="hidden" name="cookieId" value="{{ cookieId }}">
               <button class="btn btn-success" id="download">Download</button>
             </form>
         </li>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -52,7 +52,7 @@
   </div>
   <div class="" align="right">
     <form method="POST" action="/supervisorPortal/download" style="margin: 0; display: inline;">
-      <input type="hidden" id="sessionId" name="sessionId" value="{{ sessionId }}"> 
+      <input type="hidden" id="cookieId" name="cookieId" value="{{ cookieId }}"> 
       <button class="btn btn-success" type="submit" id="download">Download Results</button>
     </form>
     <button id="switchViewButton" class="btn btn-primary" value="simple">Switch To Advanced View</button>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -52,6 +52,7 @@
   </div>
   <div class="" align="right">
     <form method="POST" action="/supervisorPortal/download" style="margin: 0; display: inline;">
+      <input type="hidden" id="sessionId" name="sessionId" value="{{ sessionId }}"> 
       <button class="btn btn-success" type="submit" id="download">Download Results</button>
     </form>
     <button id="switchViewButton" class="btn btn-primary" value="simple">Switch To Advanced View</button>


### PR DESCRIPTION
Fixes #349 
Fixes #376

Downloads do not work.

What we did:
- Fixed the downloads.
- Replaced global variables (which are not thread-safe and lead to null download errors on page refresh) and replaced them with cookies for better consistency.
- Refactored the CSVMaker module and removed unnecessary DB queries + logic.
- Updated downloads to use better naming conventions, instead of the default "LaborStudents.csv"

To test:
- Pull the branch
- Test Supervisor Portal downloads as a Labor Admin (heggens is a Labor Admin)
- Test downloads with midyear and final evaluations
- Switch to Administration > Pending Forms
- Download as Labor Admin and Financial Admin. Any downloads with Financial Admin should have additional spreadsheet columns.

A good follow-up to this PR should be #484