### PR TITLE
Dynamic search and load time optimization

### DIFF
--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -16,8 +16,6 @@ from app.logic.search import getDepartmentsForSupervisor
 from app.login_manager import require_login, logout
 from app.logic.getTableData import getDatatableData
 from app.logic.banner import Banner
-from app.models.user import User # remove later?
-from app.logic.tracy import Tracy # remove later?
 
 @main_bp.route('/logout', methods=['GET'])
 def triggerLogout():
@@ -90,6 +88,7 @@ def SupervisorPortalSearch():
     """
     Returns a list of users that match a given string
     """
+    print('liveSearch called')
     def searchSupervisorPortal(searchType, userInput):
         currentUser = require_login()
         if currentUser.isLaborAdmin or currentUser.isFinancialAidAdmin or currentUser.isSaasAdmin:

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -47,8 +47,6 @@ def supervisorPortal():
         departments = list(getDepartmentsForSupervisor(currentUser).order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
         deptNames = [department.DEPT_NAME for department in departments]
 
-        supervisorPrimaryDepartment = Department.select().join(SupervisorDepartment) # count up all forms for a supervisor in department and get the max
-
         supervisors = (Supervisor.select(Supervisor, supervisorFirstName)
                                  .join_from(Supervisor, LaborStatusForm)
                                  .join_from(LaborStatusForm, Department)

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -12,7 +12,7 @@ from app.models.term import Term
 from app.controllers.admin_routes.allPendingForms import checkAdjustment
 from app.controllers.main_routes import main_bp
 from app.logic.download import CSVMaker, saveFormSearchResult, retrieveFormSearchResult
-from app.logic.search import getDepartmentsForSupervisor, searchPerson
+from app.logic.search import getDepartmentsForSupervisor, searchPerson, searchSupervisorPortal
 from app.login_manager import require_login, logout
 from app.logic.getTableData import getDatatableData
 from app.logic.banner import Banner
@@ -89,51 +89,13 @@ def SupervisorPortalSearch():
     """
     Returns a list of users that match a given string
     """
-    def searchSupervisorPortal(searchType, userInput):
-        currentUser = require_login()
-        if currentUser.isLaborAdmin or currentUser.isFinancialAidAdmin or currentUser.isSaasAdmin:
-            allowed_departments = None  # unrestricted
-        else:
-            allowed_departments = [dept.DEPT_NAME for dept in getDepartmentsForSupervisor(currentUser)]
-
-        if searchType == "termSelect":
-            terms = Term.select().where(Term.termName.contains(userInput)).order_by(Term.termCode.desc())
-            return [{'termCode': term.termCode, 'termName': term.termName} for term in terms]
-
-        elif searchType == "departmentSelect":
-            query = Department.select().where(Department.DEPT_NAME.contains(userInput))
-            if allowed_departments is not None:
-                query = query.where(Department.DEPT_NAME.in_(allowed_departments))
-            query = query.order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()).limit(10)
-            return [
-                {'DEPT_NAME': dept.DEPT_NAME, 'id': dept.departmentID, 'isActive': dept.isActive} 
-                for dept in query
-            ]
-
-        elif searchType == "supervisorSelect":
-            supervisor_query = searchPerson(Supervisor, userInput, allowed_departments)
-            supervisor_query = supervisor_query.order_by(Supervisor.isActive.desc()).limit(10)
-            return [
-                {'id': sup.ID, 'FIRST_NAME': sup.FIRST_NAME, "LAST_NAME": sup.LAST_NAME, "isActive": sup.isActive} 
-                for sup in supervisor_query
-            ]
-
-        elif searchType == "studentSelect":
-            student_query = searchPerson(Student, userInput, allowed_departments)
-            student_query = student_query.order_by(Student.LAST_NAME.asc()).limit(10)
-            return [
-                {'id': stu.ID, 'FIRST_NAME': stu.FIRST_NAME, 'LAST_NAME': stu.LAST_NAME} 
-                for stu in student_query
-            ]
-
-        return []
-    
     searchType = request.args.get("searchType")
     userInput = request.args.get("userInput")
 
     if not searchType or not userInput:
         return jsonify({}), 400
-    userList = searchSupervisorPortal(searchType, userInput)
+    currentUser = require_login()
+    userList = searchSupervisorPortal(currentUser, searchType, userInput)
     return jsonify(userList)
 
 @main_bp.route('/lsf/<formHistoryId>/submitToBanner', methods=['GET']) 

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -32,7 +32,6 @@ def supervisorPortal():
         return render_template('errors/403.html'), 403
     
     terms = LaborStatusForm.select(LaborStatusForm.termCode).distinct().order_by(LaborStatusForm.termCode.desc())
-    allSupervisors = Supervisor.select()
     supervisorFirstName = fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name)
     studentFirstName = fn.COALESCE(Student.preferred_name, Student.legal_name)
     department = None
@@ -66,7 +65,6 @@ def supervisorPortal():
     return render_template('main/supervisorPortal.html',
                             terms = terms,
                             supervisors = supervisors,
-                            allSupervisors = allSupervisors,
                             students = students,
                             departments = departments,
                             department = department,

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -36,12 +36,17 @@ def supervisorPortal():
     
     if request.method == 'POST':
         return getDatatableData(request)
+    
+    if currentUser.isLaborAdmin or currentUser.isFinancialAidAdmin or currentUser.isSaasAdmin:
+        departments = list(Department.select().order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
+    else:
+        departments = list(getDepartmentsForSupervisor(currentUser).order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
 
     return render_template('main/supervisorPortal.html',
                             terms = [],
                             supervisors = [],
                             students = [],
-                            departments = [],
+                            departments = departments,
                             department = [],
                             currentUser = currentUser
                             )

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -1,5 +1,7 @@
 from flask import render_template, request, json, redirect, url_for, send_file, g, flash, jsonify
-from peewee import fn
+from peewee import JOIN
+from functools import reduce
+import operator
 from app.models.department import Department
 from app.models.supervisor import Supervisor
 from app.models.supervisorDepartment import SupervisorDepartment
@@ -110,38 +112,19 @@ def SupervisorPortalSearch():
             ]
 
         elif searchType == "supervisorSelect":
-            query = Supervisor.select().where(
-                        (Supervisor.preferred_name.contains(userInput)) |
-                        (Supervisor.legal_name.contains(userInput)) |
-                        (Supervisor.LAST_NAME.contains(userInput))
-                    )
-            
-            if allowed_departments is not None:
-                query = (query.join_from(Supervisor, LaborStatusForm)
-                              .join_from(LaborStatusForm, Department)
-                              .where(Department.DEPT_NAME.in_(allowed_departments))
-                              .distinct())
-            query = query.order_by(Supervisor.isActive.desc()).limit(10)
+            supervisor_query = search_person(Supervisor, userInput, allowed_departments)
+            supervisor_query = supervisor_query.order_by(Supervisor.isActive.desc()).limit(10)
             return [
                 {'id': sup.ID, 'FIRST_NAME': sup.FIRST_NAME, "LAST_NAME": sup.LAST_NAME, "isActive": sup.isActive} 
-                for sup in query
+                for sup in supervisor_query
             ]
 
         elif searchType == "studentSelect":
-            query = Student.select().where(
-                        (Student.preferred_name.contains(userInput)) |
-                        (Student.legal_name.contains(userInput)) |
-                        (Student.LAST_NAME.contains(userInput))
-                    )
-            if allowed_departments is not None:
-                query = (query.join_from(Student, LaborStatusForm)
-                              .join_from(LaborStatusForm, Department)
-                              .where(Department.DEPT_NAME.in_(allowed_departments))
-                              .distinct())
-            query = query.order_by(Student.LAST_NAME.asc()).limit(10)
+            student_query = search_person(Student, userInput, allowed_departments)
+            student_query = student_query.order_by(Student.LAST_NAME.asc()).limit(10)
             return [
                 {'id': stu.ID, 'FIRST_NAME': stu.FIRST_NAME, 'LAST_NAME': stu.LAST_NAME} 
-                for stu in query
+                for stu in student_query
             ]
 
         return []
@@ -156,6 +139,35 @@ def SupervisorPortalSearch():
         return jsonify(userList)
     except Exception as e:
         print('ERROR:', e, type(e))
+
+def search_person(model, userInput, allowed_departments=None):
+    """
+    Returns a Peewee SelectObject filtered so that all words in userInput
+    must appear in at least one of the model's fields.
+    """
+    words = userInput.strip().split()
+
+    word_conditions = []
+    for word in words:
+        word_conditions.append(
+            (model.preferred_name.contains(word)) |
+            (model.legal_name.contains(word)) |
+            (model.LAST_NAME.contains(word)) |
+            (model.ID.contains(word))
+        )
+
+    query = model.select().where(reduce(operator.and_, word_conditions))
+
+    if allowed_departments is not None:
+        query = (
+            query
+            .join_from(model, LaborStatusForm, JOIN.LEFT_OUTER)
+            .join_from(LaborStatusForm, Department, JOIN.LEFT_OUTER)
+            .where(Department.DEPT_NAME.in_(allowed_departments))
+            .distinct()
+        )
+
+    return query
 
 @main_bp.route('/lsf/<formHistoryId>/submitToBanner', methods=['GET']) 
 def submitToBanner(formHistoryId):

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -94,7 +94,7 @@ def SupervisorPortalSearch():
         if currentUser.isLaborAdmin or currentUser.isFinancialAidAdmin or currentUser.isSaasAdmin:
             allowed_departments = None  # unrestricted
         else:
-            allowed_departments = getDepartmentsForSupervisor(currentUser)
+            allowed_departments = [dept.DEPT_NAME for dept in getDepartmentsForSupervisor(currentUser)]
 
         if searchType == "termSelect":
             terms = Term.select().where(Term.termName.contains(userInput)).order_by(Term.termCode.desc())

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -132,7 +132,7 @@ def SupervisorPortalSearch():
     userInput = request.args.get("userInput")
 
     if not searchType or not userInput:
-        return jsonify({""}), 400
+        return jsonify({}), 400
     userList = searchSupervisorPortal(searchType, userInput)
     return jsonify(userList)
 

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -34,33 +34,6 @@ def supervisorPortal():
 
         return render_template('errors/403.html'), 403
     
-    terms = Term.select(Term.termName).order_by(Term.termCode.desc())
-    supervisorFirstName = fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name)
-    studentFirstName = fn.COALESCE(Student.preferred_name, Student.legal_name)
-    department = None
-    if currentUser.isLaborAdmin or currentUser.isFinancialAidAdmin or currentUser.isSaasAdmin:
-        departments = list(Department.select().order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
-        supervisors = (Supervisor.select(Supervisor, supervisorFirstName)
-                                 .order_by(Supervisor.isActive.desc(), supervisorFirstName.contains("Unknown"), supervisorFirstName, Supervisor.LAST_NAME))
-        students = (Student.select(Student, studentFirstName)
-                           .order_by(studentFirstName.contains("Unknown"), studentFirstName, Student.LAST_NAME))
-
-    else:
-        departments = list(getDepartmentsForSupervisor(currentUser).order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
-
-        supervisors = (Supervisor.select(Supervisor, supervisorFirstName)
-                                 .join_from(Supervisor, LaborStatusForm)
-                                 .join_from(LaborStatusForm, Department)
-                                 .where(Department.DEPT_NAME.in_(departments))
-                                 .distinct()
-                                 .order_by(Supervisor.isActive.desc(), supervisorFirstName.contains("Unknown"), supervisorFirstName, Supervisor.LAST_NAME))
-        
-        students = (Student.select(Student, studentFirstName)
-                           .join_from(Student, LaborStatusForm)
-                           .join_from(LaborStatusForm, Department)
-                           .where(Department.DEPT_NAME.in_(departments))
-                           .order_by(studentFirstName.contains("Unknown"), studentFirstName, Student.LAST_NAME)
-                           .distinct())
     if request.method == 'POST':
         return getDatatableData(request)
 

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -45,7 +45,7 @@ def supervisorPortal():
                             students = [],
                             departments = [],
                             department = [],
-                            currentUser = []
+                            currentUser = currentUser
                             )
 
 @main_bp.route('/supervisorPortal/addUserToDept', methods=['GET', 'POST'])

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -1,4 +1,4 @@
-from flask import render_template, request, json, redirect, url_for, send_file, g, flash
+from flask import render_template, request, json, redirect, url_for, send_file, g, flash, jsonify
 from peewee import fn
 from app.models.department import Department
 from app.models.supervisor import Supervisor
@@ -108,7 +108,22 @@ def downloadSupervisorPortalResults():
     )
     return send_file(excel.relativePath, as_attachment=True, attachment_filename=excel.relativePath.split('/').pop())
 
-@main_bp.route('/lsf/<formHistoryId>/submitToBanner', methods=['GET'])
+# WORK IN PROGRESS---------------------------------------------------
+@main_bp.route('/supervisorPortal/liveSearch', methods=['POST'])
+def SupervisorPortalSearch():
+    """
+        ADD DESCRIPTION HERE
+        Logic copied from adminManagement live search function
+    """
+    try:
+        rsp = eval(request.data.decode("utf-8"))
+        userList = searchForAdmin(rsp)
+        return jsonify(userList)
+    except Exception as e:
+        print('ERROR Loading Non Labor Admins:', e, type(e))
+        return jsonify(userList)
+
+@main_bp.route('/lsf/<formHistoryId>/submitToBanner', methods=['GET']) 
 def submitToBanner(formHistoryId):
     if not (g.currentUser.isLaborAdmin or g.currentUser.isLaborDepartmentStudent):
         return render_template('errors/403.html'), 403      

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -1,5 +1,5 @@
 from flask import render_template, request, json, redirect, url_for, send_file, g, flash, jsonify
-from peewee import fn
+from peewee import fn, DoesNotExist
 from app.models.department import Department
 from app.models.supervisor import Supervisor
 from app.models.supervisorDepartment import SupervisorDepartment
@@ -14,6 +14,8 @@ from app.logic.search import getDepartmentsForSupervisor
 from app.login_manager import require_login, logout
 from app.logic.getTableData import getDatatableData
 from app.logic.banner import Banner
+from app.models.user import User # remove later?
+from app.logic.tracy import Tracy # remove later?
 
 @main_bp.route('/logout', methods=['GET'])
 def triggerLogout():
@@ -109,19 +111,82 @@ def downloadSupervisorPortalResults():
     return send_file(excel.relativePath, as_attachment=True, attachment_filename=excel.relativePath.split('/').pop())
 
 # WORK IN PROGRESS---------------------------------------------------
-@main_bp.route('/supervisorPortal/liveSearch', methods=['POST'])
+@main_bp.route('/supervisorPortal/liveSearch', methods=['GET'])
 def SupervisorPortalSearch():
     """
         ADD DESCRIPTION HERE
         Logic copied from adminManagement live search function
     """
+    def searchSupervisorPortal(searchType, userInput):
+        if searchType == "termSelect":
+            termList = []
+            terms = Term.select().where(Term.termName.contains(userInput)).order_by(Term.termCode.desc())
+            for term in terms:
+                termList.append({'termCode': term.termCode,
+                                'termName': term.termName
+                                })
+            print("this is our term list:", termList)
+            return termList
+        elif searchType == "departmentSelect":
+            pass
+        elif searchType == "supervisorSelect":
+            pass
+        elif searchType == "studentSelect":
+            pass
+
+        # userList = []
+        # if adminType == "addlaborAdmin":
+        #     tracyStudents = Tracy().getStudentsFromUserInput(userInput)
+        #     students = []
+        #     for student in tracyStudents:
+        #         try:
+        #             existingUser = User.get(User.student == student.ID)
+        #             if existingUser.isLaborAdmin:
+        #                 pass
+        #             else:
+        #                 students.append(student)
+        #         except DoesNotExist as e:
+        #             students.append(student)
+        #     for student in students:
+        #         username = student.STU_EMAIL.split('@', 1)
+        #         userList.append({'username': username[0],
+        #                         'firstName': student.FIRST_NAME,
+        #                         'lastName': student.LAST_NAME,
+        #                         'type': 'Student'
+        #                         })
+        # tracySupervisors = Tracy().getSupervisorsFromUserInput(userInput)
+        # supervisors = []
+        # for supervisor in tracySupervisors:
+        #     try:
+        #         existingUser = User.get(User.supervisor == supervisor.ID)
+        #         if ((existingUser.isLaborAdmin and adminType == "addlaborAdmin")
+        #             or (existingUser.isSaasAdmin and adminType == "addSaasAdmin")
+        #             or (existingUser.isFinancialAidAdmin and adminType == "addFinAidAdmin")):
+        #             pass
+        #         else:
+        #             supervisors.append(supervisor)
+        #     except DoesNotExist as e:
+        #         supervisors.append(supervisor)
+        # for sup in supervisors:
+        #     username = sup.EMAIL.split('@', 1)
+        #     userList.append({'username': username[0],
+        #                     'firstName': sup.FIRST_NAME,
+        #                     'lastName': sup.LAST_NAME,
+        #                     'type': 'Supervisor'})
+        # return userList
+    
+    # The acutal function code starts here***********************
     try:
-        rsp = eval(request.data.decode("utf-8"))
-        userList = searchForAdmin(rsp)
+        searchType = request.args.get("searchType")
+        userInput = request.args.get("userInput")
+
+        if not searchType or not userInput:
+            return jsonify({""}), 400
+        userList = searchSupervisorPortal(searchType, userInput)
+        
         return jsonify(userList)
     except Exception as e:
-        print('ERROR Loading Non Labor Admins:', e, type(e))
-        return jsonify(userList)
+        print('ERROR:', e, type(e))
 
 @main_bp.route('/lsf/<formHistoryId>/submitToBanner', methods=['GET']) 
 def submitToBanner(formHistoryId):

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -42,9 +42,12 @@ def supervisorPortal():
     else:
         departments = list(getDepartmentsForSupervisor(currentUser).order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
 
+    currentTerm = Term.get(Term.termCode == g.openTerm)
+
     return render_template('main/supervisorPortal.html',
                             departments = departments,
-                            currentUser = currentUser
+                            currentUser = currentUser,
+                            currentTermName = currentTerm.termName
                             )
 
 @main_bp.route('/supervisorPortal/addUserToDept', methods=['GET', 'POST'])

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -43,11 +43,7 @@ def supervisorPortal():
         departments = list(getDepartmentsForSupervisor(currentUser).order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
 
     return render_template('main/supervisorPortal.html',
-                            terms = [],
-                            supervisors = [],
-                            students = [],
                             departments = departments,
-                            department = [],
                             currentUser = currentUser
                             )
 

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -12,7 +12,7 @@ from app.models.term import Term
 from app.controllers.admin_routes.allPendingForms import checkAdjustment
 from app.controllers.main_routes import main_bp
 from app.logic.download import CSVMaker, saveFormSearchResult, retrieveFormSearchResult
-from app.logic.search import getDepartmentsForSupervisor
+from app.logic.search import getDepartmentsForSupervisor, searchPerson
 from app.login_manager import require_login, logout
 from app.logic.getTableData import getDatatableData
 from app.logic.banner import Banner
@@ -111,7 +111,7 @@ def SupervisorPortalSearch():
             ]
 
         elif searchType == "supervisorSelect":
-            supervisor_query = search_person(Supervisor, userInput, allowed_departments)
+            supervisor_query = searchPerson(Supervisor, userInput, allowed_departments)
             supervisor_query = supervisor_query.order_by(Supervisor.isActive.desc()).limit(10)
             return [
                 {'id': sup.ID, 'FIRST_NAME': sup.FIRST_NAME, "LAST_NAME": sup.LAST_NAME, "isActive": sup.isActive} 
@@ -119,7 +119,7 @@ def SupervisorPortalSearch():
             ]
 
         elif searchType == "studentSelect":
-            student_query = search_person(Student, userInput, allowed_departments)
+            student_query = searchPerson(Student, userInput, allowed_departments)
             student_query = student_query.order_by(Student.LAST_NAME.asc()).limit(10)
             return [
                 {'id': stu.ID, 'FIRST_NAME': stu.FIRST_NAME, 'LAST_NAME': stu.LAST_NAME} 
@@ -128,45 +128,13 @@ def SupervisorPortalSearch():
 
         return []
     
-    try:
-        searchType = request.args.get("searchType")
-        userInput = request.args.get("userInput")
+    searchType = request.args.get("searchType")
+    userInput = request.args.get("userInput")
 
-        if not searchType or not userInput:
-            return jsonify({""}), 400
-        userList = searchSupervisorPortal(searchType, userInput)
-        return jsonify(userList)
-    except Exception as e:
-        print('ERROR:', e, type(e))
-
-def search_person(model, userInput, allowed_departments=None):
-    """
-    Returns a Peewee SelectObject filtered so that all words in userInput
-    must appear in at least one of the model's fields.
-    """
-    words = userInput.strip().split()
-
-    word_conditions = []
-    for word in words:
-        word_conditions.append(
-            (model.preferred_name.contains(word)) |
-            (model.legal_name.contains(word)) |
-            (model.LAST_NAME.contains(word)) |
-            (model.ID.contains(word))
-        )
-
-    query = model.select().where(reduce(operator.and_, word_conditions))
-
-    if allowed_departments is not None:
-        query = (
-            query
-            .join_from(model, LaborStatusForm, JOIN.LEFT_OUTER)
-            .join_from(LaborStatusForm, Department, JOIN.LEFT_OUTER)
-            .where(Department.DEPT_NAME.in_(allowed_departments))
-            .distinct()
-        )
-
-    return query
+    if not searchType or not userInput:
+        return jsonify({""}), 400
+    userList = searchSupervisorPortal(searchType, userInput)
+    return jsonify(userList)
 
 @main_bp.route('/lsf/<formHistoryId>/submitToBanner', methods=['GET']) 
 def submitToBanner(formHistoryId):

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -183,7 +183,6 @@ def SupervisorPortalSearch():
         if not searchType or not userInput:
             return jsonify({""}), 400
         userList = searchSupervisorPortal(searchType, userInput)
-        
         return jsonify(userList)
     except Exception as e:
         print('ERROR:', e, type(e))

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -45,19 +45,18 @@ def supervisorPortal():
 
     else:
         departments = list(getDepartmentsForSupervisor(currentUser).order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
-        deptNames = [department.DEPT_NAME for department in departments]
 
         supervisors = (Supervisor.select(Supervisor, supervisorFirstName)
                                  .join_from(Supervisor, LaborStatusForm)
                                  .join_from(LaborStatusForm, Department)
-                                 .where(Department.DEPT_NAME.in_(deptNames))
+                                 .where(Department.DEPT_NAME.in_(departments))
                                  .distinct()
                                  .order_by(Supervisor.isActive.desc(), supervisorFirstName.contains("Unknown"), supervisorFirstName, Supervisor.LAST_NAME))
         
         students = (Student.select(Student, studentFirstName)
                            .join_from(Student, LaborStatusForm)
                            .join_from(LaborStatusForm, Department)
-                           .where(Department.DEPT_NAME.in_(deptNames))
+                           .where(Department.DEPT_NAME.in_(departments))
                            .order_by(studentFirstName.contains("Unknown"), studentFirstName, Student.LAST_NAME)
                            .distinct())
     if request.method == 'POST':

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -83,7 +83,6 @@ def downloadSupervisorPortalResults():
     )
     return send_file(excel.relativePath, as_attachment=True, attachment_filename=excel.relativePath.split('/').pop())
 
-# WORK IN PROGRESS---------------------------------------------------
 @main_bp.route('/supervisorPortal/liveSearch', methods=['GET'])
 def SupervisorPortalSearch():
     """
@@ -111,14 +110,12 @@ def SupervisorPortalSearch():
             ]
 
         elif searchType == "supervisorSelect":
-            query = (
-                    Supervisor
-                     .select(Supervisor, fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name).alias("FIRST_NAME"))
-                     .where(
-                            fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name).contains(userInput),
-                            Supervisor.LAST_NAME.contains(userInput)
-                        )
+            query = Supervisor.select().where(
+                        (Supervisor.preferred_name.contains(userInput)) |
+                        (Supervisor.legal_name.contains(userInput)) |
+                        (Supervisor.LAST_NAME.contains(userInput))
                     )
+            
             if allowed_departments is not None:
                 query = (query.join_from(Supervisor, LaborStatusForm)
                               .join_from(LaborStatusForm, Department)
@@ -126,18 +123,15 @@ def SupervisorPortalSearch():
                               .distinct())
             query = query.order_by(Supervisor.isActive.desc()).limit(10)
             return [
-                {'id': sup.id, 'FIRST_NAME': sup.name, "LAST_NAME": sup.LAST_NAME, "isActive": sup.isActive} 
+                {'id': sup.ID, 'FIRST_NAME': sup.FIRST_NAME, "LAST_NAME": sup.LAST_NAME, "isActive": sup.isActive} 
                 for sup in query
             ]
 
         elif searchType == "studentSelect":
-            query = (
-                    Student
-                     .select(Student, fn.COALESCE(Student.preferred_name, Student.legal_name).alias("name"))
-                     .where(
-                            fn.COALESCE(Student.preferred_name, Student.legal_name).contains(userInput) |
-                            Student.LAST_NAME.contains(userInput)
-                            )
+            query = Student.select().where(
+                        (Student.preferred_name.contains(userInput)) |
+                        (Student.legal_name.contains(userInput)) |
+                        (Student.LAST_NAME.contains(userInput))
                     )
             if allowed_departments is not None:
                 query = (query.join_from(Student, LaborStatusForm)
@@ -146,7 +140,7 @@ def SupervisorPortalSearch():
                               .distinct())
             query = query.order_by(Student.LAST_NAME.asc()).limit(10)
             return [
-                {'id': stu.id, 'FIRST_NAME': stu.FIRST_NAME, 'LAST_NAME': stu.LAST_NAME} 
+                {'id': stu.ID, 'FIRST_NAME': stu.FIRST_NAME, 'LAST_NAME': stu.LAST_NAME} 
                 for stu in query
             ]
 

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -1,5 +1,5 @@
 from flask import render_template, request, json, redirect, url_for, send_file, g, flash, jsonify
-from peewee import fn, DoesNotExist
+from peewee import fn
 from app.models.department import Department
 from app.models.supervisor import Supervisor
 from app.models.supervisorDepartment import SupervisorDepartment
@@ -65,12 +65,12 @@ def supervisorPortal():
         return getDatatableData(request)
 
     return render_template('main/supervisorPortal.html',
-                            terms = terms,
-                            supervisors = supervisors,
-                            students = students,
-                            departments = departments,
-                            department = department,
-                            currentUser = currentUser
+                            terms = [],
+                            supervisors = [],
+                            students = [],
+                            departments = [],
+                            department = [],
+                            currentUser = []
                             )
 
 @main_bp.route('/supervisorPortal/addUserToDept', methods=['GET', 'POST'])
@@ -114,68 +114,71 @@ def downloadSupervisorPortalResults():
 @main_bp.route('/supervisorPortal/liveSearch', methods=['GET'])
 def SupervisorPortalSearch():
     """
-        ADD DESCRIPTION HERE
-        Logic copied from adminManagement live search function
+    Returns a list of users that match a given string
     """
     def searchSupervisorPortal(searchType, userInput):
-        if searchType == "termSelect":
-            termList = []
-            terms = Term.select().where(Term.termName.contains(userInput)).order_by(Term.termCode.desc())
-            for term in terms:
-                termList.append({'termCode': term.termCode,
-                                'termName': term.termName
-                                })
-            print("this is our term list:", termList)
-            return termList
-        elif searchType == "departmentSelect":
-            pass
-        elif searchType == "supervisorSelect":
-            pass
-        elif searchType == "studentSelect":
-            pass
+        currentUser = require_login()
+        if currentUser.isLaborAdmin or currentUser.isFinancialAidAdmin or currentUser.isSaasAdmin:
+            allowed_departments = None  # unrestricted
+        else:
+            allowed_departments = getDepartmentsForSupervisor(currentUser)
 
-        # userList = []
-        # if adminType == "addlaborAdmin":
-        #     tracyStudents = Tracy().getStudentsFromUserInput(userInput)
-        #     students = []
-        #     for student in tracyStudents:
-        #         try:
-        #             existingUser = User.get(User.student == student.ID)
-        #             if existingUser.isLaborAdmin:
-        #                 pass
-        #             else:
-        #                 students.append(student)
-        #         except DoesNotExist as e:
-        #             students.append(student)
-        #     for student in students:
-        #         username = student.STU_EMAIL.split('@', 1)
-        #         userList.append({'username': username[0],
-        #                         'firstName': student.FIRST_NAME,
-        #                         'lastName': student.LAST_NAME,
-        #                         'type': 'Student'
-        #                         })
-        # tracySupervisors = Tracy().getSupervisorsFromUserInput(userInput)
-        # supervisors = []
-        # for supervisor in tracySupervisors:
-        #     try:
-        #         existingUser = User.get(User.supervisor == supervisor.ID)
-        #         if ((existingUser.isLaborAdmin and adminType == "addlaborAdmin")
-        #             or (existingUser.isSaasAdmin and adminType == "addSaasAdmin")
-        #             or (existingUser.isFinancialAidAdmin and adminType == "addFinAidAdmin")):
-        #             pass
-        #         else:
-        #             supervisors.append(supervisor)
-        #     except DoesNotExist as e:
-        #         supervisors.append(supervisor)
-        # for sup in supervisors:
-        #     username = sup.EMAIL.split('@', 1)
-        #     userList.append({'username': username[0],
-        #                     'firstName': sup.FIRST_NAME,
-        #                     'lastName': sup.LAST_NAME,
-        #                     'type': 'Supervisor'})
-        # return userList
+        if searchType == "termSelect":
+            terms = Term.select().where(Term.termName.contains(userInput)).order_by(Term.termCode.desc())
+            return [{'termCode': term.termCode, 'termName': term.termName} for term in terms]
+
+        elif searchType == "departmentSelect":
+            query = Department.select().where(Department.DEPT_NAME.contains(userInput))
+            if allowed_departments is not None:
+                query = query.where(Department.DEPT_NAME.in_(allowed_departments))
+            query = query.order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()).limit(10)
+            return [
+                {'DEPT_NAME': dept.DEPT_NAME, 'id': dept.id, 'isActive': dept.isActive} 
+                for dept in query
+            ]
+
+        elif searchType == "supervisorSelect":
+            query = (
+                    Supervisor
+                     .select(Supervisor, fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name).alias("FIRST_NAME"))
+                     .where(
+                            fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name).contains(userInput),
+                            Supervisor.LAST_NAME.contains(userInput)
+                        )
+                    )
+            if allowed_departments is not None:
+                query = (query.join_from(Supervisor, LaborStatusForm)
+                              .join_from(LaborStatusForm, Department)
+                              .where(Department.DEPT_NAME.in_(allowed_departments))
+                              .distinct())
+            query = query.order_by(Supervisor.isActive.desc()).limit(10)
+            return [
+                {'id': sup.id, 'FIRST_NAME': sup.name, "LAST_NAME": sup.LAST_NAME, "isActive": sup.isActive} 
+                for sup in query
+            ]
+
+        elif searchType == "studentSelect":
+            query = (
+                    Student
+                     .select(Student, fn.COALESCE(Student.preferred_name, Student.legal_name).alias("name"))
+                     .where(
+                            fn.COALESCE(Student.preferred_name, Student.legal_name).contains(userInput) |
+                            Student.LAST_NAME.contains(userInput)
+                            )
+                    )
+            if allowed_departments is not None:
+                query = (query.join_from(Student, LaborStatusForm)
+                              .join_from(LaborStatusForm, Department)
+                              .where(Department.DEPT_NAME.in_(allowed_departments))
+                              .distinct())
+            query = query.order_by(Student.LAST_NAME.asc()).limit(10)
+            return [
+                {'id': stu.id, 'FIRST_NAME': stu.FIRST_NAME, 'LAST_NAME': stu.LAST_NAME} 
+                for stu in query
+            ]
+
+        return []
     
-    # The acutal function code starts here***********************
     try:
         searchType = request.args.get("searchType")
         userInput = request.args.get("userInput")

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -42,12 +42,9 @@ def supervisorPortal():
     else:
         departments = list(getDepartmentsForSupervisor(currentUser).order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
 
-    currentTerm = Term.get(Term.termCode == g.openTerm)
-
     return render_template('main/supervisorPortal.html',
                             departments = departments,
-                            currentUser = currentUser,
-                            currentTermName = currentTerm.termName
+                            currentUser = currentUser
                             )
 
 @main_bp.route('/supervisorPortal/addUserToDept', methods=['GET', 'POST'])

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -107,7 +107,7 @@ def SupervisorPortalSearch():
                 query = query.where(Department.DEPT_NAME.in_(allowed_departments))
             query = query.order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()).limit(10)
             return [
-                {'DEPT_NAME': dept.DEPT_NAME, 'id': dept.id, 'isActive': dept.isActive} 
+                {'DEPT_NAME': dept.DEPT_NAME, 'id': dept.departmentID, 'isActive': dept.isActive} 
                 for dept in query
             ]
 

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -89,7 +89,6 @@ def SupervisorPortalSearch():
     """
     Returns a list of users that match a given string
     """
-    print('liveSearch called')
     def searchSupervisorPortal(searchType, userInput):
         currentUser = require_login()
         if currentUser.isLaborAdmin or currentUser.isFinancialAidAdmin or currentUser.isSaasAdmin:

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -6,6 +6,7 @@ from app.models.supervisorDepartment import SupervisorDepartment
 from app.models.student import Student
 from app.models.laborStatusForm import LaborStatusForm
 from app.models.formHistory import FormHistory
+from app.models.term import Term
 from app.controllers.admin_routes.allPendingForms import checkAdjustment
 from app.controllers.main_routes import main_bp
 from app.logic.download import CSVMaker, saveFormSearchResult, retrieveFormSearchResult
@@ -31,7 +32,7 @@ def supervisorPortal():
 
         return render_template('errors/403.html'), 403
     
-    terms = LaborStatusForm.select(LaborStatusForm.termCode).distinct().order_by(LaborStatusForm.termCode.desc())
+    terms = Term.select(Term.termName).order_by(Term.termCode.desc())
     supervisorFirstName = fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name)
     studentFirstName = fn.COALESCE(Student.preferred_name, Student.legal_name)
     department = None

--- a/app/logic/getTableData.py
+++ b/app/logic/getTableData.py
@@ -3,7 +3,7 @@ from datetime import datetime, date
 from functools import reduce
 
 from flask import json, jsonify, g, make_response
-from peewee import fn, Case
+from peewee import fn, SQL
 
 from app.controllers.admin_routes.allPendingForms import checkAdjustment
 from app.logic.search import getDepartmentsForSupervisor
@@ -68,20 +68,28 @@ def getDatatableData(request):
             else:
                 clauses.append(field == value)
     # This expression creates SQL AND operator between the conditions added to 'clauses' list
-    formSearchResults = (FormHistory.select()
-                                    .join(LaborStatusForm, on=(FormHistory.formID == LaborStatusForm.laborStatusFormID))
-                                    .join(Department, on=(LaborStatusForm.department == Department.departmentID))
-                                    .join(Supervisor, on=(LaborStatusForm.supervisor == Supervisor.ID))
-                                    .join(Student, on=(LaborStatusForm.studentSupervisee == Student.ID))
-                                    .join(Term, on=(LaborStatusForm.termCode == Term.termCode))
-                                    .join(User, on=(FormHistory.createdBy == User.userID)))
-    if clauses:
-        formSearchResults = formSearchResults.where(reduce(operator.and_, clauses))
     if not g.currentUser.isLaborAdmin:
-        supervisorDepartments = getDepartmentsForSupervisor(g.currentUser)
-        formSearchResults = formSearchResults.where(FormHistory.formID.department.in_(supervisorDepartments)) 
-    recordsTotal = formSearchResults.count()
+        supervisor_filter = (
+            (Supervisor.ID == g.currentUser.supervisor.ID) |
+            (FormHistory.createdBy == g.currentUser)
+        )
+        clauses.append(supervisor_filter)
 
+    formSearchResults = (
+                            FormHistory.select()
+                            .join(LaborStatusForm, on=(FormHistory.formID == LaborStatusForm.laborStatusFormID))
+                            .join(Department, on=(LaborStatusForm.department == Department.departmentID))
+                            .join(Supervisor, on=(LaborStatusForm.supervisor == Supervisor.ID))
+                            .join(Student, on=(LaborStatusForm.studentSupervisee == Student.ID))
+                            .join(Term, on=(LaborStatusForm.termCode == Term.termCode))
+                            .join(User, on=(FormHistory.createdBy == User.userID))
+                            .where(
+                                reduce(operator.and_, clauses)
+                            ) if clauses else SQL("1=1")
+                        )
+
+    recordsTotal = formSearchResults.count()
+    exit(1)
     # this checks and finds the first value that is not null of preferred_name, legal_name and last_name.
     # including last_name is necessary because there are like 4 cases where someone has no first name or last name, instead their full name is
     # stored in last_name

--- a/app/logic/getTableData.py
+++ b/app/logic/getTableData.py
@@ -68,26 +68,18 @@ def getDatatableData(request):
             else:
                 clauses.append(field == value)
     # This expression creates SQL AND operator between the conditions added to 'clauses' list
+    formSearchResults = (FormHistory.select()
+                                    .join(LaborStatusForm, on=(FormHistory.formID == LaborStatusForm.laborStatusFormID))
+                                    .join(Department, on=(LaborStatusForm.department == Department.departmentID))
+                                    .join(Supervisor, on=(LaborStatusForm.supervisor == Supervisor.ID))
+                                    .join(Student, on=(LaborStatusForm.studentSupervisee == Student.ID))
+                                    .join(Term, on=(LaborStatusForm.termCode == Term.termCode))
+                                    .join(User, on=(FormHistory.createdBy == User.userID)))
+    if clauses:
+        formSearchResults = formSearchResults.where(reduce(operator.and_, clauses))
     if not g.currentUser.isLaborAdmin:
-        supervisor_filter = (
-            (Supervisor.ID == g.currentUser.supervisor.ID) |
-            (FormHistory.createdBy == g.currentUser)
-        )
-        clauses.append(supervisor_filter)
-
-    formSearchResults = (
-                            FormHistory.select()
-                            .join(LaborStatusForm, on=(FormHistory.formID == LaborStatusForm.laborStatusFormID))
-                            .join(Department, on=(LaborStatusForm.department == Department.departmentID))
-                            .join(Supervisor, on=(LaborStatusForm.supervisor == Supervisor.ID))
-                            .join(Student, on=(LaborStatusForm.studentSupervisee == Student.ID))
-                            .join(Term, on=(LaborStatusForm.termCode == Term.termCode))
-                            .join(User, on=(FormHistory.createdBy == User.userID))
-                            .where(
-                                reduce(operator.and_, clauses)
-                            ) if clauses else SQL("1=1")
-                        )
-
+        supervisorDepartments = getDepartmentsForSupervisor(g.currentUser)
+        formSearchResults = formSearchResults.where(FormHistory.formID.department.in_(supervisorDepartments)) 
     recordsTotal = formSearchResults.count()
     # this checks and finds the first value that is not null of preferred_name, legal_name and last_name.
     # including last_name is necessary because there are like 4 cases where someone has no first name or last name, instead their full name is

--- a/app/logic/getTableData.py
+++ b/app/logic/getTableData.py
@@ -3,7 +3,7 @@ from datetime import datetime, date
 from functools import reduce
 
 from flask import json, jsonify, g, make_response
-from peewee import fn, Case
+from peewee import fn, SQL
 
 from app.controllers.admin_routes.allPendingForms import checkAdjustment
 from app.logic.search import getDepartmentsForSupervisor
@@ -68,20 +68,27 @@ def getDatatableData(request):
             else:
                 clauses.append(field == value)
     # This expression creates SQL AND operator between the conditions added to 'clauses' list
-    formSearchResults = (FormHistory.select()
-                                    .join(LaborStatusForm, on=(FormHistory.formID == LaborStatusForm.laborStatusFormID))
-                                    .join(Department, on=(LaborStatusForm.department == Department.departmentID))
-                                    .join(Supervisor, on=(LaborStatusForm.supervisor == Supervisor.ID))
-                                    .join(Student, on=(LaborStatusForm.studentSupervisee == Student.ID))
-                                    .join(Term, on=(LaborStatusForm.termCode == Term.termCode))
-                                    .join(User, on=(FormHistory.createdBy == User.userID)))
-    if clauses:
-        formSearchResults = formSearchResults.where(reduce(operator.and_, clauses))
     if not g.currentUser.isLaborAdmin:
-        supervisorDepartments = getDepartmentsForSupervisor(g.currentUser)
-        formSearchResults = formSearchResults.where(FormHistory.formID.department.in_(supervisorDepartments)) 
-    recordsTotal = formSearchResults.count()
+        supervisor_filter = (
+            (Supervisor.ID == g.currentUser.supervisor.ID) |
+            (FormHistory.createdBy == g.currentUser)
+        )
+        clauses.append(supervisor_filter)
 
+    formSearchResults = (
+                            FormHistory.select()
+                            .join(LaborStatusForm, on=(FormHistory.formID == LaborStatusForm.laborStatusFormID))
+                            .join(Department, on=(LaborStatusForm.department == Department.departmentID))
+                            .join(Supervisor, on=(LaborStatusForm.supervisor == Supervisor.ID))
+                            .join(Student, on=(LaborStatusForm.studentSupervisee == Student.ID))
+                            .join(Term, on=(LaborStatusForm.termCode == Term.termCode))
+                            .join(User, on=(FormHistory.createdBy == User.userID))
+                            .where(
+                                reduce(operator.and_, clauses)
+                            ) if clauses else SQL("1=1")
+                        )
+
+    recordsTotal = formSearchResults.count()
     # this checks and finds the first value that is not null of preferred_name, legal_name and last_name.
     # including last_name is necessary because there are like 4 cases where someone has no first name or last name, instead their full name is
     # stored in last_name

--- a/app/logic/getTableData.py
+++ b/app/logic/getTableData.py
@@ -1,5 +1,5 @@
 import operator
-from datetime import datetime, date
+from datetime import date
 from functools import reduce
 
 from flask import json, jsonify, g, make_response
@@ -40,7 +40,7 @@ def getDatatableData(request):
     if termCode == "currentTerm":
         termCode = g.openTerm
     elif termCode == "activeTerms":
-        termCode = list(Term.select(Term.termCode).where(Term.termEnd >= datetime.now()))
+        termCode = list(Term.select(Term.termCode).where(Term.termEnd >= date.today()))
     departmentId = queryFilterDict.get('departmentID', "")
     supervisorId = queryFilterDict.get('supervisorID', "")
     if supervisorId == "currentUser":

--- a/app/logic/getTableData.py
+++ b/app/logic/getTableData.py
@@ -80,7 +80,7 @@ def getDatatableData(request):
     if not g.currentUser.isLaborAdmin:
         supervisorDepartments = [d.departmentID for d in getDepartmentsForSupervisor(g.currentUser)]
         formSearchResults = formSearchResults.where(FormHistory.formID.department.in_(supervisorDepartments)) 
-    recordsTotal = len(formSearchResults)
+    recordsTotal = formSearchResults.count()
 
     # this checks and finds the first value that is not null of preferred_name, legal_name and last_name.
     # including last_name is necessary because there are like 4 cases where someone has no first name or last name, instead their full name is

--- a/app/logic/getTableData.py
+++ b/app/logic/getTableData.py
@@ -78,7 +78,7 @@ def getDatatableData(request):
     if clauses:
         formSearchResults = formSearchResults.where(reduce(operator.and_, clauses))
     if not g.currentUser.isLaborAdmin:
-        supervisorDepartments = [d.departmentID for d in getDepartmentsForSupervisor(g.currentUser)]
+        supervisorDepartments = getDepartmentsForSupervisor(g.currentUser)
         formSearchResults = formSearchResults.where(FormHistory.formID.department.in_(supervisorDepartments)) 
     recordsTotal = formSearchResults.count()
 

--- a/app/logic/search.py
+++ b/app/logic/search.py
@@ -4,6 +4,7 @@ from app.models.supervisorDepartment import SupervisorDepartment
 from app.models.laborStatusForm import LaborStatusForm
 from app.models.department import Department
 from app.models.formHistory import FormHistory
+from app.models.term import Term
 
 from functools import reduce
 import operator
@@ -67,6 +68,44 @@ def getDepartmentsForSupervisor(currentUser):
 def getSupervisorsForDepartment(departmentId):
     departmentSupervisors = Supervisor.select().join(SupervisorDepartment).where(SupervisorDepartment.department == departmentId).order_by(Supervisor.LAST_NAME).execute()
     return departmentSupervisors
+
+def searchSupervisorPortal(currentUser, searchType, userInput):
+    if currentUser.isLaborAdmin or currentUser.isFinancialAidAdmin or currentUser.isSaasAdmin:
+        allowed_departments = None  # unrestricted
+    else:
+        allowed_departments = [dept.DEPT_NAME for dept in getDepartmentsForSupervisor(currentUser)]
+
+    if searchType == "termSelect":
+        terms = Term.select().where(Term.termName.contains(userInput)).order_by(Term.termCode.desc())
+        return [{'termCode': term.termCode, 'termName': term.termName} for term in terms]
+
+    elif searchType == "departmentSelect":
+        query = Department.select().where(Department.DEPT_NAME.contains(userInput))
+        if allowed_departments is not None:
+            query = query.where(Department.DEPT_NAME.in_(allowed_departments))
+        query = query.order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()).limit(10)
+        return [
+            {'DEPT_NAME': dept.DEPT_NAME, 'id': dept.departmentID, 'isActive': dept.isActive} 
+            for dept in query
+        ]
+
+    elif searchType == "supervisorSelect":
+        supervisor_query = searchPerson(Supervisor, userInput, allowed_departments)
+        supervisor_query = supervisor_query.order_by(Supervisor.isActive.desc()).limit(10)
+        return [
+            {'id': sup.ID, 'FIRST_NAME': sup.FIRST_NAME, "LAST_NAME": sup.LAST_NAME, "isActive": sup.isActive} 
+            for sup in supervisor_query
+        ]
+
+    elif searchType == "studentSelect":
+        student_query = searchPerson(Student, userInput, allowed_departments)
+        student_query = student_query.order_by(Student.LAST_NAME.asc()).limit(10)
+        return [
+            {'id': stu.ID, 'FIRST_NAME': stu.FIRST_NAME, 'LAST_NAME': stu.LAST_NAME} 
+            for stu in student_query
+        ]
+
+    return []
 
 def searchPerson(model, userInput, allowed_departments=None):
     """

--- a/app/logic/search.py
+++ b/app/logic/search.py
@@ -46,19 +46,22 @@ def getDepartmentsForSupervisor(currentUser):
     """
     Given currentUser, find and return all departments that the user is associated with.
     """
-    # query the SupervisorDepartment table to see if any entries exist for the currentUser
-    supervisorDepts = Department.select().join(SupervisorDepartment).where(SupervisorDepartment.supervisor == currentUser.supervisor)
-
-    # queries all forms to see what departments the user has interacted with
-    departments = (Department.select(Department)
-                    .join_from(Department, LaborStatusForm)
-                    .join_from(LaborStatusForm, FormHistory)
-                    .join_from(LaborStatusForm, Supervisor)
-                    .where((LaborStatusForm.supervisor.ID == currentUser.supervisor.ID) | (FormHistory.createdBy == currentUser)).order_by(Department.DEPT_NAME)
-                    .distinct()
+    # queries all forms to see the department IDs which the user has interacted with
+    departments = (
+                    Department.select(Department.departmentID)
+                    .join(LaborStatusForm)
+                    .join(FormHistory)
+                    .join(Supervisor)
+                    .join(SupervisorDepartment)
+                    .where(
+                        (SupervisorDepartment.supervisor == currentUser.supervisor) |
+                        (LaborStatusForm.supervisor.ID == currentUser.supervisor.ID) | 
+                        (FormHistory.createdBy == currentUser)
                     )
-    alldepts = departments.union(supervisorDepts)
-    return alldepts
+                    .order_by(Department.DEPT_NAME)
+                    .distinct()
+                )
+    return departments
 
 def getSupervisorsForDepartment(departmentId):
     departmentSupervisors = Supervisor.select().join(SupervisorDepartment).where(SupervisorDepartment.department == departmentId).order_by(Supervisor.LAST_NAME).execute()

--- a/app/logic/search.py
+++ b/app/logic/search.py
@@ -48,7 +48,7 @@ def getDepartmentsForSupervisor(currentUser):
     """
     # queries all forms to see the department IDs which the user has interacted with
     departments = (
-                    Department.select(Department.departmentID)
+                    Department.select(Department)
                     .join(LaborStatusForm)
                     .join(FormHistory)
                     .join(Supervisor)

--- a/app/logic/search.py
+++ b/app/logic/search.py
@@ -46,22 +46,19 @@ def getDepartmentsForSupervisor(currentUser):
     """
     Given currentUser, find and return all departments that the user is associated with.
     """
-    # queries all forms to see the department IDs which the user has interacted with
-    departments = (
-                    Department.select(Department)
-                    .join(LaborStatusForm)
-                    .join(FormHistory)
-                    .join(Supervisor)
-                    .join(SupervisorDepartment)
-                    .where(
-                        (SupervisorDepartment.supervisor == currentUser.supervisor) |
-                        (LaborStatusForm.supervisor.ID == currentUser.supervisor.ID) | 
-                        (FormHistory.createdBy == currentUser)
-                    )
-                    .order_by(Department.DEPT_NAME)
+    # query the SupervisorDepartment table to see if any entries exist for the currentUser
+    supervisorDepts = Department.select().join(SupervisorDepartment).where(SupervisorDepartment.supervisor == currentUser.supervisor)
+
+    # queries all forms to see what departments the user has interacted with
+    departments = (Department.select(Department)
+                    .join_from(Department, LaborStatusForm)
+                    .join_from(LaborStatusForm, FormHistory)
+                    .join_from(LaborStatusForm, Supervisor)
+                    .where((LaborStatusForm.supervisor.ID == currentUser.supervisor.ID) | (FormHistory.createdBy == currentUser)).order_by(Department.DEPT_NAME)
                     .distinct()
-                )
-    return departments
+                    )
+    alldepts = departments.union(supervisorDepts)
+    return alldepts
 
 def getSupervisorsForDepartment(departmentId):
     departmentSupervisors = Supervisor.select().join(SupervisorDepartment).where(SupervisorDepartment.department == departmentId).order_by(Supervisor.LAST_NAME).execute()

--- a/app/logic/search.py
+++ b/app/logic/search.py
@@ -5,6 +5,10 @@ from app.models.laborStatusForm import LaborStatusForm
 from app.models.department import Department
 from app.models.formHistory import FormHistory
 
+from functools import reduce
+import operator
+from peewee import JOIN
+
 def limitSearchByUserDepartment(students, currentUser):
     """
     Given a list of student dictionaries and the currentUser the function will only return a
@@ -63,3 +67,32 @@ def getDepartmentsForSupervisor(currentUser):
 def getSupervisorsForDepartment(departmentId):
     departmentSupervisors = Supervisor.select().join(SupervisorDepartment).where(SupervisorDepartment.department == departmentId).order_by(Supervisor.LAST_NAME).execute()
     return departmentSupervisors
+
+def searchPerson(model, userInput, allowed_departments=None):
+    """
+    Returns a Peewee SelectObject filtered so that all words in userInput
+    must appear in at least one of the model's fields.
+    """
+    words = userInput.strip().split()
+
+    word_conditions = []
+    for word in words:
+        word_conditions.append(
+            (model.preferred_name.contains(word)) |
+            (model.legal_name.contains(word)) |
+            (model.LAST_NAME.contains(word)) |
+            (model.ID.contains(word))
+        )
+
+    query = model.select().where(reduce(operator.and_, word_conditions))
+
+    if allowed_departments is not None:
+        query = (
+            query
+            .join_from(model, LaborStatusForm, JOIN.LEFT_OUTER)
+            .join_from(LaborStatusForm, Department, JOIN.LEFT_OUTER)
+            .where(Department.DEPT_NAME.in_(allowed_departments))
+            .distinct()
+        )
+
+    return query

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -114,6 +114,7 @@ $(document).ready(function () {
       fetchSimpleView(cookieStr)
       switchViewButton('simple')
     }
+    loadSavedSearchOptions(cookieJSON)
     setFormSearchValues(cookieJSON)
 
   } else {
@@ -247,14 +248,21 @@ case "mySupervisees":
   queryDict = {
     'view': currentView,
     'termCode': termCode,
+    'termName': $('#termSelect option:selected').text(),
     'departmentID': departmentID,
+    'departmentName': $('#departmentSelect option:selected').text(),
+    'departmentContent': $('#departmentSelect option:selected').attr('data-content'),
     'supervisorID': supervisorID,
+    'supervisorName': $('#supervisorSelect option:selected').text(),
+    'supervisorContent': $('#supervisorSelect option:selected').attr('data-content'),
     'studentID': studentID,
+    'studentName': $('#studentSelect option:selected').text(),
+    'studentContent': $('#studentSelect option:selected').attr('data-content'),
     'formStatus': formStatusList,
     'formType': formTypeList,
     'sortBy': sortBy,
     'order': order
-  };
+};
   setFormSearchValues(queryDict)
   data = JSON.stringify(queryDict)
 
@@ -382,6 +390,50 @@ function updateDownloadButton(response){
         } else {
           $("#download").prop('disabled', true);
         }
+}
+
+function loadSavedSearchOptions(searchDict) {
+  // creates the search options that setFormSearchValues uses
+  if (searchDict.termCode && searchDict.termCode !== "" && searchDict.termCode !== "activeTerms") {
+    if ($(`#termSelect option[value="${searchDict.termCode}"]`).length === 0) {
+      $('#termSelect').append($("<option>", {
+        value: searchDict.termCode,
+        text: searchDict.termName
+      }));
+    }
+  }
+  
+  if (searchDict.supervisorID && searchDict.supervisorID !== "" && searchDict.supervisorID !== "currentUser") {
+    if ($(`#supervisorSelect option[value="${searchDict.supervisorID}"]`).length === 0) {
+      $('#supervisorSelect').append($("<option>", {
+        value: searchDict.supervisorID,
+        text: searchDict.supervisorName,
+        "data-content": searchDict.supervisorContent || searchDict.supervisorName
+      }));
+    }
+  }
+  
+  if (searchDict.studentID && searchDict.studentID !== "") {
+    if ($(`#studentSelect option[value="${searchDict.studentID}"]`).length === 0) {
+      $('#studentSelect').append($("<option>", {
+        value: searchDict.studentID,
+        text: searchDict.studentName,
+        "data-content": searchDict.studentContent || searchDict.studentName
+      }));
+    }
+  }
+  
+  if (searchDict.departmentID && searchDict.departmentID !== "") {
+    if ($(`#departmentSelect option[value="${searchDict.departmentID}"]`).length === 0) {
+      $('#departmentSelect').append($("<option>", {
+        value: searchDict.departmentID,
+        text: searchDict.departmentName,
+        "data-content": searchDict.departmentContent || searchDict.departmentName
+      }));
+    }
+  }
+  
+  $('.selectpicker').selectpicker('refresh');
 }
 
 function setFormSearchValues(searchDict) {

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -433,7 +433,6 @@ const selectConfig = {
   }
 };
 
-
 function resetSelect(selectPickerID) {
   const $select = $("#" + selectPickerID);
   $select.empty();
@@ -446,33 +445,35 @@ function resetSelect(selectPickerID) {
 }
 
 function liveSearch(selectPickerID, e) {
-    const searchQuery = e.target.value;
-    if (searchQuery.length < 3) {
-      resetSelect(selectPickerID);
-      return;
+  const searchQuery = e.target.value;
+  if (searchQuery.length < 3) {
+    resetSelect(selectPickerID);
+    return;
+  }
+
+  const selectObject = $("#" + selectPickerID);
+  const searchType = selectPickerID;
+
+  $.ajax({
+    type: "GET",
+    url: "/supervisorPortal/liveSearch",
+    data: {
+            searchType: searchType,
+            userInput: searchQuery
+          },
+    success: function(response) {
+      selectObject.empty();
+      const buildOption = selectConfig[selectPickerID].build;
+      response.forEach(row => {
+        const option = buildOption(row);
+        selectObject.append($("<option>", option));
+      });
+      selectObject.selectpicker("refresh");
+    },
+    error: function(xhr, status, error) {
+      resetSelect(selectPickerID)
+      console.log(xhr, status, error)
     }
-
-    const selectObject = $("#" + selectPickerID);
-    const searchType = selectPickerID;
-
-    $.ajax({
-      type: "GET",
-      url: "/supervisorPortal/liveSearch",
-      data: {
-              searchType: searchType,
-              userInput: searchQuery
-            },
-      contentType: 'application/json',
-      success: function(response) {
-        selectObject.empty();
-        const buildOption = selectConfig[selectPickerID].build;
-        response.forEach(row => {
-          const option = buildOption(row);
-          console.log(option);
-          selectObject.append($("<option>", option));
-        });
-        selectObject.selectpicker("refresh");
-      }
-    });
+  });
 };
 

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -121,6 +121,11 @@ $('#collapseSearch').collapse(false)
 $('#mySupervisees').trigger("click")
 }
 
+$("#termSelectParent .bs-searchbox input").on("keyup", function(e) {
+  console.log("it's clicking")
+  liveSearch("termSelect", e);
+});
+
 });
 
 // this is a mapping which maps the column option to its field options.
@@ -372,4 +377,41 @@ function setFormSearchValues(searchDict) {
     $(`input:checkbox[value='${value}']`).prop('checked', true);
   })
 }
+// Dynamic search for dropdowns (from adminManagement.js)
+
+$("#termSelectParent .bs-searchbox input").on("keyup", function(e) {
+  console.log("it's clicking")
+  liveSearch("termSelect", e);
+});
+
+function liveSearch(selectPickerID, e) {
+    let searchData = e.target.value;
+    $("#"+ selectPickerID).empty();
+    if (searchData.length >= 3) {
+      $("#"+ selectPickerID).empty();
+      let data = [selectPickerID, searchData]
+      data = JSON.stringify(data)
+      $.ajax({
+        type: "POST",
+        url: "/supervisorFormSearch",
+        datatype: "json",
+        data: data,
+        contentType: 'application/json',
+        success: function(response) {
+          for (let key = 0; key < response.length; key++) {
+            let username = response[key]['username']
+            let firstName = response[key]['firstName']
+            let lastName = response[key]['lastName']
+            let type = response[key]['type']
+            if (type == "Student") {
+              $("#"+ selectPickerID).append('<option value="' + username + '" data-subtext="' + username + ' (' + type + ')">' + firstName + ' ' + lastName + '</option>');
+            } else {
+              $("#"+ selectPickerID).append('<option value="' + username + '" data-subtext="' + username + '">' + firstName + ' ' + lastName + '</option>');
+            }
+          }
+          $("#"+ selectPickerID).selectpicker("refresh");
+        }
+      });
+    }
+};
 

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -391,35 +391,81 @@ function setFormSearchValues(searchDict) {
     $(`input:checkbox[value='${value}']`).prop('checked', true);
   })
 }
-// Dynamic search for dropdowns (from adminManagement.js)
+
+
+function resetSelect(selectPickerID) {
+  const defaultOptions = {
+    termSelect: [
+      { value: "", text: "All terms" },
+      { value: "activeTerms", text: "All Active Terms" }
+    ],
+    departmentSelect: [
+      { value: "", text: "All departments" }
+    ],
+    supervisorSelect: [
+      { value: "", text: "All supervisors" }
+    ],
+    studentSelect: [
+      { value: "", text: "All students" }
+    ]
+  };
+
+  const $select = $("#" + selectPickerID);
+  $select.empty();
+
+  defaultOptions[selectPickerID].forEach(option => {
+    $select.append($("<option>", { value: option.value, text: option.text }));
+  });
+
+  $select.selectpicker("refresh");
+}
+
 function liveSearch(selectPickerID, e) {
-    const searchData = e.target.value;
-    $("#"+ selectPickerID).empty();
-    if (searchData.length >= 3) {
-      const searchType = selectPickerID;
-      $.ajax({
-        type: "GET",
-        url: "/supervisorPortal/liveSearch",
-        data: {
-                searchType: searchType,
-                userInput: searchData
-            },
-        contentType: 'application/json',
-        success: function(response) {
-          if(selectPickerID == "termSelect"){ 
-            for (let key = 0; key < response.length; key++) {
-              $("#"+ selectPickerID).append('<option value="' + response[key]['termCode'] + '">' + response[key]['termName'] + '</option>');
-            }
-          }
-          else if (selectPickerID == "departmentSelect"){
-          }
-          else if (selectPickerID == "supervisorSelect"){
-          }
-          else if (selectPickerID == "studentSelect"){
-          }
-          $("#"+ selectPickerID).selectpicker("refresh");
-        }
-      });
+    const searchQuery = e.target.value;
+    if (searchQuery.length < 3) {
+      resetSelect(selectPickerID);
+      return;
     }
+
+    const selectObject = $("#" + selectPickerID);
+    const searchType = selectPickerID;
+    const optionBuilders = {
+      termSelect: row => ({
+        value: row.termCode,
+        text: row.termName
+      }),
+      departmentSelect: row => ({
+        value: row.departmentID,
+        text: row.DEPT_NAME
+      }),
+      supervisorSelect: row => ({
+        value: row.ID,
+        text: `${row.FIRST_NAME} ${row.LAST_NAME} (${row.ID})`
+      }),
+      studentSelect: row => ({
+        value: row.ID,
+        text: `${row.FIRST_NAME} ${row.LAST_NAME} (${row.ID})`
+      })
+    };
+
+    $.ajax({
+      type: "GET",
+      url: "/supervisorPortal/liveSearch",
+      data: {
+              searchType: searchType,
+              userInput: searchQuery
+            },
+      contentType: 'application/json',
+      success: function(response) {
+        selectObject.empty();
+        const buildOption = optionBuilders[selectPickerID];
+        response.forEach(row => {
+          const option = buildOption(row);
+          console.log(option);
+          selectObject.append($("<option>", option));
+        });
+        $("#"+ selectPickerID).selectpicker("refresh");
+      }
+    });
 };
 

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -1,139 +1,144 @@
 $(document).ready(function () {
-$('#formSearchButton').on('click', function () {
-runFormSearchQuery();
-$('#sortOptions').show();
-});
-
-$('#switchViewButton').on('click', function () {
-// toggle the view and button value
-buttonVal = $("#switchViewButton").val()
-switchViewButton((buttonVal == "simple") ? "advanced" : "simple")
-
-// we can just rerun the form search query as it pulls down the value
-// of the button to determine what button to render
-runFormSearchQuery();
-$('#sortOptions').show();
-});
-
-$('#addUserToDept').on('click', function () {
-$("#addSupervisorToDeptModal").modal("show");
-$('#addUser').prop('disabled', true)
-})
-$("#sortByButton").on('click', function () {
-var isDisabled = $('#fieldPicker').prop('disabled');
-if (!isDisabled && $('#fieldPicker').val() == '') {
-  msgFlash("Cannot sort without selecting a field.", 'warning')
-  return
-}
-runFormSearchQuery()
-})
-
-if ($('#columnPicker').val() == '') {
-$('#fieldPicker').prop('disabled', true)
-$('.selectpicker').selectpicker('refresh')
-}
-
-$('#addUser').on('click', function () {
-let supervisorID = $('#supervisorModalSelect :selected').val()
-let departmentID = $('#departmentModalSelect :selected').val()
-
-addSupervisorToDepartment(supervisorID, departmentID)
-})
-$('#departmentModalSelect').on('change', disableButtonHandler)
-$('#supervisorModalSelect').on('change', disableButtonHandler)
-
-$('#clearSelectionsButton').on('click', function () {
-$("input:checkbox").removeAttr("checked");
-clearDropdowns()
-});
-
-$(function () {
-$("#formSearchAccordion").accordion({
-  collapsible: true
-});
-});
-$(function () {
-$("#formSearchAccordion").accordion();
-$("#formSearchAccordion .ui-accordion-header").css({ fontSize: 20 });// width of the box content area
-});
-// listening for preset button clicks.
-$('#mySupervisees').on('click', function () {
-$("input:checkbox").removeAttr("checked");
-runFormSearchQuery("mySupervisees");
-});
-$('#superviseesPendingForms').on('click', function () {
-$("input:checkbox").removeAttr("checked");
-runFormSearchQuery("pendingForms");
-});
-$('#currentTerm').on('click', function () {
-runFormSearchQuery("currentTerm");
-});
-$('#columnPicker').on('change', function () {
-let column = $('#columnPicker :selected').text()
-buttonVal = $("#switchViewButton").val()
-let fields = buttonVal == "advanced" ? advancedColumnFieldMap[column] : simpleColumnFieldMap[column];
-
-// clear the options from the current field picker and replace 
-// them with the ones from the columnFieldMap 
-$('#fieldPicker').empty();
-fields.forEach((field) => {
-  var option = $('<option>', {
-    value: field[1],
-    text: field[0]
+  $('#formSearchButton').on('click', function () {
+    runFormSearchQuery();
+    $('#sortOptions').show();
   });
-  $('#fieldPicker').append(option)
-})
 
-// if there is only one field then that means we can disable the fieldPicker and rely
-// on the column instead
-if (fields.length === 1) {
-  $('#fieldPicker').prop('disabled', true);
+  $('#switchViewButton').on('click', function () {
+    // toggle the view and button value
+    buttonVal = $("#switchViewButton").val()
+    switchViewButton((buttonVal == "simple") ? "advanced" : "simple")
 
-} else {
-  $('#fieldPicker').prop('disabled', false);
-}
-$('.selectpicker').selectpicker('refresh')
-})
+    // we can just rerun the form search query as it pulls down the value
+    // of the button to determine what button to render
+    runFormSearchQuery();
+    $('#sortOptions').show();
+  });
 
-////////////////////////////////////////////
-// check the cookie and GO!
-if ((document.cookie).includes("lsfSearchResults=")) {
-cookieStr = Cookies.get('lsfSearchResults')
-cookieJSON = JSON.parse(cookieStr)
+  $('#addUserToDept').on('click', function () {
+    $("#addSupervisorToDeptModal").modal("show");
+    $('#addUser').prop('disabled', true)
+  })
+  $("#sortByButton").on('click', function () {
+    var isDisabled = $('#fieldPicker').prop('disabled');
+    if (!isDisabled && $('#fieldPicker').val() == '') {
+      msgFlash("Cannot sort without selecting a field.", 'warning')
+      return
+    }
+    runFormSearchQuery()
+  })
 
-// using the cookies, make sure the view is properly set as well
-if (cookieJSON.view == 'advanced') {
-  createDataTable(cookieStr)
-  switchViewButton('advanced')
-} else {
-  fetchSimpleView(cookieStr)
-  switchViewButton('simple')
-}
-setFormSearchValues(cookieJSON)
+  if ($('#columnPicker').val() == '') {
+    $('#fieldPicker').prop('disabled', true)
+    $('.selectpicker').selectpicker('refresh')
+  }
 
-} else {
-$('#formSearchTable').hide();
-$('#sortOptions').hide();
-$("#download").prop('disabled', true);
-$('#collapseSearch').collapse(false)
+  $('#addUser').on('click', function () {
+    let supervisorID = $('#supervisorModalSelect :selected').val()
+    let departmentID = $('#departmentModalSelect :selected').val()
 
-// select current supervisees if nothing selected
-$('#mySupervisees').trigger("click")
-}
+    addSupervisorToDepartment(supervisorID, departmentID)
+  })
 
-//--------------------- WE ARE HERE --------------------------------------------------
-$("#termSelectParent .bs-searchbox input").on("keyup", function(e) {
-  liveSearch("termSelect", e);
-});
-$("#departmentSelectParent .bs-searchbox input").on("keyup", function(e) {
-  liveSearch("departmentSelect", e);
-});
-$("#supervisorSelectParent .bs-searchbox input").on("keyup", function(e) {
-  liveSearch("supervisorSelect", e);
-});
-$("#studentSelectParent .bs-searchbox input").on("keyup", function(e) {
-  liveSearch("studentSelect", e);
-});
+  $('#departmentModalSelect').on('change', disableButtonHandler)
+  $('#supervisorModalSelect').on('change', disableButtonHandler)
+
+  $('#clearSelectionsButton').on('click', function () {
+    $("input:checkbox").removeAttr("checked");
+    clearDropdowns()
+  });
+
+  $(function () {
+    $("#formSearchAccordion").accordion({
+      collapsible: true
+    });
+  });
+
+  $(function () {
+    $("#formSearchAccordion").accordion();
+    $("#formSearchAccordion .ui-accordion-header").css({ fontSize: 20 });// width of the box content area
+  });
+  // listening for preset button clicks.
+  $('#mySupervisees').on('click', function () {
+    $("input:checkbox").removeAttr("checked");
+    runFormSearchQuery("mySupervisees");
+  });
+
+  $('#superviseesPendingForms').on('click', function () {
+    $("input:checkbox").removeAttr("checked");
+    runFormSearchQuery("pendingForms");
+  });
+
+  $('#currentTerm').on('click', function () {
+    runFormSearchQuery("currentTerm");
+  });
+
+  $('#columnPicker').on('change', function () {
+    let column = $('#columnPicker :selected').text()
+    buttonVal = $("#switchViewButton").val()
+    let fields = buttonVal == "advanced" ? advancedColumnFieldMap[column] : simpleColumnFieldMap[column];
+
+    // clear the options from the current field picker and replace 
+    // them with the ones from the columnFieldMap 
+    $('#fieldPicker').empty();
+    fields.forEach((field) => {
+      var option = $('<option>', {
+        value: field[1],
+        text: field[0]
+      });
+      $('#fieldPicker').append(option)
+    })
+
+    // if there is only one field then that means we can disable the fieldPicker and rely
+    // on the column instead
+    if (fields.length === 1) {
+      $('#fieldPicker').prop('disabled', true);
+
+    } else {
+      $('#fieldPicker').prop('disabled', false);
+    }
+    $('.selectpicker').selectpicker('refresh')
+  })
+
+  ////////////////////////////////////////////
+  // check the cookie and GO!
+  if ((document.cookie).includes("lsfSearchResults=")) {
+    cookieStr = Cookies.get('lsfSearchResults')
+    cookieJSON = JSON.parse(cookieStr)
+
+    // using the cookies, make sure the view is properly set as well
+    if (cookieJSON.view == 'advanced') {
+      createDataTable(cookieStr)
+      switchViewButton('advanced')
+    } else {
+      fetchSimpleView(cookieStr)
+      switchViewButton('simple')
+    }
+    setFormSearchValues(cookieJSON)
+
+  } else {
+    $('#formSearchTable').hide();
+    $('#sortOptions').hide();
+    $("#download").prop('disabled', true);
+    $('#collapseSearch').collapse(false)
+
+    // select current supervisees if nothing selected
+    $('#mySupervisees').trigger("click")
+  }
+
+  // Live search handling for dropdowns
+  $("#termSelectParent .bs-searchbox input").on("keyup", function(e) {
+    liveSearch("termSelect", e);
+  });
+  $("#departmentSelectParent .bs-searchbox input").on("keyup", function(e) {
+    liveSearch("departmentSelect", e);
+  });
+  $("#supervisorSelectParent .bs-searchbox input").on("keyup", function(e) {
+    liveSearch("supervisorSelect", e);
+  });
+  $("#studentSelectParent .bs-searchbox input").on("keyup", function(e) {
+    liveSearch("studentSelect", e);
+  });
 
 });
 
@@ -388,29 +393,29 @@ function setFormSearchValues(searchDict) {
 }
 // Dynamic search for dropdowns (from adminManagement.js)
 function liveSearch(selectPickerID, e) {
-    let searchData = e.target.value;
+    const searchData = e.target.value;
     $("#"+ selectPickerID).empty();
     if (searchData.length >= 3) {
-      $("#"+ selectPickerID).empty();
-      let data = [selectPickerID, searchData]
-      data = JSON.stringify(data)
+      const searchType = selectPickerID;
       $.ajax({
-        type: "POST",
-        url: "/supervisorFormSearch",
-        datatype: "json",
-        data: data,
+        type: "GET",
+        url: "/supervisorPortal/liveSearch",
+        data: {
+                searchType: searchType,
+                userInput: searchData
+            },
         contentType: 'application/json',
         success: function(response) {
-          for (let key = 0; key < response.length; key++) {
-            let username = response[key]['username']
-            let firstName = response[key]['firstName']
-            let lastName = response[key]['lastName']
-            let type = response[key]['type']
-            if (type == "Student") {
-              $("#"+ selectPickerID).append('<option value="' + username + '" data-subtext="' + username + ' (' + type + ')">' + firstName + ' ' + lastName + '</option>');
-            } else {
-              $("#"+ selectPickerID).append('<option value="' + username + '" data-subtext="' + username + '">' + firstName + ' ' + lastName + '</option>');
+          if(selectPickerID == "termSelect"){ 
+            for (let key = 0; key < response.length; key++) {
+              $("#"+ selectPickerID).append('<option value="' + response[key]['termCode'] + '">' + response[key]['termName'] + '</option>');
             }
+          }
+          else if (selectPickerID == "departmentSelect"){
+          }
+          else if (selectPickerID == "supervisorSelect"){
+          }
+          else if (selectPickerID == "studentSelect"){
           }
           $("#"+ selectPickerID).selectpicker("refresh");
         }

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -123,8 +123,16 @@ $('#mySupervisees').trigger("click")
 
 //--------------------- WE ARE HERE --------------------------------------------------
 $("#termSelectParent .bs-searchbox input").on("keyup", function(e) {
-  console.log("it's clicking")
   liveSearch("termSelect", e);
+});
+$("#departmentSelectParent .bs-searchbox input").on("keyup", function(e) {
+  liveSearch("departmentSelect", e);
+});
+$("#supervisorSelectParent .bs-searchbox input").on("keyup", function(e) {
+  liveSearch("supervisorSelect", e);
+});
+$("#studentSelectParent .bs-searchbox input").on("keyup", function(e) {
+  liveSearch("studentSelect", e);
 });
 
 });

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -459,9 +459,17 @@ function liveSearch(selectPickerID, e) {
           },
     success: function(response) {
       selectObject.empty();
-      if (response.length > 0 && allOption.length > 0) {
-        selectObject.append(allOption);
+      if (selectPickerID === "termSelect") {
+        selectConfig.termSelect.defaults.forEach(opt => {
+          selectObject.append($("<option>", { value: opt.value, text: opt.text }));
+        });
+      } else {
+        // For other selects, append the single "All" option if it existed in HTML
+        if (allOption.length > 0) {
+          selectObject.append(allOption);
+        }
       }
+
       const buildOption = selectConfig[selectPickerID].build;
       response.forEach(row => {
         const option = buildOption(row);

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -121,6 +121,7 @@ $('#collapseSearch').collapse(false)
 $('#mySupervisees').trigger("click")
 }
 
+//--------------------- WE ARE HERE --------------------------------------------------
 $("#termSelectParent .bs-searchbox input").on("keyup", function(e) {
   console.log("it's clicking")
   liveSearch("termSelect", e);
@@ -378,12 +379,6 @@ function setFormSearchValues(searchDict) {
   })
 }
 // Dynamic search for dropdowns (from adminManagement.js)
-
-$("#termSelectParent .bs-searchbox input").on("keyup", function(e) {
-  console.log("it's clicking")
-  liveSearch("termSelect", e);
-});
-
 function liveSearch(selectPickerID, e) {
     let searchData = e.target.value;
     $("#"+ selectPickerID).empty();

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -127,20 +127,35 @@ $(document).ready(function () {
   }
 
   // Live search handling for dropdowns
-  $("#termSelectParent .bs-searchbox input").on("keyup", function(e) {
-    liveSearch("termSelect", e);
-  });
-  $("#departmentSelectParent .bs-searchbox input").on("keyup", function(e) {
-    liveSearch("departmentSelect", e);
-  });
-  $("#supervisorSelectParent .bs-searchbox input").on("keyup", function(e) {
-    liveSearch("supervisorSelect", e);
-  });
-  $("#studentSelectParent .bs-searchbox input").on("keyup", function(e) {
-    liveSearch("studentSelect", e);
-  });
+  $("#termSelectParent .bs-searchbox input").on("keyup", debouncedSearchTerm);
+  $("#departmentSelectParent .bs-searchbox input").on("keyup", debouncedSearchDepartment); 
+  $("#supervisorSelectParent .bs-searchbox input").on("keyup", debouncedSearchSupervisor); 
+  $("#studentSelectParent .bs-searchbox input").on("keyup", debouncedSearchStudent);
 
 });
+
+function debounce(func, delay) {
+    let timeout;
+    return function (...args) {
+        clearTimeout(timeout);
+        timeout = setTimeout(() => {
+            func.apply(this, args);
+        }, delay);
+    };
+}
+
+const debouncedSearchTerm = debounce(function(e) {
+    liveSearch("termSelect", e);
+}, 500);
+const debouncedSearchDepartment = debounce(function(e) {
+    liveSearch("departmentSelect", e);
+}, 500);
+const debouncedSearchSupervisor = debounce(function(e) {
+    liveSearch("supervisorSelect", e);
+}, 500);
+const debouncedSearchStudent = debounce(function(e) {
+    liveSearch("studentSelect", e);
+}, 500);
 
 // this is a mapping which maps the column option to its field options.
 // many do not have multiple fields so the field is just the column itself (e.g. term)
@@ -445,6 +460,7 @@ function resetSelect(selectPickerID) {
 }
 
 function liveSearch(selectPickerID, e) {
+
   const searchQuery = e.target.value;
   const selectObject = $("#" + selectPickerID);
   const searchType = selectPickerID;

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -293,7 +293,6 @@ case "mySupervisees":
     'order': order
   };
 
-  console.log(queryDict)
   setFormSearchValues(queryDict)
   data = JSON.stringify(queryDict)
 
@@ -525,9 +524,7 @@ function resetSelect(selectPickerID) {
 }
 
 function injectCurrentTermOption() {
-  // Remove if it exists
   $('#termSelect option[value="' + g_currentTermOption.value + '"]').remove();
-  // Add it
   $('#termSelect').append($('<option>', g_currentTermOption));
   $('#termSelect').selectpicker('val', g_currentTermOption.value);
   $('#termSelect').selectpicker('refresh');

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -1,4 +1,21 @@
 $(document).ready(function () {
+  var termOption = $('#termSelect option[data-preloaded="current"]');
+  var supervisorOption = $('#supervisorSelect option[data-preloaded="current"]');
+  
+  g_currentTermOption = {
+    value: termOption.val(),
+    text: termOption.text()
+  };
+  
+  g_currentUserOption = {
+    value: supervisorOption.val(),
+    text: supervisorOption.text(),
+    'data-content': supervisorOption.attr('data-content')
+  };
+  
+  termOption.remove();
+  supervisorOption.remove();
+
   $('#formSearchButton').on('click', function () {
     runFormSearchQuery();
     $('#sortOptions').show();
@@ -132,7 +149,7 @@ $(document).ready(function () {
   $("#departmentSelectParent .bs-searchbox input").on("keyup", debouncedSearchDepartment); 
   $("#supervisorSelectParent .bs-searchbox input").on("keyup", debouncedSearchSupervisor); 
   $("#studentSelectParent .bs-searchbox input").on("keyup", debouncedSearchStudent);
-
+  
 });
 
 function debounce(func, delay) {
@@ -276,6 +293,7 @@ case "mySupervisees":
     'order': order
   };
 
+  console.log(queryDict)
   setFormSearchValues(queryDict)
   data = JSON.stringify(queryDict)
 
@@ -505,6 +523,36 @@ function resetSelect(selectPickerID) {
 
   $select.selectpicker("refresh");
 }
+
+function injectCurrentTermOption() {
+  // Remove if it exists
+  $('#termSelect option[value="' + g_currentTermOption.value + '"]').remove();
+  // Add it
+  $('#termSelect').append($('<option>', g_currentTermOption));
+  $('#termSelect').selectpicker('val', g_currentTermOption.value);
+  $('#termSelect').selectpicker('refresh');
+}
+
+function injectCurrentUserOption() {
+  $('#supervisorSelect option[value="' + g_currentUserOption.value + '"]').remove();
+  $('#supervisorSelect').append($('<option>', g_currentUserOption));
+  $('#supervisorSelect').selectpicker('val', g_currentUserOption.value);
+  $('#supervisorSelect').selectpicker('refresh');
+}
+
+$('#mySupervisees').on('click', function () {
+  $("input:checkbox").removeAttr("checked");
+  injectCurrentTermOption();
+  injectCurrentUserOption();
+  runFormSearchQuery("mySupervisees");
+});
+
+$('#superviseesPendingForms').on('click', function () {
+  $("input:checkbox").removeAttr("checked");
+  injectCurrentTermOption();
+  injectCurrentUserOption();
+  runFormSearchQuery("pendingForms");
+});
 
 function liveSearch(selectPickerID, e) {
 

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -248,21 +248,34 @@ case "mySupervisees":
   queryDict = {
     'view': currentView,
     'termCode': termCode,
-    'termName': $('#termSelect option:selected').text(),
+    'termOption': {
+      value: termCode,
+      text: $('#termSelect option:selected').text()
+    },
     'departmentID': departmentID,
-    'departmentName': $('#departmentSelect option:selected').text(),
-    'departmentContent': $('#departmentSelect option:selected').attr('data-content'),
+    'departmentOption': {
+      value: departmentID,
+      text: $('#departmentSelect option:selected').text(),
+      'data-content': $('#departmentSelect option:selected').attr('data-content')
+    },
     'supervisorID': supervisorID,
-    'supervisorName': $('#supervisorSelect option:selected').text(),
-    'supervisorContent': $('#supervisorSelect option:selected').attr('data-content'),
+    'supervisorOption': {
+      value: supervisorID,
+      text: $('#supervisorSelect option:selected').text(),
+      'data-content': $('#supervisorSelect option:selected').attr('data-content')
+    },
     'studentID': studentID,
-    'studentName': $('#studentSelect option:selected').text(),
-    'studentContent': $('#studentSelect option:selected').attr('data-content'),
+    'studentOption': {
+      value: studentID,
+      text: $('#studentSelect option:selected').text(),
+      'data-content': $('#studentSelect option:selected').attr('data-content')
+    },
     'formStatus': formStatusList,
     'formType': formTypeList,
     'sortBy': sortBy,
     'order': order
-};
+  };
+
   setFormSearchValues(queryDict)
   data = JSON.stringify(queryDict)
 
@@ -392,46 +405,28 @@ function updateDownloadButton(response){
         }
 }
 
-function loadSavedSearchOptions(searchDict) {
-  // creates the search options that setFormSearchValues uses
-  if (searchDict.termCode && searchDict.termCode !== "" && searchDict.termCode !== "activeTerms") {
-    if ($(`#termSelect option[value="${searchDict.termCode}"]`).length === 0) {
-      $('#termSelect').append($("<option>", {
-        value: searchDict.termCode,
-        text: searchDict.termName
-      }));
-    }
-  }
+function loadSavedSearchOptions(cookies) {
+  const selectMap = {
+    'termOption': 'termSelect',
+    'supervisorOption': 'supervisorSelect', 
+    'studentOption': 'studentSelect',
+    'departmentOption': 'departmentSelect'
+  };
   
-  if (searchDict.supervisorID && searchDict.supervisorID !== "" && searchDict.supervisorID !== "currentUser") {
-    if ($(`#supervisorSelect option[value="${searchDict.supervisorID}"]`).length === 0) {
-      $('#supervisorSelect').append($("<option>", {
-        value: searchDict.supervisorID,
-        text: searchDict.supervisorName,
-        "data-content": searchDict.supervisorContent || searchDict.supervisorName
-      }));
-    }
-  }
+  const skipValues = ['', 'currentUser', 'currentTerm', 'activeTerms'];
   
-  if (searchDict.studentID && searchDict.studentID !== "") {
-    if ($(`#studentSelect option[value="${searchDict.studentID}"]`).length === 0) {
-      $('#studentSelect').append($("<option>", {
-        value: searchDict.studentID,
-        text: searchDict.studentName,
-        "data-content": searchDict.studentContent || searchDict.studentName
-      }));
+  Object.keys(selectMap).forEach(optionKey => {
+    const selectId = selectMap[optionKey];
+    const option = cookies[optionKey];
+    
+    // Check if option exists and has a valid value
+    if (option && option.value && !skipValues.includes(option.value)) {
+      // Check if option doesn't already exist in the select
+      if ($(`#${selectId} option[value="${option.value}"]`).length === 0) {
+        $(`#${selectId}`).append($("<option>", option));
+      }
     }
-  }
-  
-  if (searchDict.departmentID && searchDict.departmentID !== "") {
-    if ($(`#departmentSelect option[value="${searchDict.departmentID}"]`).length === 0) {
-      $('#departmentSelect').append($("<option>", {
-        value: searchDict.departmentID,
-        text: searchDict.departmentName,
-        "data-content": searchDict.departmentContent || searchDict.departmentName
-      }));
-    }
-  }
+  });
   
   $('.selectpicker').selectpicker('refresh');
 }

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -446,13 +446,9 @@ function resetSelect(selectPickerID) {
 
 function liveSearch(selectPickerID, e) {
   const searchQuery = e.target.value;
-  if (searchQuery.length < 3) {
-    resetSelect(selectPickerID);
-    return;
-  }
-
   const selectObject = $("#" + selectPickerID);
   const searchType = selectPickerID;
+  const allOption = selectObject.find("option").filter(function() {return $(this).val() === "";});
 
   $.ajax({
     type: "GET",
@@ -463,6 +459,9 @@ function liveSearch(selectPickerID, e) {
           },
     success: function(response) {
       selectObject.empty();
+      if (response.length > 0 && allOption.length > 0) {
+        selectObject.append(allOption);
+      }
       const buildOption = selectConfig[selectPickerID].build;
       response.forEach(row => {
         const option = buildOption(row);
@@ -476,4 +475,3 @@ function liveSearch(selectPickerID, e) {
     }
   });
 };
-

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -406,7 +406,7 @@ const selectConfig = {
   departmentSelect: {
     defaults: [{ value: "", text: "All departments" }],
     build: row => ({
-      value: row.departmentID,
+      value: row.id,
       text: row.DEPT_NAME,
       "data-content": row.isActive
         ? row.DEPT_NAME
@@ -416,19 +416,19 @@ const selectConfig = {
   supervisorSelect: {
     defaults: [{ value: "", text: "All supervisors" }],
     build: row => ({
-      value: row.ID,
-      text: `${row.FIRST_NAME} ${row.LAST_NAME} (${row.ID})`,
+      value: row.id,
+      text: `${row.FIRST_NAME} ${row.LAST_NAME} (${row.id})`,
       "data-content": row.isActive
-        ? `${row.FIRST_NAME} ${row.LAST_NAME} <small class='text-muted'> (${row.ID})</small>`
-        : `<div class='text-muted'>${row.FIRST_NAME} ${row.LAST_NAME} <small>(${row.ID}) --INACTIVE--</small></div>`
+        ? `${row.FIRST_NAME} ${row.LAST_NAME} <small class='text-muted'> (${row.id})</small>`
+        : `<div class='text-muted'>${row.FIRST_NAME} ${row.LAST_NAME} <small>(${row.id}) --INACTIVE--</small></div>`
     })
   },
   studentSelect: {
     defaults: [{ value: "", text: "All students" }],
     build: row => ({
-      value: row.ID,
-      text: `${row.FIRST_NAME} ${row.LAST_NAME} (${row.ID})`,
-      "data-content": `${row.FIRST_NAME} ${row.LAST_NAME} <small class='text-muted'> (${row.ID})</small>`
+      value: row.id,
+      text: `${row.FIRST_NAME} ${row.LAST_NAME} (${row.id})`,
+      "data-content": `${row.FIRST_NAME} ${row.LAST_NAME} <small class='text-muted'> (${row.id})</small>`
     })
   }
 };

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -1,11 +1,5 @@
 $(document).ready(function () {
-  var termOption = $('#termSelect option[data-preloaded="current"]');
   var supervisorOption = $('#supervisorSelect option[data-preloaded="current"]');
-  
-  g_currentTermOption = {
-    value: termOption.val(),
-    text: termOption.text()
-  };
   
   g_currentUserOption = {
     value: supervisorOption.val(),
@@ -13,7 +7,6 @@ $(document).ready(function () {
     'data-content': supervisorOption.attr('data-content')
   };
   
-  termOption.remove();
   supervisorOption.remove();
 
   $('#formSearchButton').on('click', function () {
@@ -84,10 +77,6 @@ $(document).ready(function () {
   $('#superviseesPendingForms').on('click', function () {
     $("input:checkbox").removeAttr("checked");
     runFormSearchQuery("pendingForms");
-  });
-
-  $('#currentTerm').on('click', function () {
-    runFormSearchQuery("currentTerm");
   });
 
   $('#columnPicker').on('change', function () {
@@ -224,7 +213,7 @@ let order = $('#orderPicker').val()
 
 switch (button) {
 case "mySupervisees":
-  termCode = "currentTerm"
+  termCode = "activeTerms"
   departmentID = ""
   supervisorID = "currentUser"
   studentID = ""
@@ -235,22 +224,11 @@ case "mySupervisees":
       break;
 
     case "pendingForms":
-      termCode = "currentTerm"
+      termCode = "activeTerms"
       departmentID = ""
       supervisorID = "currentUser"
       studentID = ""
       formStatusList = ["Pending", "Pre-Student Approval"]
-      break;
-
-    case "currentTerm":
-      termCode = "currentTerm"
-      departmentID = ""
-      supervisorID = ""
-      studentID = ""
-      formStatusList = []
-      if (currentView == "simple") { // avoid duplicates in the table
-        formTypeList = ["Labor Status Form"]
-      }
       break;
 
     default:
@@ -430,7 +408,7 @@ function loadSavedSearchOptions(cookies) {
     'departmentOption': 'departmentSelect'
   };
   
-  const skipValues = ['', 'currentUser', 'currentTerm', 'activeTerms'];
+  const skipValues = ['', 'currentUser', 'activeTerms'];
   
   Object.keys(selectMap).forEach(optionKey => {
     const selectId = selectMap[optionKey];
@@ -450,8 +428,8 @@ function loadSavedSearchOptions(cookies) {
 
 function setFormSearchValues(searchDict) {
 
-  if (searchDict.termCode == "currentTerm") {
-    $("#termSelect").selectpicker("val", g_currentTerm);
+  if (searchDict.termCode == "activeTerms") {
+    $("#termSelect").selectpicker("val", "activeTerms");
   } else {
     $("#termSelect").selectpicker("val", searchDict.termCode);
   }
@@ -523,13 +501,6 @@ function resetSelect(selectPickerID) {
   $select.selectpicker("refresh");
 }
 
-function injectCurrentTermOption() {
-  $('#termSelect option[value="' + g_currentTermOption.value + '"]').remove();
-  $('#termSelect').append($('<option>', g_currentTermOption));
-  $('#termSelect').selectpicker('val', g_currentTermOption.value);
-  $('#termSelect').selectpicker('refresh');
-}
-
 function injectCurrentUserOption() {
   $('#supervisorSelect option[value="' + g_currentUserOption.value + '"]').remove();
   $('#supervisorSelect').append($('<option>', g_currentUserOption));
@@ -539,14 +510,12 @@ function injectCurrentUserOption() {
 
 $('#mySupervisees').on('click', function () {
   $("input:checkbox").removeAttr("checked");
-  injectCurrentTermOption();
   injectCurrentUserOption();
   runFormSearchQuery("mySupervisees");
 });
 
 $('#superviseesPendingForms').on('click', function () {
   $("input:checkbox").removeAttr("checked");
-  injectCurrentTermOption();
   injectCurrentUserOption();
   runFormSearchQuery("pendingForms");
 });

--- a/app/static/js/supervisorPortal.js
+++ b/app/static/js/supervisorPortal.js
@@ -392,28 +392,53 @@ function setFormSearchValues(searchDict) {
   })
 }
 
-
-function resetSelect(selectPickerID) {
-  const defaultOptions = {
-    termSelect: [
+const selectConfig = {
+  termSelect: {
+    defaults: [
       { value: "", text: "All terms" },
       { value: "activeTerms", text: "All Active Terms" }
     ],
-    departmentSelect: [
-      { value: "", text: "All departments" }
-    ],
-    supervisorSelect: [
-      { value: "", text: "All supervisors" }
-    ],
-    studentSelect: [
-      { value: "", text: "All students" }
-    ]
-  };
+    build: row => ({
+      value: row.termCode,
+      text: row.termName
+    })
+  },
+  departmentSelect: {
+    defaults: [{ value: "", text: "All departments" }],
+    build: row => ({
+      value: row.departmentID,
+      text: row.DEPT_NAME,
+      "data-content": row.isActive
+        ? row.DEPT_NAME
+        : `<div class='text-muted'>${row.DEPT_NAME} <small>--INACTIVE--</small></div>`
+    })
+  },
+  supervisorSelect: {
+    defaults: [{ value: "", text: "All supervisors" }],
+    build: row => ({
+      value: row.ID,
+      text: `${row.FIRST_NAME} ${row.LAST_NAME} (${row.ID})`,
+      "data-content": row.isActive
+        ? `${row.FIRST_NAME} ${row.LAST_NAME} <small class='text-muted'> (${row.ID})</small>`
+        : `<div class='text-muted'>${row.FIRST_NAME} ${row.LAST_NAME} <small>(${row.ID}) --INACTIVE--</small></div>`
+    })
+  },
+  studentSelect: {
+    defaults: [{ value: "", text: "All students" }],
+    build: row => ({
+      value: row.ID,
+      text: `${row.FIRST_NAME} ${row.LAST_NAME} (${row.ID})`,
+      "data-content": `${row.FIRST_NAME} ${row.LAST_NAME} <small class='text-muted'> (${row.ID})</small>`
+    })
+  }
+};
 
+
+function resetSelect(selectPickerID) {
   const $select = $("#" + selectPickerID);
   $select.empty();
 
-  defaultOptions[selectPickerID].forEach(option => {
+  selectConfig[selectPickerID].defaults.forEach(option => {
     $select.append($("<option>", { value: option.value, text: option.text }));
   });
 
@@ -429,24 +454,6 @@ function liveSearch(selectPickerID, e) {
 
     const selectObject = $("#" + selectPickerID);
     const searchType = selectPickerID;
-    const optionBuilders = {
-      termSelect: row => ({
-        value: row.termCode,
-        text: row.termName
-      }),
-      departmentSelect: row => ({
-        value: row.departmentID,
-        text: row.DEPT_NAME
-      }),
-      supervisorSelect: row => ({
-        value: row.ID,
-        text: `${row.FIRST_NAME} ${row.LAST_NAME} (${row.ID})`
-      }),
-      studentSelect: row => ({
-        value: row.ID,
-        text: `${row.FIRST_NAME} ${row.LAST_NAME} (${row.ID})`
-      })
-    };
 
     $.ajax({
       type: "GET",
@@ -458,13 +465,13 @@ function liveSearch(selectPickerID, e) {
       contentType: 'application/json',
       success: function(response) {
         selectObject.empty();
-        const buildOption = optionBuilders[selectPickerID];
+        const buildOption = selectConfig[selectPickerID].build;
         response.forEach(row => {
           const option = buildOption(row);
           console.log(option);
           selectObject.append($("<option>", option));
         });
-        $("#"+ selectPickerID).selectpicker("refresh");
+        selectObject.selectpicker("refresh");
       }
     });
 };

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -77,11 +77,7 @@
                 <select class="selectpicker" name='term' id='termSelect' data-live-search='true' title="All terms">
                   <option value="">All terms</option>
                   <option value="activeTerms">All Active Terms</option>
-                  {% for term in terms %}
-                  <option value="{{term.termCode}}">
-                    {{term.termName}}
-                  </option>
-                  {% endfor %}
+                  
                 </select>
               </div>
             </div>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -85,19 +85,9 @@
               <label for="departmentSelect">Department</label>
               <div>
                 <select class="selectpicker" id="departmentSelect" data-live-search='true' title="Department">
-                  {% if departments|count != 1 %}
-                  <option value="" selected>All departments</option>
+                  {% if g.currentUser.isLaborAdmin or g.currentUser.isFinancialAidAdmin or g.currentUser.isSaasAdmin %}
+                    <option value="" selected>All departments</option>
                   {% endif %}
-                  {% for department in departments %}
-                  <!-- We want to either select the first option, or the option that matches the department -->
-                  {% if department.isActive %}
-                  <option value="{{department.departmentID}}" data-content="{{department.DEPT_NAME}}">
-                    {% else %}
-                  <option value="{{department.departmentID}}"
-                    data-content="<div class='text-muted'>{{department.DEPT_NAME}} <small>--INACTIVE--</small></div>">
-                    {% endif %}
-                  </option>
-                  {% endfor %}
                 </select>
               </div>
             </div>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -32,7 +32,6 @@
   src="{{url_for('static', filename='js/addSupervisorsToDepartment.js') }}?u={{lastStaticUpdate}}"></script>
 <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
 <script>
-  var g_currentTerm = {{ g.openTerm }};
   var g_currentUser = "{{g.currentUser.supervisor}}";
 </script>
 
@@ -77,7 +76,6 @@
                 <select class="selectpicker" name='term' data-live-search-placeholder="Type term to search" id='termSelect' data-live-search='true' title="All terms">
                   <option value="">All terms</option>
                   <option value="activeTerms">All Active Terms</option>
-                  <option value="{{g.openTerm}}" data-preloaded="current" style="display:none;">{{currentTermName}}</option>
                 </select>
               </div>
             </div>
@@ -302,9 +300,7 @@
   </div>
 </div>
 <script>
-  var g_currentTerm = {{ g.openTerm }};
   var g_currentUser = "{{g.currentUser.supervisor}}";
-  var g_currentTermOption = null;
   var g_currentUserOption = null;
 </script>
 {% include "snips/pendingNotesModal.html" %}

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -74,7 +74,7 @@
               <br>
               <label for="termSelect">Term</label>
               <div>
-                <select class="selectpicker" name='term' id='termSelect' data-live-search='true' title="All terms">
+                <select class="selectpicker" name='term' data-live-search-placeholder="Type term to search" id='termSelect' data-live-search='true' title="All terms">
                   <option value="">All terms</option>
                   <option value="activeTerms">All Active Terms</option>
                   
@@ -84,7 +84,7 @@
             <div class="form-group" id="departmentSelectParent">
               <label for="departmentSelect">Department</label>
               <div>
-                <select class="selectpicker" id="departmentSelect" data-live-search='true' title="Department">
+                <select class="selectpicker" id="departmentSelect" data-live-search-placeholder="Type department to search" data-live-search='true' title="Department">
                   <option value="" selected>All departments</option>
                   {% for department in departments %}
                   <!-- We want to either select the first option, or the option that matches the department -->
@@ -102,7 +102,7 @@
             <div class="form-group" id="supervisorSelectParent">
               <label for="supervisorSelect">Supervisor</label>
               <div class="dropdown">
-                <select class="selectpicker" name='supervisor' id='supervisorSelect' data-live-search='true'
+                <select class="selectpicker" name='supervisor' id='supervisorSelect' data-live-search-placeholder="Type name or B# to search" data-live-search='true'
                   title="All supervisors">
                   <option value="">All supervisors</option>
                 </select>
@@ -111,7 +111,7 @@
             <div class="form-group" id="studentSelectParent">
               <label for="studentSelect">Student</label>
               <div>
-                <select class="selectpicker" name='student' id='studentSelect' data-live-search='true'
+                <select class="selectpicker" name='student' id='studentSelect' data-live-search-placeholder="Type name or B# to search" data-live-search='true'
                   title="All students">
                   <option value="">All students</option>
                 </select>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -77,7 +77,7 @@
                 <select class="selectpicker" name='term' data-live-search-placeholder="Type term to search" id='termSelect' data-live-search='true' title="All terms">
                   <option value="">All terms</option>
                   <option value="activeTerms">All Active Terms</option>
-                  
+                  <option value="{{g.openTerm}}" data-preloaded="current" style="display:none;">{{currentTermName}}</option>
                 </select>
               </div>
             </div>
@@ -105,6 +105,11 @@
                 <select class="selectpicker" name='supervisor' id='supervisorSelect' data-live-search-placeholder="Type name or B# to search" data-live-search='true'
                   title="All supervisors">
                   <option value="">All supervisors</option>
+                  <option value="{{g.currentUser.supervisor}}" data-preloaded="current" style="display:none;" 
+                        data-content="{{g.currentUser.supervisor.preferred_name or g.currentUser.supervisor.legal_name}} 
+                        {{g.currentUser.supervisor.LAST_NAME}} <small class='text-muted'> ({{g.currentUser.supervisor.ID}})</small>">
+                  {{g.currentUser.supervisor.preferred_name or g.currentUser.supervisor.legal_name}} {{g.currentUser.supervisor.LAST_NAME}} ({{g.currentUser.supervisor.ID}})
+                </option>
                 </select>
               </div>
             </div>
@@ -296,6 +301,12 @@
     </div>
   </div>
 </div>
+<script>
+  var g_currentTerm = {{ g.openTerm }};
+  var g_currentUser = "{{g.currentUser.supervisor}}";
+  var g_currentTermOption = null;
+  var g_currentUserOption = null;
+</script>
 {% include "snips/pendingNotesModal.html" %}
 {% include "snips/FormsDeny.html" %}
 {% include "snips/pendingApprovalModal.html" %}

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -85,9 +85,17 @@
               <label for="departmentSelect">Department</label>
               <div>
                 <select class="selectpicker" id="departmentSelect" data-live-search='true' title="Department">
-                  {% if g.currentUser.isLaborAdmin or g.currentUser.isFinancialAidAdmin or g.currentUser.isSaasAdmin %}
-                    <option value="" selected>All departments</option>
-                  {% endif %}
+                  <option value="" selected>All departments</option>
+                  {% for department in departments %}
+                  <!-- We want to either select the first option, or the option that matches the department -->
+                  {% if department.isActive %}
+                  <option value="{{department.departmentID}}" data-content="{{department.DEPT_NAME}}">
+                    {% else %}
+                  <option value="{{department.departmentID}}"
+                    data-content="<div class='text-muted'>{{department.DEPT_NAME}} <small>--INACTIVE--</small></div>">
+                    {% endif %}
+                  </option>
+                  {% endfor %}
                 </select>
               </div>
             </div>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -107,17 +107,6 @@
                 <select class="selectpicker" name='supervisor' id='supervisorSelect' data-live-search='true'
                   title="All supervisors">
                   <option value="">All supervisors</option>
-                  {% for supervisor in supervisors %}
-                  {% if supervisor.isActive %}
-                  <option value="{{supervisor.ID}}"
-                    data-content="{{supervisor.FIRST_NAME}} {{supervisor.LAST_NAME}} <small class='text-muted'>  ({{supervisor.ID}})</small>">
-                    {% else %}
-                  <option value="{{supervisor.ID}}"
-                    data-content="<div class='text-muted'>{{supervisor.FIRST_NAME}} {{supervisor.LAST_NAME}} <small>({{supervisor.ID}}) --INACTIVE-- </small></div>">
-                    {% endif %}
-                    {{supervisor.FIRST_NAME}} {{supervisor.LAST_NAME}}
-                  </option>
-                  {% endfor %}
                 </select>
               </div>
             </div>
@@ -127,12 +116,6 @@
                 <select class="selectpicker" name='student' id='studentSelect' data-live-search='true'
                   title="All students">
                   <option value="">All students</option>
-                  {% for student in students %}
-                  <option value="{{student.ID}}"
-                    data-content="{{student.FIRST_NAME}} {{student.LAST_NAME}}<small class='text-muted'> ({{student.ID}})</small>">
-                    {{student.FIRST_NAME}} {{student.LAST_NAME}} ({{student.ID}})
-                  </option>
-                  {% endfor %}
                 </select>
               </div>
             </div>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -70,7 +70,7 @@
         <form id="supervisorPortalForm">
           <div class="col-md-2"></div> <!-- empty div used for positioning -->
           <div class="col-md-5">
-            <div class="form-group">
+            <div class="form-group" id="termSelectParent">
               <br>
               <label for="termSelect">Term</label>
               <div>

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -85,7 +85,7 @@
                 </select>
               </div>
             </div>
-            <div class="form-group">
+            <div class="form-group" id="departmentSelectParent">
               <label for="departmentSelect">Department</label>
               <div>
                 <select class="selectpicker" id="departmentSelect" data-live-search='true' title="Department">
@@ -105,7 +105,7 @@
                 </select>
               </div>
             </div>
-            <div class="form-group">
+            <div class="form-group" id="supervisorSelectParent">
               <label for="supervisorSelect">Supervisor</label>
               <div class="dropdown">
                 <select class="selectpicker" name='supervisor' id='supervisorSelect' data-live-search='true'
@@ -125,7 +125,7 @@
                 </select>
               </div>
             </div>
-            <div class="form-group">
+            <div class="form-group" id="studentSelectParent">
               <label for="studentSelect">Student</label>
               <div>
                 <select class="selectpicker" name='student' id='studentSelect' data-live-search='true'

--- a/app/templates/main/supervisorPortal.html
+++ b/app/templates/main/supervisorPortal.html
@@ -79,7 +79,7 @@
                   <option value="activeTerms">All Active Terms</option>
                   {% for term in terms %}
                   <option value="{{term.termCode}}">
-                    {{term.termCode.termName}}
+                    {{term.termName}}
                   </option>
                   {% endfor %}
                 </select>


### PR DESCRIPTION
Closes #502 

First, we cut down unnecessary double-querying in the Supervisor Portal and removed a few hanging + unused queries.

Then, we added a dynamic search function for the supervisor portal for all of the dropdown boxes. This is so that when the page is loaded, the boxes with a lot of options are not prefilled with a large amount of HTML that's largely unused, as supervisors scarcely scan through the longer dropdowns, especially student names.

However, the Departments dropdown's functionality remains the same. Due to the small number of items in the dropdown, it's faster for users to simply scan through with their eyes and click, instead of searching.

### Testing 
- You may test the dynamic search on any of the boxes in supervisor portal. The only box that will be automatically populated with anything but the default 'all' options will be departments.
- Compare load times and number of queries generated
