### PR TITLE
fixed Student Search results to show preferred name not legal first name

### DIFF
--- a/app/templates/main/formHistory.html
+++ b/app/templates/main/formHistory.html
@@ -12,7 +12,7 @@
 <a class="skipContent" href="#downloadButton" tabindex="1">Click to Skip</a>
 <div align= "center">
   <h1>Labor History</h1>
-    <span id="studentName">{{student.FIRST_NAME}} {{student.LAST_NAME}} </span> <a href="mailto:{{student.STU_EMAIL}}" id="studentName"><span id="mailtoIcon" class="glyphicon glyphicon-envelope"></span></a>
+    <span id="studentName">{{student.preferred_name}} {{student.LAST_NAME}} </span> <a href="mailto:{{student.STU_EMAIL}}" id="studentName"><span id="mailtoIcon" class="glyphicon glyphicon-envelope"></span></a>
     <br><span class="h4">{{student.ID}} </span>
     <form method="POST" action="/laborHistory/download">
       <input hidden name="listOfForms" value="{{laborStatusFormList}}" />


### PR DESCRIPTION
[Isssue #499](https://github.com/BCStudentSoftwareDevTeam/lsf/issues/499) 
-Student Search results should show the preferred name not legal first name

Changes
-when searching for a student, it now shows their preferred name not their legal name. 
<img width="1133" height="370" alt="image" src="https://github.com/user-attachments/assets/ef7398fa-db0b-463d-bce0-3081e234a334" />

Testing
-flask run
-Under the Student Search tab, look up a student who has a preferred name set up. For example: Jaylin James, preferred name is Jay. 