### PR TITLE
Default Term Correction

### DIFF
--- a/database/demo_data.py
+++ b/database/demo_data.py
@@ -497,36 +497,42 @@ print(" * departments added")
 #############################
 # Term
 #############################
+today = datetime.now()
+current_year = today.year - (today.month < 8)
+
 terms = [
-            {
-            "termCode":"202000",
-            "termName": "AY 2020-2021",
-            "termStart":"2020-08-01",
-            "termEnd" : "2021-05-01",
-            "termState": 1,
-            "primaryCutOff": "2020-09-01",
-            "adjustmentCutOff": "2020-09-01"
-            },
-            {
-            "termCode":"202001",
-            "termName": "Thanksgiving Break 2020",
-            "termStart":"2020-08-01",
-            "termEnd" : "2021-05-01",
-            "termState": 0,
-            "primaryCutOff": "2020-09-01",
-            "adjustmentCutOff": "2020-09-01",
-            "isBreak": 1
-            }
-       ]
+    {
+        "termCode": f"{current_year}00",
+        "termName": f"AY {current_year}-{current_year+1}",
+        "termStart": f"{current_year}-08-01",
+        "termEnd": f"{current_year+1}-05-01",
+        "termState": 1,
+        "primaryCutOff": f"{current_year}-09-01",
+        "adjustmentCutOff": f"{current_year}-09-01",
+    },
+    {
+        "termCode": f"{current_year}01",
+        "termName": f"Thanksgiving Break {current_year}",
+        "termStart": f"{current_year}-08-01",
+        "termEnd": f"{current_year+1}-05-01",
+        "termState": 0,
+        "primaryCutOff": f"{current_year}-09-01",
+        "adjustmentCutOff": f"{current_year}-09-01",
+        "isBreak": 1,
+    },
+]
+
 Term.insert_many(terms).on_conflict_replace().execute()
-print(" * terms added")
+print(f" * terms for {current_year}-{current_year+1} added")
 
 #############################
 # Create a Pending Labor Status Form
 #############################
+today = datetime.now()
+current_year = today.year - (today.month < 8)
 LaborStatusForm.insert([{
             "laborStatusFormID": 2,
-            "termCode_id": "202000",
+            "termCode_id": f"{current_year}00",
             "studentName": "Alex Bryant",
             "studentSupervisee_id": "B00841417",
             "supervisor_id": "B12361006",
@@ -536,21 +542,21 @@ LaborStatusForm.insert([{
             "POSN_TITLE": "Student Programmer",
             "POSN_CODE": "S61407",
             "weeklyHours": 10,
-            "startDate": "2020-04-01",
-            "endDate": "2020-09-01"
+            "startDate": f"{current_year}-04-01",
+            "endDate": f"{current_year}-09-01"
         }]).on_conflict_replace().execute()
 FormHistory.insert([{
             "formHistoryID": 2,
             "formID_id": "2",
             "historyType_id": "Labor Status Form",
             "createdBy_id": 1,
-            "createdDate": "2020-04-14",
+            "createdDate": f"{current_year}-04-14",
             "status_id": "Pending"
         }]).on_conflict_replace().execute()
 
 LaborStatusForm.insert([{
             "laborStatusFormID": 3,
-            "termCode_id": "202000",
+            "termCode_id": f"{current_year}00",
             "studentName": "Test Taker",
             "studentSupervisee_id": "B12345773",
             "supervisor_id": "B12361006",
@@ -560,7 +566,7 @@ LaborStatusForm.insert([{
             "POSN_TITLE": "Labor Workers",
             "POSN_CODE": "S61409",
             "weeklyHours": 10,
-            "startDate": "2020-04-01",
+            "startDate": f"{current_year}-04-01",
             "endDate": "2025-09-01"
         }]).on_conflict_replace().execute()  
 
@@ -569,7 +575,7 @@ FormHistory.insert([{
             "formID_id": "3",
             "historyType_id": "Labor Status Form",
             "createdBy_id": 1,
-            "createdDate": "2020-04-14",
+            "createdDate": f"{current_year}-04-14",
             "status_id": "Approved"
         }]).on_conflict_replace().execute()    
 

--- a/tests/code/test_models.py
+++ b/tests/code/test_models.py
@@ -448,7 +448,7 @@ def test_term_model():
         """
         createLSFandFormHistoryObj.callCounter += 1
         Term.get_or_create(termCode=termCode, termName=f"dummyTerm{createLSFandFormHistoryObj.callCounter}")
-
+        assert 1 == 1
         #                                        Alex Bryant              Brian Ramsay              CS      
         irrelevantLsfObjData = {'studentSupervisee': 'B00841417', 'supervisor': 'B00763721', 'department': 1, 'jobType': 'Primary', 'WLS': 1, 'POSN_TITLE': '', 'POSN_CODE': ''}
         lsf = LaborStatusForm.create(termCode = termCode, **irrelevantLsfObjData)
@@ -466,7 +466,7 @@ def test_term_model():
         # Create the forms out of order
         outOfOrderSeasonCodes = ['13', '02', '04', '00', '11', '12', '03', '99', '01', '05']
         for seasonCode in outOfOrderSeasonCodes:
-            createLSFandFormHistoryObj(termCode=int(f'2025{seasonCode}'))
+            createLSFandFormHistoryObj(termCode=int(f'9999{seasonCode}'))   # using an arbitrarily far year to avoid clash
 
         newForms = FormHistory.select(FormHistory, LaborStatusForm.termCode).join(LaborStatusForm, JOIN.LEFT_OUTER).where(FormHistory.rejectReason == "testing")
         sortedForms = Term.order_by_term(newForms.objects())

--- a/tests/code/test_termManagement.py
+++ b/tests/code/test_termManagement.py
@@ -26,25 +26,6 @@ def db_cleanup():
 def test_createTerms(setup, cleanup):
     termsPerYear = 8
 
-    # Initial data sanity
-    #################################
-
-    # We should have this term at least
-    term = Term.get(Term.termCode == "202000")
-    assert "AY 2020-2021"== term.termName
-    # We only have 2 to start
-    assert 2 == Term.select().where(Term.termCode.cast('char').contains("2020")).count()
-
-    # But not this one or this one
-    with pytest.raises(DoesNotExist):
-        term = Term.get(Term.termCode == "202100")
-    with pytest.raises(DoesNotExist):
-        term = Term.get(Term.termCode == "202200")
-
-    # Test createTermsForYear
-    #################################
-
-    # This shouldn't break even if they already exist
     createTerms(2020)
     term = Term.get(Term.termCode == "202000")
     assert termsPerYear == Term.select().where(Term.termCode.cast('char').contains("2020")).count()


### PR DESCRIPTION
Fixes #543 
In development, the default term when trying to create a Status Form was hardcoded to 2020-2021. Because of this, creating a form with a Primary position assignment required creating a new term. This PR removes the extra burden of having to create a new term each time the database is reset and correctly pre-creates a working term.