### PR TITLE
Disable Download Button if Supervisor Portal Returns No Results

### DIFF
--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -100,6 +100,7 @@ $(document).ready(function () {
   if ((document.cookie).includes("lsfSearchResults=")) {
     cookieStr = Cookies.get('lsfSearchResults')
     cookieJSON = JSON.parse(cookieStr)
+
     // using the cookies, make sure the view is properly set as well
     if (cookieJSON.view == 'advanced') {
       createDataTable(cookieStr)
@@ -292,6 +293,7 @@ function fetchSimpleView(data) {
       data: { 'data': data },
       dataSrc: function(response) {
         $('#cookieId').val(response.cookieId);
+        disablingDownloadButton(response)
         return response.data;
       }
     }
@@ -300,7 +302,7 @@ function fetchSimpleView(data) {
 
 function createDataTable(data) {
   $("#formSearchAccordion").accordion({ collapsible: true, active: false });
-  $("#download").prop('disabled', false);
+  $("#download").prop('disabled', true);
   $('#formSearchTable').show();
   $('#simpleView').hide()
   $('#simpleView_wrapper').hide();
@@ -332,8 +334,20 @@ function createDataTable(data) {
       type: "POST",
       data: { 'data': data },
       dataSrc: "data",
+      success: function(response){
+        disablingDownloadButton(response)
+      }
     }
   });
+
+}
+
+function disablingDownloadButton(response){
+ if (response.recordsTotal && response.recordsTotal > 0) {
+          $("#download").prop('disabled', false);
+        } else {
+          $("#download").prop('disabled', true);
+        }
 }
 
 function setFormSearchValues(searchDict) {

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -293,7 +293,7 @@ function fetchSimpleView(data) {
       data: { 'data': data },
       dataSrc: function(response) {
         $('#cookieId').val(response.cookieId);
-        disablingDownloadButton(response)
+        updateDownloadButton(response)
         return response.data;
       }
     }
@@ -335,14 +335,14 @@ function createDataTable(data) {
       data: { 'data': data },
       dataSrc: "data",
       success: function(response){
-        disablingDownloadButton(response)
+        updateDownloadButton(response)
       }
     }
   });
 
 }
 
-function disablingDownloadButton(response){
+function updateDownloadButton(response){
  if (response.recordsTotal && response.recordsTotal > 0) {
           $("#download").prop('disabled', false);
         } else {

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -53,7 +53,7 @@
   <div class="" align="right">
     <form method="POST" action="/supervisorPortal/download" style="margin: 0; display: inline;">
       <input type="hidden" id="cookieId" name="cookieId" value="{{ cookieId }}"> 
-      <button class="btn btn-success" type="submit" id="download">Download Results</button>
+      <button class="btn btn-success" type="submit" id="download" >Download Results</button>
     </form>
     <button id="switchViewButton" class="btn btn-primary" value="simple">Switch To Advanced View</button>
     <button class="btn btn-info" type="button" id="addUserToDept">Add User to Dept.</button>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -53,7 +53,7 @@
   <div class="" align="right">
     <form method="POST" action="/supervisorPortal/download" style="margin: 0; display: inline;">
       <input type="hidden" id="cookieId" name="cookieId" value="{{ cookieId }}"> 
-      <button class="btn btn-success" type="submit" id="download" >Download Results</button>
+      <button class="btn btn-success" type="submit" id="download">Download Results</button>
     </form>
     <button id="switchViewButton" class="btn btn-primary" value="simple">Switch To Advanced View</button>
     <button class="btn btn-info" type="button" id="addUserToDept">Add User to Dept.</button>


### PR DESCRIPTION
**Issue Description**
Fixes #484 
-On the Supervisor Portal, if there are no results for no data available in table, the Download Results button is still clickable and gives an error when you try to download.

**Changes**
-Fixed the download button to be disabled if there was no data available in the table
![ya](https://github.com/user-attachments/assets/5aa29b9e-15dc-4057-b39c-1446dee18260)

**Testing**
-Go to Supervisor Portal and check if you can download results when no data is available vs if data is available (a working case example is portrayed with the image below)
![image](https://github.com/user-attachments/assets/52e2b227-ea47-464a-a597-28a8fa9306fa)
-Check the same on advanced view