### PR TITLE
Bypass student approval

### DIFF
--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -1,4 +1,4 @@
-from flask import abort, flash, jsonify, redirect, send_file, make_response
+from flask import abort, flash, jsonify, redirect, send_file, make_response, g
 import uuid
 import json
 from peewee import JOIN
@@ -23,6 +23,7 @@ from app.models.supervisor import Supervisor
 from app.models.historyType import HistoryType
 from app.models.department import Department
 from app.controllers.main_routes.download import CSVMaker
+from app.models import mainDB
 
 @admin.route('/admin/pendingForms/<formType>',  methods=['GET'])
 def allPendingForms(formType):
@@ -275,6 +276,50 @@ def approved_and_denied_Forms():
     except Exception as e:
         print(e)
         return jsonify({"Success": False}),500
+
+@admin.route('/admin/skipStudentApproval', methods=['POST'])
+def skipStudentApproval():
+    '''
+    Mark a form as approved by the student and update status to pending
+    '''
+    if not (g.currentUser.isLaborAdmin or g.currentUser.isLaborDepartmentStudent):
+        abort(403)
+
+    note = "Skipping Student Approval: " + request.form.get("skipNote")
+    formID = request.form.get("formID")
+
+    # TODO should pull this out into a function in a logic file after PR #494 is merged
+
+    # Update form history status
+    try:
+        form = LaborStatusForm.get_by_id(formID)
+    except DoesNotExist:
+        flash("Invalid form ID provided", "danger")
+        abort(404)
+
+    # make sure our database changes happen all at once
+    try:
+        with mainDB.atomic():
+            form.studentConfirmation = True
+            form.studentResponseDate = date.today()
+            form.save()
+
+            # Get the form history record. XXX Currently restricted to original lsf.
+            formHistory = FormHistory.get_or_none(FormHistory.formID == form.laborStatusFormID, 
+                                                  FormHistory.historyType == "Labor Status Form")
+            if formHistory:
+                formHistory.status = "Pending"
+                formHistory.save()
+
+            # Add Labor note
+            Notes.create(formID=form.laborStatusFormID, createdBy=g.currentUser, date=date.today(), notesContents=note, noteType = "Labor Note")
+
+    except Exception as e:
+        print("Error skipping student approval", e)
+        flash("Error skipping student approval. Please try again.","danger")
+
+    return redirect('/admin/pendingForms/preStudentApproval')
+
 
 @admin.route('/admin/updateStatus/<raw_status>', methods=['POST'])
 def finalUpdateStatus(raw_status):

--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -11,7 +11,7 @@ from app.models.adjustedForm import AdjustedForm
 from app.models.emailTracker import EmailTracker
 from app.models.overloadForm import OverloadForm
 from app.models.notes import Notes
-from app.logic.emailHandler import *
+from app.logic.emailHandler import emailHandler
 from app.logic.utils import makeThirdPartyLink
 from app.models.formHistory import *
 from app.models.term import Term
@@ -20,6 +20,7 @@ from app.logic.tracy import Tracy
 from datetime import datetime, date
 from app.models.Tracy.stuposn import STUPOSN
 from app.models.supervisor import Supervisor
+from app.models.student import Student
 from app.models.historyType import HistoryType
 from app.models.department import Department
 from app.controllers.main_routes.download import CSVMaker
@@ -319,6 +320,30 @@ def skipStudentApproval():
         flash("Error skipping student approval. Please try again.","danger")
 
     return redirect('/admin/pendingForms/preStudentApproval')
+
+@admin.route('/admin/resendStudentConfirmation/<formID>', methods=['POST'])
+def resendStudentConfirmation(formID):
+    if not (g.currentUser.isLaborAdmin or g.currentUser.isLaborDepartmentStudent):       # Not an admin
+        return render_template('errors/403.html'), 403
+
+    try:
+        # get the base form history for the given labor status form
+        formhistory = FormHistory.get(FormHistory.formID == formID, FormHistory.historyType == "Labor Status Form")
+
+        # resend but only to students
+        emailer = emailHandler(formhistory.formHistoryID)
+        if formhistory.formID.termCode.isBreak:
+            emailer.checkRecipient("Break Labor Status Form Submitted For Student")
+        else:
+            emailer.checkRecipient("Labor Status Form Submitted For Student")
+
+        return jsonify({"student_email":formhistory.formID.studentSupervisee.STU_EMAIL});
+
+    except Exception as e:
+        print("Error sending confirmation email. Invalid Form ID.", e)
+        flash("Error sending confirmation email. Please try again.","danger")
+        abort(500)
+
 
 
 @admin.route('/admin/updateStatus/<raw_status>', methods=['POST'])

--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -285,7 +285,7 @@ def skipStudentApproval():
     if not (g.currentUser.isLaborAdmin or g.currentUser.isLaborDepartmentStudent):
         abort(403)
 
-    note = "Skipping Student Approval: " + request.form.get("skipNote")
+    note = "Skipped Student Approval: " + request.form.get("skipNote")
     formID = request.form.get("formID")
 
     # TODO should pull this out into a function in a logic file after PR #494 is merged
@@ -323,7 +323,7 @@ def skipStudentApproval():
 
 @admin.route('/admin/updateStatus/<raw_status>', methods=['POST'])
 def finalUpdateStatus(raw_status):
-    ''' This method changes the status of the pending forms to approved '''
+    ''' This method changes the status of the pending forms '''
     currentUser = require_login()
     if not currentUser:                    # Not logged in
         return render_template('errors/403.html'), 403
@@ -334,55 +334,67 @@ def finalUpdateStatus(raw_status):
         new_status = "Approved"
     elif raw_status == 'denied':
         new_status = "Denied by Admin"
+    elif raw_status == 'pending':
+        new_status = "Pending"
     else:
         print("Unknown status: ", raw_status)
         return jsonify({"success": False})
+
     form_ids = eval(request.data.decode("utf-8"))
     return saveStatus(new_status, form_ids, currentUser)
 
-def saveStatus(new_status, form_ids, currentUser):
+def saveStatus(new_status, formHistoryIds, currentUser):
     try:
         if new_status == 'Denied by Admin':
             # Index 1 will always hold the reject reason in the list, so we can
             # set a variable equal to the index value and then slice off the list
             # item before the iteration
-            denyReason = form_ids[1]
-            form_ids = form_ids[:1]
-        for id in form_ids:
-            history_type_data = FormHistory.get(FormHistory.formHistoryID == int(id))
-            history_type = str(history_type_data.historyType)
+            denyReason = formHistoryIds[1]
+            formHistoryIds = formHistoryIds[:1]
 
-            labor_forms = FormHistory.get(FormHistory.formHistoryID == int(id), FormHistory.historyType == history_type)
-            labor_forms.status = Status.get(Status.statusName == new_status)
+        for formHistoryID in formHistoryIds:
+            formHistory = FormHistory.get(FormHistory.formHistoryID == formHistoryID)
+            formHistory.status = Status.get(Status.statusName == new_status)
             
-            labor_forms.reviewedDate = date.today()
-            labor_forms.reviewedBy = currentUser
+            formHistory.reviewedDate = date.today()
+            formHistory.reviewedBy = currentUser
+
+            # Add a note if we've skipped to Pending
+            if new_status == 'Pending':
+                note = "Skipped Student Approval"
+                Notes.create(formID=formHistory.formID,
+                             createdBy=currentUser,
+                             date=date.today(),
+                             notesContents=note,
+                             noteType = "Labor Note")
+
 
             # Add to BANNER
             save_status = True # default true so that we will still save in other cases
-            if new_status == 'Approved' and history_type == "Labor Status Form" and labor_forms.formID.POSN_CODE != "S12345": # don't update banner for Adjustment forms or for CS dummy position
-                if labor_forms.formID.POSN_CODE == "SNOLAB":
-                       labor_forms.formID.weeklyHours = 10
+            if new_status == 'Approved' and formHistory.historyType == "Labor Status Form" and formHistory.formID.POSN_CODE != "S12345": # don't update banner for Adjustment forms or for CS dummy position
+                if formHistory.formID.POSN_CODE == "SNOLAB":
+                       formHistory.formID.weeklyHours = 10
                 conn = Banner()
-                save_status = conn.insert(labor_forms)
+                save_status = conn.insert(formHistory)
 
             # if we are able to save
             if save_status:
 
                 if new_status == 'Denied by Admin':
-                    labor_forms.rejectReason = denyReason
-                labor_forms.save()
+                    formHistory.rejectReason = denyReason
+                formHistory.save()
 
-                email = emailHandler(labor_forms.formHistoryID)
-                if new_status == "Denied by Admin" and history_type == "Labor Status Form":
+                # Send necessary emails from the status change
+                email = emailHandler(formHistory.formHistoryID)
+                if new_status == "Denied by Admin" and formHistory.historyType == "Labor Status Form":
                     email.laborStatusFormRejected()
-                if new_status == "Approved" and history_type == "Labor Status Form":
+                if new_status == "Approved" and formHistory.historyType == "Labor Status Form":
                     email.laborStatusFormApproved()
-                if new_status == "Approved" and history_type == "Labor Adjustment Form":
+                if new_status == "Approved" and formHistory.historyType == "Labor Adjustment Form":
                     # This function is triggered whenever an adjustment form is approved.
                     # The following function overrides the original data in lsf with the new data from adjustment form.
-                    LSF = LaborStatusForm.get(LaborStatusForm.laborStatusFormID == history_type_data.formID) # getting the specific labor status form
-                    overrideOriginalStatusFormOnAdjustmentFormApproval(history_type_data, LSF)
+                    LSF = LaborStatusForm.get_by_id(formHistory.formID)
+                    overrideOriginalStatusFormOnAdjustmentFormApproval(formHistory, LSF)
 
             else:
                 print("Unable to update form status for formHistoryID {}.".format(id))

--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -17,6 +17,7 @@ from app.models.formHistory import *
 from app.models.term import Term
 from app.logic.banner import Banner
 from app.logic.tracy import Tracy
+from app.logic.userInsertFunctions import calculateExpirationDate
 from datetime import datetime, date
 from app.models.Tracy.stuposn import STUPOSN
 from app.models.supervisor import Supervisor
@@ -329,6 +330,10 @@ def resendStudentConfirmation(formID):
     try:
         # get the base form history for the given labor status form
         formhistory = FormHistory.get(FormHistory.formID == formID, FormHistory.historyType == "Labor Status Form")
+
+        # make a new expiration date
+        formhistory.formID.studentExpirationDate = calculateExpirationDate()
+        formhistory.formID.save()
 
         # resend but only to students
         emailer = emailHandler(formhistory.formHistoryID)

--- a/app/logic/emailHandler.py
+++ b/app/logic/emailHandler.py
@@ -55,11 +55,16 @@ class emailHandler():
                 pass
 
         self.link = ""
-        self.confirmationLink = ""
         self.releaseReason = ""
         self.releaseDate = ""
         self.newAdjustmentField = ""
         self.oldAdjustmentField = ""
+
+        # generating a confirmation link for student approval
+        self.confirmationLink = ""
+        if self.laborStatusForm.confirmationToken:
+            self.confirmationLink = f"{request.host_url}studentResponse/confirm?token={self.laborStatusForm.confirmationToken}"
+
 
         if self.formHistory.adjustedForm:
             if self.formHistory.adjustedForm.fieldAdjusted == "supervisor":
@@ -114,13 +119,6 @@ class emailHandler():
     # is pulled from the model, and replaceText method will replace the neccesary keywords with the correct data.
     # The sendEmail method will handle all of the email sending once the email template has been populated.
     def laborStatusFormSubmitted(self):
-        try:
-            # generating a link for confirmation for student
-            self.confirmationLink = f"{request.host_url}studentResponse/confirm?token={self.laborStatusForm.confirmationToken}"
-
-        except Student.DoesNotExist:
-            print("Error: Student record not found.")
-            return
 
         # Submit the forms for secondary, break, and regular
         if self.laborStatusForm.jobType == 'Secondary':

--- a/app/static/js/allPendingForms.js
+++ b/app/static/js/allPendingForms.js
@@ -250,6 +250,17 @@ function skipApproval(formId) {
     $("#skipApprovalFormID").val(formId);
 }
 
+// send another link to the confirmation page and renew the expiration time
+function resendApprovalLink(formId) {
+  $.ajax({
+    type: "POST",
+    url: "/admin/resendStudentConfirmation/" + formId,
+    contentType: 'application/json',
+    success: function(response) {
+        msgFlash("New confirmation email sent to " + response['student_email'],"success")
+    }
+  });
+}
 
 function getNotes(formId) {
   $.ajax({

--- a/app/static/js/allPendingForms.js
+++ b/app/static/js/allPendingForms.js
@@ -245,6 +245,11 @@ function finalDenial() { // this mehod is AJAX call for the finalDenial method i
   });
 }
 
+// make sure the modal has the id we are talking about
+function skipApproval(formId) {
+    $("#skipApprovalFormID").val(formId);
+}
+
 
 function getNotes(formId) {
   $.ajax({
@@ -340,6 +345,7 @@ function finalDeny() {
 
 function clearTextArea() { //makes sure that it empties text areas and p tags when modal is closed
   $("#notesText").val("");
+  $("#skipNote").val("");
   $("#laborNotesText").val("");
 }
 

--- a/app/static/js/allPendingForms.js
+++ b/app/static/js/allPendingForms.js
@@ -134,7 +134,7 @@ function finalApproval() { //this method changes the status of the lsf from pend
   $("#approvalModal").data("bs.modal").options.keyboard = false;
   var data = JSON.stringify(labor_details_ids);
 
-  newStatus = (true) ? "pending" : "approved";
+  newStatus = ($("#formType").val() == "preStudentApproval") ? "pending" : "approved";
   $.ajax({
     type: "POST",
     url: "/admin/updateStatus/" + newStatus,

--- a/app/static/js/allPendingForms.js
+++ b/app/static/js/allPendingForms.js
@@ -133,15 +133,16 @@ function finalApproval() { //this method changes the status of the lsf from pend
   $("#approvalModal").data("bs.modal").options.backdrop = "static";
   $("#approvalModal").data("bs.modal").options.keyboard = false;
   var data = JSON.stringify(labor_details_ids);
+
+  newStatus = (true) ? "pending" : "approved";
   $.ajax({
     type: "POST",
-    url: "/admin/updateStatus/approved",
+    url: "/admin/updateStatus/" + newStatus,
     datatype: "json",
     data: data,
     contentType: 'application/json',
     success: function(response) {
-      if (response) {
-        if (response.success) {
+      if (response && response.success) {
           $(".btn").prop("disabled", false);
           $(".close").prop("disabled", false);
           $("#approveModalButton").text("Approve");
@@ -157,7 +158,6 @@ function finalApproval() { //this method changes the status of the lsf from pend
           catch(e){
             location.reload(true);
           }
-        }
       }
     }
   });

--- a/app/templates/admin/allPendingForms.html
+++ b/app/templates/admin/allPendingForms.html
@@ -204,7 +204,7 @@
                   {% include "snips/pendingNotesModal.html" %}
                   <button class="btn btn-primary dropdown-toggle" type="button" id="menu1" data-toggle="dropdown" onclick="notesCounter({{allForms.formID.laborStatusFormID}}, {{allForms.formHistoryID}})">Actions
                     <span class="caret"></span></button>
-                  <ul class="dropdown-menu" role="menu" aria-labelledby="menu1" style="min-width: 100%;">
+                  <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="menu1" style="min-width: 100%;">
                     {% if allForms.historyType.historyTypeName == 'Labor Overload Form' %}
                         <li role="presentation">
                         {% if currentUser.isFinancialAidAdmin or currentUser.isSaasAdmin %}
@@ -229,14 +229,13 @@
                                 onclick="loadOverloadModal({{pendingOverloadFormPairs[allForms.formHistoryID]}}, {{allForms.formID.laborStatusFormID}});">Manage</span></a></li>
                     {% else %}
                         <li role="presentation"><a role="menuitem" href="#">
-                          <span id="reject_{{allForms.formHistoryID}}"
-                                onclick="insertDenial({{allForms.formHistoryID}})"
+                          <span onclick="insertDenial({{allForms.formHistoryID}})"
                                 data-toggle="modal"
                                 data-target="#denyModal">Deny</span></a></li>
                     {% endif %}
                     {% if allForms.historyType.historyTypeName == 'Labor Status Form' %}
                         <li role="presentation"><a role="menuitem" href="/alterLSF/{{allForms.formID.laborStatusFormID}}">
-                            <span id="edit_{{allForms.formID.laborStatusFormID}}">Modify</span></a></li>
+                            <span >Modify</span></a></li>
                     {% endif %}
                         <li role="presentation"><a role="menuitem" href="#">
                           <span id="notes_{{allForms.formHistoryID}}"
@@ -245,10 +244,12 @@
                                 data-target="#NotesModal">View Notes</span></a></li>
                     {% if formType == 'preStudentApproval' %}
                         <li role="presentation"><a role="menuitem" href="#">
-                          <span id="pending_{{allForms.formHistoryID}}"
-                                onclick="skipApproval({{allForms.formID.laborStatusFormID}})"
+                          <span onclick="skipApproval({{allForms.formID.laborStatusFormID}})"
                                 data-toggle="modal"
                                 data-target="#skipApprovalModal">Skip Student Approval</span></a></li>
+                        <li role="presentation"><a role="menuitem" href="#">
+                          <span onclick="resendApprovalLink({{allForms.formID.laborStatusFormID}})">
+                              Re-send Approval Email</span></a></li>
                     {% endif %}
                   </ul>
                 </div>

--- a/app/templates/admin/allPendingForms.html
+++ b/app/templates/admin/allPendingForms.html
@@ -242,6 +242,13 @@
                                 onclick="getNotes({{allForms.formID.laborStatusFormID}})"
                                 data-toggle="modal"
                                 data-target="#NotesModal">View Notes</span></a></li>
+                    {% if formType == 'preStudentApproval' %}
+                        <li role="presentation"><a role="menuitem" href="#">
+                          <span id="pending_{{allForms.formHistoryID}}"
+                                onclick="skipApproval({{allForms.formID.laborStatusFormID}})"
+                                data-toggle="modal"
+                                data-target="#skipApprovalModal">Skip Student Approval</span></a></li>
+                    {% endif %}
                   </ul>
                 </div>
               </td>
@@ -269,4 +276,31 @@
     </div>
   </div>
 </div>
+
+{# ##############################################################
+   Skip Approval Modal
+   ##############################################################}
+<div class="modal fade" id="skipApprovalModal" tabindex="-1" role="dialog" aria-labelledby="skipModalLabel" aria-describedby="skipModalBody">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <form action="/admin/skipStudentApproval" method="POST">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close" onclick= "clearTextArea()"><span aria-hidden="true">&times;</span></button>
+          <h3 class="modal-title" id="skipModalLabel">Skip Student Approval</h3>
+      </div>
+      <div class="modal-body" id="skipModalBody">
+          <input type="hidden" name="formID" id="skipApprovalFormID" />
+          <label class=" control-label text-left" for="skipNote">Enter Note:</label>
+          <textarea id="skipNote" name="skipNote" rows="4" cols="70" required></textarea>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal" onclick= "clearTextArea()">Close</button>
+        <input type="submit" class="btn btn-primary" value="Send to Pending" />
+      </div>
+      </form>
+    </div>
+  </div>
+</div>
+<!-- END OF MODAL -->
+
 {% endblock %}

--- a/app/templates/admin/allPendingForms.html
+++ b/app/templates/admin/allPendingForms.html
@@ -80,7 +80,7 @@
           <!-- Made empty header tags because we need to hide the header -->
           <thead id="headTable" text-align="center">
             <tr id="tableHeaders" class="tableHeaders">
-              {% if formType != "pendingOverload" and formType != "pendingRelease" and formType !="completedOverload" and formType != "preStudentApproval" %}
+              {% if formType != "pendingOverload" and formType != "pendingRelease" and formType !="completedOverload" %}
                 <th><input type="checkbox" id="checkAll"/></th>
               {% endif %}
               {% if formType == "pendingOverload" or formType == "preStudentApproval" %}
@@ -106,7 +106,7 @@
             <!--  -->
             {% for allForms in formList %}
             <tr id="tableData" class="tableData" align="center">
-              {% if formType != "pendingOverload" and formType != "pendingRelease" and formType !="completedOverload" and formType !="preStudentApproval" %}
+              {% if formType != "pendingOverload" and formType != "pendingRelease" and formType !="completedOverload" %}
                 {% if allForms.formHistoryID in pendingOverloadFormPairs %}
                   <td> {# REDIRECT #}
                     {% with modalTarget = modalTarget %}
@@ -257,6 +257,7 @@
           </tbody>
         </table>
         {% if formType != 'pendingOverload' and formType != 'pendingRelease' and formType != 'completedOverload'%}
+            {% set buttonText = "Approve Selected" if formType == 'pendingLabor' else "Skip Student Approval for Selected" %}
         <div style='float:left'>
           <button
             id="approveSelected"
@@ -264,10 +265,10 @@
             type="button"
             class="btn btn-newcolor"
             onclick="insertApprovals();"
-            value="Approve Selected"
+            value="{{buttonText}} Forms"
             data-target="#approvalModal"
             data-toggle="modal">
-            Approve Selected
+              {{buttonText}} Forms
           </button>
         {% include "snips/pendingApprovalModal.html" %}
         </div>

--- a/app/templates/admin/allPendingForms.html
+++ b/app/templates/admin/allPendingForms.html
@@ -14,6 +14,7 @@
 {% endblock %}
 
 {% block app_content %}
+<input type="hidden" id="formType" value="{{formType}}" />
 <div align="center">
   <a class="skipContent" href="#pendingLabor" tabindex="1">Click to Skip</a>
   <h1>{{title}}</h1>
@@ -303,5 +304,4 @@
   </div>
 </div>
 <!-- END OF MODAL -->
-
 {% endblock %}

--- a/app/templates/snips/pendingApprovalModal.html
+++ b/app/templates/snips/pendingApprovalModal.html
@@ -3,7 +3,8 @@
 <div class="modal-dialog" role="document">
   <div class="modal-content">
     <div class="modal-header">
-      <h5 class="modal-title" id="approvalModalLabel" align="center"><strong>Form(s) ready for Approval</strong></h5>
+        {% set modalTitle = "Forms to Approve" if formType == "pendingLabor" else "Forms to make Pending" %}
+        <h5 class="modal-title" id="approvalModalLabel" align="center"><strong>{{modalTitle}}</strong></h5>
       <button type="button" class="close" data-dismiss="modal" onclick="approvalModalClose()" aria-label="Close">
         <span aria-hidden="true">&times;</span>
       </button>
@@ -26,7 +27,8 @@
     </div>
     <div class="modal-footer">
       <button type="button" class="btn btn-secondary" data-dismiss="modal" onclick="approvalModalClose()">Close</button>
-      <button id="approveModalButton" type="button" class="btn btn-primary"  data-dismiss="modal" onclick="finalApproval()" >Approve</button>
+      {% set buttonText = "Approve" if formType == "pendingLabor" else "Skip Student Approval" %}
+      <button id="approveModalButton" type="button" class="btn btn-primary"  data-dismiss="modal" onclick="finalApproval()" >{{buttonText}}</button>
     </div>
   </div>
 


### PR DESCRIPTION
Quick feature adds for Labor:

- Admins should have the ability to bypass the student approval step. This is used for incoming first-year students, and for labor probation cases.
- Admins should be able to re-send the student confirmation email. This should update the confirmation expiration date, and send a new email to the student for their approval.

For the first issue, there are now checkboxes on the Pre-Student Approval tab of the Pending Forms page. This should work like it does on the Pending Forms tab, only it moves the status to Pending. There is also a new item in the Actions menu to change one form at a time and add a note.

For the second, there is a new item in the Actions menu of the Pre-Student Approval tab to re-send the email.