### PR TITLE
Flash message after form approval

### DIFF
--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -494,10 +494,8 @@ def modalFormUpdate():
 
             # send it to banner if they have approved an overload
             if rsp['formType'] == 'Overload' and "Approved" in rsp['status'] and historyForm.formID.POSN_CODE != "S12345":
-                # conn = Banner()
-                # save_form_status = conn.insert(historyForm)
-                save_form_status = True
-
+                conn = Banner()
+                save_form_status = conn.insert(historyForm)
 
             # if we are able to save
             if save_form_status:

--- a/app/controllers/admin_routes/allPendingForms.py
+++ b/app/controllers/admin_routes/allPendingForms.py
@@ -317,6 +317,7 @@ def finalUpdateStatus(raw_status):
         print("Unknown status: ", raw_status)
         return jsonify({"success": False})
 
+    flash("Forms have been successfully updated.", "success")
     form_ids = eval(request.data.decode("utf-8"))
     return saveStatus(new_status, form_ids, currentUser)
 
@@ -493,8 +494,9 @@ def modalFormUpdate():
 
             # send it to banner if they have approved an overload
             if rsp['formType'] == 'Overload' and "Approved" in rsp['status'] and historyForm.formID.POSN_CODE != "S12345":
-                conn = Banner()
-                save_form_status = conn.insert(historyForm)
+                # conn = Banner()
+                # save_form_status = conn.insert(historyForm)
+                save_form_status = True
 
 
             # if we are able to save

--- a/app/static/js/allPendingForms.js
+++ b/app/static/js/allPendingForms.js
@@ -141,6 +141,7 @@ function finalApproval() { //this method changes the status of the lsf from pend
     contentType: 'application/json',
     success: function(response) {
       if (response && response.success) {
+          msgFlash("The selected forms have been approved.","success");
           $(".btn").prop("disabled", false);
           $(".close").prop("disabled", false);
           $("#approveModalButton").text("Approve");

--- a/app/static/js/allPendingForms.js
+++ b/app/static/js/allPendingForms.js
@@ -121,6 +121,10 @@ $('#approvalModal').on('hidden.bs.modal', function () {// Makes the close functi
 function approvalModalClose(){// on close of approval modal we are clearing the table to prevent duplicate data.
   $('#classTableBody').empty();
   labor_details_ids = [] // emptying the list, becuase otherwise will cause duplicate data.
+  if (window.approvalSuccess) {
+    msgFlash("The selected forms have been approved.","success");
+    window.approvalSuccess = false;
+  }
 }
 
 
@@ -141,7 +145,7 @@ function finalApproval() { //this method changes the status of the lsf from pend
     contentType: 'application/json',
     success: function(response) {
       if (response && response.success) {
-          msgFlash("The selected forms have been approved.","success");
+          window.approvalSuccess = true;
           $(".btn").prop("disabled", false);
           $(".close").prop("disabled", false);
           $("#approveModalButton").text("Approve");

--- a/app/static/js/allPendingForms.js
+++ b/app/static/js/allPendingForms.js
@@ -121,10 +121,6 @@ $('#approvalModal').on('hidden.bs.modal', function () {// Makes the close functi
 function approvalModalClose(){// on close of approval modal we are clearing the table to prevent duplicate data.
   $('#classTableBody').empty();
   labor_details_ids = [] // emptying the list, becuase otherwise will cause duplicate data.
-  if (window.approvalSuccess) {
-    msgFlash("The selected forms have been approved.","success");
-    window.approvalSuccess = false;
-  }
 }
 
 
@@ -145,7 +141,6 @@ function finalApproval() { //this method changes the status of the lsf from pend
     contentType: 'application/json',
     success: function(response) {
       if (response && response.success) {
-          window.approvalSuccess = true;
           $(".btn").prop("disabled", false);
           $(".close").prop("disabled", false);
           $("#approveModalButton").text("Approve");

--- a/app/static/js/allPendingForms.js
+++ b/app/static/js/allPendingForms.js
@@ -146,16 +146,8 @@ function finalApproval() { //this method changes the status of the lsf from pend
           $("#approveModalButton").text("Approve");
           $("#approvalModal").data("bs.modal").options.backdrop = true;
           $("#approvalModal").data("bs.modal").options.keyboard = true;
-
-
-          // Try and catch is used here to prevent General Search page from reloading the entire the page.
-          try {
-            runformSearchQuery();
-            $('#approvalModal').modal('hide');
-          }
-          catch(e){
-            location.reload(true);
-          }
+          
+          location.reload(true);
       }
     }
   });

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -46,6 +46,16 @@
                 {% endif %}
             {% endwith %}
         </div>
+        
+        <script>
+        window.setTimeout(function() {
+            $("#flash_container .alert").fadeTo(500, 0).slideUp(500, function() {
+            $(this).remove();
+            });
+        }, 4000);
+        </script>
+
+
         {% block app_content %}
             {# application content needs to be provided in the app_content block #}
         {% endblock %}


### PR DESCRIPTION
Add a flash message to appear after selected pending forms have been approved. 

### TESTING

- Load up the all pending forms page
- Check one or more of the boxes next to the forms
- Go to the bottom of the page and hit the "Approve Selected Forms" button
- In the modal that appears, press the "Approve Selected" button 
- After the information is saved, a flash message should appear saying that the forms have been approved

Image for context:
<img width="1903" height="963" alt="image" src="https://github.com/user-attachments/assets/affe9815-7e65-4283-9042-87af649dcf18" />
