### PR TITLE
Disabled The Download Button When No Data In Table

### DIFF
--- a/app/templates/admin/allPendingForms.html
+++ b/app/templates/admin/allPendingForms.html
@@ -53,7 +53,21 @@
         <li class="pull-right">
             <form method="POST" action="/admin/pendingForms/download">
               <input type="hidden" name="cookieId" value="{{ cookieId }}">
-              <button class="btn btn-success" id="download">Download</button>
+              <button class="btn btn-success" id="download"
+              {% if formType == "pendingLabor" and laborStatusFormCounter == 0 %}
+                disabled
+              {% elif formType == "pendingAdjustment" and adjustedFormCounter == 0 %}
+                disabled
+              {% elif formType == "pendingOverload" and overloadFormCounter == 0 %}
+                disabled
+              {% elif formType == "completedOverload" and completedOverloadFormCounter == 0 %}
+                disabled
+              {% elif formType == "pendingRelease" and releaseFormCounter == 0 %}
+                disabled
+              {% elif formType == "preStudentApproval" and preStudentApprovalCounter == 0 %}
+                disabled
+              {% endif %}
+              >Download</button>
             </form>
         </li>
     </ul>


### PR DESCRIPTION
**Issue Description**
Fixes #489 
-On the Pending Labor Status Forms page the download button gives a TypeError if there is "No data available in table"

**Changes**
-Fixed the download button to be disabled if there was no data available in the table
![image](https://github.com/user-attachments/assets/dd0f9983-84f0-4fa0-8b9b-5afc42ffcfbc)

**Testing**
-Under administration on the sidebar, click Pending Forms
-Check each separate tab:
     -[Pending Labor Status Forms]
     -[Pending Adjustment Forms]
     -[Pending Overload Forms]
     -[Pending Release Forms]
     -[Pre-Student Approval]
-Ensure that the download button is disabled when no entries and enabled when there is and that it works