### PR TITLE
this change is made because term with recent peewee update is broken …

### DIFF
--- a/app/controllers/admin_routes/termManagement.py
+++ b/app/controllers/admin_routes/termManagement.py
@@ -25,7 +25,7 @@ def term_Management():
     termsByYear ={}
     for termYear in range(today.year-2, today.year+3):
         createTerms(termYear)
-        termsByYear[termYear] = list(Term.select().where(Term.termCode.cast('char').contains(termYear)))
+        termsByYear[termYear] = list(Term.select().where(Term.termCode.cast('char').contains(str(termYear))))
 
     return render_template( 'admin/termManagement.html',
                              title='Term Management',


### PR DESCRIPTION
After the recent peewee update the termmanagment.py is broken because peewee is not flexible with data type anymore when it comes to parameter it only accept strings. 
Documentation: https://docs.peewee-orm.com/en/latest/peewee/query_operators.html

Fixed: added str() to convert termYear into string for the contains() to work,
