### PR TITLE
Auto-focus on search bar in student search page

### DIFF
--- a/app/static/js/search.js
+++ b/app/static/js/search.js
@@ -1,5 +1,12 @@
 // Creates a dom fragment from html, rather than having to add dom elements
 // https://love2dev.com/blog/inserting-html-using-createdocumentfragment-instead-of-using-jquery/
+
+
+$(document).ready(function(){
+  $('#searchBoxContainer').children('.dropdown, .bootstrap-select, .form-control').addClass('open')
+  $('[type="search"], .form-control').focus();
+})
+
 function createFragment(htmlStr) {
     let frag = document.createDocumentFragment(), temp = document.createElement('div');
     temp.innerHTML = htmlStr;

--- a/app/static/js/search.js
+++ b/app/static/js/search.js
@@ -1,12 +1,11 @@
-// Creates a dom fragment from html, rather than having to add dom elements
-// https://love2dev.com/blog/inserting-html-using-createdocumentfragment-instead-of-using-jquery/
-
-
+// Focus and expand the search box on page load
 $(document).ready(function(){
   $('#searchBoxContainer').children('.dropdown, .bootstrap-select, .form-control').addClass('open')
   $('[type="search"], .form-control').focus();
 })
 
+// Creates a dom fragment from html, rather than having to add dom elements
+// https://love2dev.com/blog/inserting-html-using-createdocumentfragment-instead-of-using-jquery/
 function createFragment(htmlStr) {
     let frag = document.createDocumentFragment(), temp = document.createElement('div');
     temp.innerHTML = htmlStr;

--- a/app/templates/main/search.html
+++ b/app/templates/main/search.html
@@ -19,7 +19,7 @@ mark { padding: 0px; }
     <div class="row text-center">
       <br/>
       <div id="borders">
-        <div class="form-group">
+        <div class="form-group" id='searchBoxContainer'>
           <select id="search"
                   class="form-control selectpicker"
                   title="Search by bnumber or name"


### PR DESCRIPTION
## Issue Description
Student Search page should auto-focus the search box when loaded so they can type in the search box right away without having to click on it first

Issue is not on Github issue queue
Issue in trello:
https://trello.com/c/Lz0nE4Xj/884-student-search-page-should-auto-focus-the-search-box


## Changes

- Now when we open the student search page, it automatically opens the search bar, and focus on it
- The user will be able to type the text they want right away 

## Testing

- Go to lsf website as a labor admin (Scott's or Brian's account are labor admins)
- make sure you have some data in the database (Students)
- Use the backup database if the test database is empty (to ensure searching functionality still works)
- From left-side navigation panel, click on "Student Search"
- The search bar should be open, with the cursor inside, like in the picture below:

<img width="1909" height="871" alt="image" src="https://github.com/user-attachments/assets/129fddfa-76ee-4346-9383-50af6d68c30d" />

- Try typing anything. The text should be typed in the open box
- Try typing a student name or Bnumber, and check if it works and correctly searches for student(s)
- Try clicking on a search result and ensure it takes you to their labor history page