### PR TITLE
added flash message

### DIFF
--- a/app/static/js/allPendingForms.js
+++ b/app/static/js/allPendingForms.js
@@ -146,7 +146,7 @@ function finalApproval() { //this method changes the status of the lsf from pend
           $("#approveModalButton").text("Approve");
           $("#approvalModal").data("bs.modal").options.backdrop = true;
           $("#approvalModal").data("bs.modal").options.keyboard = true;
-
+          msgFlash("Approval successful!", "success");
 
           // Try and catch is used here to prevent General Search page from reloading the entire the page.
           try {


### PR DESCRIPTION
fixes #521 

Flash message after form approval

**Changes** 

- Added a flash message if the final approval is a success

**Testing** 

- There has been a problem related to sending the emails when we want to approve a form. We cannot see the message unless the email is sent. Otherwise everything should be fine with the flash message.