### PR TITLE
Logout issue 451

### DIFF
--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -17,12 +17,12 @@ from app.controllers.admin_routes.allPendingForms import checkAdjustment
 from app.controllers.main_routes import main_bp
 from app.controllers.main_routes.download import CSVMaker
 from app.logic.search import getDepartmentsForSupervisor
-from app.login_manager import require_login, logout
-
+from app.login_manager import require_login, logout as performlogout
 
 @main_bp.route('/logout', methods=['GET'])
-def logout():
-    return redirect(logout())
+def handlelogout():  
+    performlogout() 
+    return redirect('https://www.berea.edu/labor-program-office')
 
 @main_bp.route('/', methods=['GET', 'POST'])
 def supervisorPortal():

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -21,7 +21,8 @@ from app.login_manager import require_login, logout as performlogout
 
 @main_bp.route('/logout', methods=['GET'])
 def handlelogout():  
-    performlogout() 
+    performlogout()
+    return redirect("https://secure.berea.edu/Shibboleth.sso/Logout?return=https://lsf.berea.edu/logged_out") 
    
 @main_bp.route('/', methods=['GET', 'POST'])
 def supervisorPortal():

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -22,8 +22,7 @@ from app.login_manager import require_login, logout as performlogout
 @main_bp.route('/logout', methods=['GET'])
 def handlelogout():  
     performlogout() 
-    return redirect('https://www.berea.edu/labor-program-office')
-
+   
 @main_bp.route('/', methods=['GET', 'POST'])
 def supervisorPortal():
     '''

--- a/app/login_manager.py
+++ b/app/login_manager.py
@@ -20,7 +20,7 @@ def logout():
     """
     if 'username' in session:
         print("Logging out", session['username'])
-    session.clear()
+        session.clear()
 
     url ="/"
     if app.config['use_shibboleth']:

--- a/app/templates/sidebar.html
+++ b/app/templates/sidebar.html
@@ -83,7 +83,7 @@
       {% endif %}
           <div class="container-fluid">
             <div class="panel panel-default">
-                <a href="/logout">
+                <a href="https://secure.berea.edu/Shibboleth.sso/Logout?return=https://login.berea.edu/idp/profile/Logout">
                     <div class="panel-heading" tabindex="14">
                         <h4>
                             Logout

--- a/app/templates/sidebar.html
+++ b/app/templates/sidebar.html
@@ -1,4 +1,12 @@
 <div id="sidebar" class="col-sm-2">
+    {% block javascript %}
+    <script type="text/javascript">
+        function preventBack(){window.history.forward();}
+        setTimeout("preventBack()", 0);
+        window.onunload=function(){null};
+    </script>
+    {% endblock %}
+
     <nav class="navbar">
       <!-- Logo -->
       <div id="logo"><img src="/static/labor-logo.png" title="Labor Program Logo" /></div>
@@ -83,7 +91,7 @@
       {% endif %}
           <div class="container-fluid">
             <div class="panel panel-default">
-                <a href="https://secure.berea.edu/Shibboleth.sso/Logout?return=https://login.berea.edu/idp/profile/Logout">
+                <a href="https://secure.berea.edu/Shibboleth.sso/Logout?return=https://lsf.berea.edu/logged_out">
                     <div class="panel-heading" tabindex="14">
                         <h4>
                             Logout


### PR DESCRIPTION
Resolved issue: [451_ LSF](https://github.com/BCStudentSoftwareDevTeam/lsf/issues/451)

_Fixed:_

- The log out button on LSF student side has been fixed so that they will be logged out successfully and also  communicated about it by removing the remove error message and showing a shibboleth logged out message on a new web page.

_Issue:_

 -Logout page doesn’t log you out and only redirects to basic HTML template (On student side). 
- It gave a maximum recursion depth reached error, on the side of development and an unexpected error occurred on the production side when the user attempts to log out. 
-The user was not informed that they have successfully checked out only that there has been:
“Unexpected error has occurred, an administrator has been notified and sorry for the problem page”.

**_Testing the issue :Development error_** 
![image](https://github.com/user-attachments/assets/abd21068-fa86-4258-8d76-b6c2a0bd72f1)

**_Testing the issue: production/published side_** 
![image](https://github.com/user-attachments/assets/f0d34145-e4fc-4e50-8882-a4d9a69e2cc8) 
 
**_Currently tested to output/ resolved :_**  
![image](https://github.com/user-attachments/assets/32e8c5e4-1e35-45cc-b132-5fefdf9cb298)

**_When the user is logged out, they are redirected to the Duo login page:-_**
![image](https://github.com/user-attachments/assets/5d7c766b-e56e-41b4-8122-b3cc93fc2565)
**_If the user presses back on the web browser, a stale request will be rendered._** 
![image](https://github.com/user-attachments/assets/166ffe43-f491-4bb6-8823-b10e6e25aa94)

 


 
Test: 
•	Normally, students the way that we can get the labor form website if we are provided with a link from a supervisor.
•	Check out branch:   logout_issue_45.
•	Once on the page, there is a sidebar with a logout button on it. 
•	Click the log out and followed by a “logged-out operation is complete page.
•	The user has successfully logged out; they can exit the page.

