### PR TITLE
Optimize Supervisor Portal Loading Time

### DIFF
--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -47,8 +47,6 @@ def supervisorPortal():
         departments = list(getDepartmentsForSupervisor(currentUser).order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
         deptNames = [department.DEPT_NAME for department in departments]
 
-        supervisorPrimaryDepartment = Department.select().join(SupervisorDepartment) # count up all forms for a supervisor in department and get the max
-
         supervisors = (Supervisor.select(Supervisor, supervisorFirstName)
                                  .join_from(Supervisor, LaborStatusForm)
                                  .join_from(LaborStatusForm, Department)

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -32,7 +32,6 @@ def supervisorPortal():
         return render_template('errors/403.html'), 403
     
     terms = LaborStatusForm.select(LaborStatusForm.termCode).distinct().order_by(LaborStatusForm.termCode.desc())
-    allSupervisors = Supervisor.select()
     supervisorFirstName = fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name)
     studentFirstName = fn.COALESCE(Student.preferred_name, Student.legal_name)
     department = None
@@ -66,7 +65,6 @@ def supervisorPortal():
     return render_template('main/supervisorPortal.html',
                             terms = terms,
                             supervisors = supervisors,
-                            allSupervisors = allSupervisors,
                             students = students,
                             departments = departments,
                             department = department,

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -45,19 +45,18 @@ def supervisorPortal():
 
     else:
         departments = list(getDepartmentsForSupervisor(currentUser).order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
-        deptNames = [department.DEPT_NAME for department in departments]
 
         supervisors = (Supervisor.select(Supervisor, supervisorFirstName)
                                  .join_from(Supervisor, LaborStatusForm)
                                  .join_from(LaborStatusForm, Department)
-                                 .where(Department.DEPT_NAME.in_(deptNames))
+                                 .where(Department.DEPT_NAME.in_(departments))
                                  .distinct()
                                  .order_by(Supervisor.isActive.desc(), supervisorFirstName.contains("Unknown"), supervisorFirstName, Supervisor.LAST_NAME))
         
         students = (Student.select(Student, studentFirstName)
                            .join_from(Student, LaborStatusForm)
                            .join_from(LaborStatusForm, Department)
-                           .where(Department.DEPT_NAME.in_(deptNames))
+                           .where(Department.DEPT_NAME.in_(departments))
                            .order_by(studentFirstName.contains("Unknown"), studentFirstName, Student.LAST_NAME)
                            .distinct())
     if request.method == 'POST':

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -6,6 +6,7 @@ from app.models.supervisorDepartment import SupervisorDepartment
 from app.models.student import Student
 from app.models.laborStatusForm import LaborStatusForm
 from app.models.formHistory import FormHistory
+from app.models.term import Term
 from app.controllers.admin_routes.allPendingForms import checkAdjustment
 from app.controllers.main_routes import main_bp
 from app.logic.download import CSVMaker, saveFormSearchResult, retrieveFormSearchResult
@@ -31,7 +32,7 @@ def supervisorPortal():
 
         return render_template('errors/403.html'), 403
     
-    terms = LaborStatusForm.select(LaborStatusForm.termCode).distinct().order_by(LaborStatusForm.termCode.desc())
+    terms = Term.select(Term.termName).order_by(Term.termCode.desc())
     supervisorFirstName = fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name)
     studentFirstName = fn.COALESCE(Student.preferred_name, Student.legal_name)
     department = None

--- a/app/logic/getTableData.py
+++ b/app/logic/getTableData.py
@@ -3,7 +3,7 @@ from datetime import datetime, date
 from functools import reduce
 
 from flask import json, jsonify, g, make_response
-from peewee import fn, Case
+from peewee import fn, SQL
 
 from app.controllers.admin_routes.allPendingForms import checkAdjustment
 from app.logic.search import getDepartmentsForSupervisor
@@ -68,20 +68,27 @@ def getDatatableData(request):
             else:
                 clauses.append(field == value)
     # This expression creates SQL AND operator between the conditions added to 'clauses' list
-    formSearchResults = (FormHistory.select()
-                                    .join(LaborStatusForm, on=(FormHistory.formID == LaborStatusForm.laborStatusFormID))
-                                    .join(Department, on=(LaborStatusForm.department == Department.departmentID))
-                                    .join(Supervisor, on=(LaborStatusForm.supervisor == Supervisor.ID))
-                                    .join(Student, on=(LaborStatusForm.studentSupervisee == Student.ID))
-                                    .join(Term, on=(LaborStatusForm.termCode == Term.termCode))
-                                    .join(User, on=(FormHistory.createdBy == User.userID)))
-    if clauses:
-        formSearchResults = formSearchResults.where(reduce(operator.and_, clauses))
     if not g.currentUser.isLaborAdmin:
-        supervisorDepartments = getDepartmentsForSupervisor(g.currentUser)
-        formSearchResults = formSearchResults.where(FormHistory.formID.department.in_(supervisorDepartments)) 
-    recordsTotal = formSearchResults.count()
+        supervisor_filter = (
+            (Supervisor.ID == g.currentUser.supervisor.ID) |
+            (FormHistory.createdBy == g.currentUser)
+        )
+        clauses.append(supervisor_filter)
 
+    formSearchResults = (
+                            FormHistory.select()
+                            .join(LaborStatusForm, on=(FormHistory.formID == LaborStatusForm.laborStatusFormID))
+                            .join(Department, on=(LaborStatusForm.department == Department.departmentID))
+                            .join(Supervisor, on=(LaborStatusForm.supervisor == Supervisor.ID))
+                            .join(Student, on=(LaborStatusForm.studentSupervisee == Student.ID))
+                            .join(Term, on=(LaborStatusForm.termCode == Term.termCode))
+                            .join(User, on=(FormHistory.createdBy == User.userID))
+                            .where(
+                                reduce(operator.and_, clauses)
+                            ) if clauses else SQL("1=1")
+                        )
+
+    recordsTotal = formSearchResults.count()
     # this checks and finds the first value that is not null of preferred_name, legal_name and last_name.
     # including last_name is necessary because there are like 4 cases where someone has no first name or last name, instead their full name is
     # stored in last_name

--- a/app/logic/getTableData.py
+++ b/app/logic/getTableData.py
@@ -80,7 +80,7 @@ def getDatatableData(request):
     if not g.currentUser.isLaborAdmin:
         supervisorDepartments = [d.departmentID for d in getDepartmentsForSupervisor(g.currentUser)]
         formSearchResults = formSearchResults.where(FormHistory.formID.department.in_(supervisorDepartments)) 
-    recordsTotal = len(formSearchResults)
+    recordsTotal = formSearchResults.count()
 
     # this checks and finds the first value that is not null of preferred_name, legal_name and last_name.
     # including last_name is necessary because there are like 4 cases where someone has no first name or last name, instead their full name is

--- a/app/logic/getTableData.py
+++ b/app/logic/getTableData.py
@@ -78,7 +78,7 @@ def getDatatableData(request):
     if clauses:
         formSearchResults = formSearchResults.where(reduce(operator.and_, clauses))
     if not g.currentUser.isLaborAdmin:
-        supervisorDepartments = [d.departmentID for d in getDepartmentsForSupervisor(g.currentUser)]
+        supervisorDepartments = getDepartmentsForSupervisor(g.currentUser)
         formSearchResults = formSearchResults.where(FormHistory.formID.department.in_(supervisorDepartments)) 
     recordsTotal = formSearchResults.count()
 

--- a/app/logic/search.py
+++ b/app/logic/search.py
@@ -46,19 +46,22 @@ def getDepartmentsForSupervisor(currentUser):
     """
     Given currentUser, find and return all departments that the user is associated with.
     """
-    # query the SupervisorDepartment table to see if any entries exist for the currentUser
-    supervisorDepts = Department.select().join(SupervisorDepartment).where(SupervisorDepartment.supervisor == currentUser.supervisor)
-
-    # queries all forms to see what departments the user has interacted with
-    departments = (Department.select(Department)
-                    .join_from(Department, LaborStatusForm)
-                    .join_from(LaborStatusForm, FormHistory)
-                    .join_from(LaborStatusForm, Supervisor)
-                    .where((LaborStatusForm.supervisor.ID == currentUser.supervisor.ID) | (FormHistory.createdBy == currentUser)).order_by(Department.DEPT_NAME)
-                    .distinct()
+    # queries all forms to see the department IDs which the user has interacted with
+    departments = (
+                    Department.select(Department.departmentID)
+                    .join(LaborStatusForm)
+                    .join(FormHistory)
+                    .join(Supervisor)
+                    .join(SupervisorDepartment)
+                    .where(
+                        (SupervisorDepartment.supervisor == currentUser.supervisor) |
+                        (LaborStatusForm.supervisor.ID == currentUser.supervisor.ID) | 
+                        (FormHistory.createdBy == currentUser)
                     )
-    alldepts = departments.union(supervisorDepts)
-    return alldepts
+                    .order_by(Department.DEPT_NAME)
+                    .distinct()
+                )
+    return departments
 
 def getSupervisorsForDepartment(departmentId):
     departmentSupervisors = Supervisor.select().join(SupervisorDepartment).where(SupervisorDepartment.department == departmentId).order_by(Supervisor.LAST_NAME).execute()

--- a/app/logic/search.py
+++ b/app/logic/search.py
@@ -48,7 +48,7 @@ def getDepartmentsForSupervisor(currentUser):
     """
     # queries all forms to see the department IDs which the user has interacted with
     departments = (
-                    Department.select(Department.departmentID)
+                    Department.select(Department)
                     .join(LaborStatusForm)
                     .join(FormHistory)
                     .join(Supervisor)

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -79,7 +79,7 @@
                   <option value="activeTerms">All Active Terms</option>
                   {% for term in terms %}
                   <option value="{{term.termCode}}">
-                    {{term.termCode.termName}}
+                    {{term.termName}}
                   </option>
                   {% endfor %}
                 </select>


### PR DESCRIPTION
Partial fix for #504

Cuts out some redundant queries on the Form Search landing page and improves its load time.

A subsequent PR under the same ticket will update the form search so that data is dynamically queried (rather than preloaded into the webpage) to further reduce the load time.