### PR TITLE
Labor History datetime Quick Fix

### DIFF
--- a/app/controllers/main_routes/laborHistory.py
+++ b/app/controllers/main_routes/laborHistory.py
@@ -134,8 +134,7 @@ def populateModal(statusKey):
         forms = (FormHistory.select().join(LaborReleaseForm, join_type=JOIN.LEFT_OUTER)
                             .where(FormHistory.formID == statusKey).order_by(FormHistory.createdDate.desc(), FormHistory.formHistoryID.desc()))
         statusForm = LaborStatusForm.get(LaborStatusForm.laborStatusFormID == statusKey)
-        student = Student.get(Student.ID == statusForm.studentSupervisee)
-        currentDate = datetime.date.today()
+        currentDate = datetime.today()
         pendingformType = None
         first = True  # temp variable to determine if this is the newest form
         for form in forms:


### PR DESCRIPTION
datetime syntax was causing labor form modals to not work properly on Labor History pages because the use of .date for this function was deprecated. I also removed an unused line. 