### PR TITLE
Fixed issue #531; Now  remove and discard has consistant msg flash color

### DIFF
--- a/app/controllers/admin_routes/adminManagement.py
+++ b/app/controllers/admin_routes/adminManagement.py
@@ -84,8 +84,4 @@ def removeAdmin(user, adminType):
 
 def flashMessage(user, action, adminType):
     message = "{} has been {} as a {} Admin".format(user.fullName, action, adminType)
-
-    if action == 'added':
-        flash(message, "success")
-    elif action == 'removed':
-        flash(message, "danger")
+    flash(message, "success")

--- a/app/static/js/addSupervisorsToDepartment.js
+++ b/app/static/js/addSupervisorsToDepartment.js
@@ -1,14 +1,18 @@
-function addSupervisorToDepartment(supervisorID, departmentID, callback=() => {}) {
+function addSupervisorToDepartment(supervisorID, departmentID, supervisor_FirstName, supervisor_LastName, callback=() => {}) {
+  let supervisorfirstName = supervisor_FirstName
+  let supervisorLastName = supervisor_LastName
+  console.log("Names  ",supervisorfirstName, supervisorLastName)
+
     return $.ajax({
       method: "POST",
       url: `/supervisorPortal/addUserToDept`,
       data: {"supervisorID": supervisorID, "departmentID": departmentID},
       success: function(response) {
         if (response == "True") {
-          msgFlash("Supervisor has been added to department.", "success")
+          msgFlash(`Supervisor ${supervisorfirstName} ${supervisorLastName} (${supervisorID}) has been added to the department.`, "success")
           clearDropdowns()
         } else {
-          msgFlash("Supervisor is already a member of this department.", "warning")
+          msgFlash(`Supervisor ${supervisorfirstName} ${supervisorLastName} (${supervisorID}) is already a member of this department.`, "warning")
           clearDropdowns()
         }
         if (callback){

--- a/app/static/js/addSupervisorsToDepartment.js
+++ b/app/static/js/addSupervisorsToDepartment.js
@@ -1,7 +1,6 @@
-function addSupervisorToDepartment(supervisorID, departmentID, supervisor_FirstName, supervisor_LastName, callback=() => {}) {
-  let supervisorfirstName = supervisor_FirstName
-  let supervisorLastName = supervisor_LastName
-  console.log("Names  ",supervisorfirstName, supervisorLastName)
+function addSupervisorToDepartment(supervisorID, departmentID, supervisorFirstNameData, supervisorLastNameData, callback=() => {}) {
+  let supervisorFirstName = supervisorFirstNameData
+  let supervisorLastName = supervisorLastNameData
 
     return $.ajax({
       method: "POST",
@@ -9,10 +8,10 @@ function addSupervisorToDepartment(supervisorID, departmentID, supervisor_FirstN
       data: {"supervisorID": supervisorID, "departmentID": departmentID},
       success: function(response) {
         if (response == "True") {
-          msgFlash(`Supervisor ${supervisorfirstName} ${supervisorLastName} (${supervisorID}) has been added to the department.`, "success")
+          msgFlash(`Supervisor ${supervisorFirstName} ${supervisorLastName} (${supervisorID}) has been added to the department.`, "success")
           clearDropdowns()
         } else {
-          msgFlash(`Supervisor ${supervisorfirstName} ${supervisorLastName} (${supervisorID}) is already a member of this department.`, "warning")
+          msgFlash(`Supervisor ${supervisorFirstName} ${supervisorLastName} (${supervisorID}) is already a member of this department.`, "warning")
           clearDropdowns()
         }
         if (callback){

--- a/app/static/js/emailTemplates.js
+++ b/app/static/js/emailTemplates.js
@@ -152,7 +152,7 @@ function discard() {
     $("#subject").val('').selectpicker("refresh")
     CKEDITOR.instances["editor1"].setData('')
     msg = "The email template changes have been discarded.";
-    category = "info";
+    category = "danger";
   }
   $("#flash_container").prepend('<div class="alert alert-'+ category +'" role="alert" id="flasher">'+msg+'</div>');
   $("#flasher").delay(3000).fadeOut();

--- a/app/static/js/emailTemplates.js
+++ b/app/static/js/emailTemplates.js
@@ -165,7 +165,7 @@ function saveChanges() {
   // will ask the user if they are sure they want to save their changes.
   if ( !$("#subject").val() ) {
     msg = "There are no changes to be saved.";
-    category = "danger";
+    category = "warning";
     $("#flash_container").prepend('<div class="alert alert-'+ category +'" role="alert" id="flasher">'+msg+'</div>');
     $("#flasher").delay(3000).fadeOut();
   } else {

--- a/app/static/js/emailTemplates.js
+++ b/app/static/js/emailTemplates.js
@@ -152,7 +152,7 @@ function discard() {
     $("#subject").val('').selectpicker("refresh")
     CKEDITOR.instances["editor1"].setData('')
     msg = "The email template changes have been discarded.";
-    category = "danger";
+    category = "success";
   }
   $("#flash_container").prepend('<div class="alert alert-'+ category +'" role="alert" id="flasher">'+msg+'</div>');
   $("#flasher").delay(3000).fadeOut();

--- a/app/static/js/manageDepartments.js
+++ b/app/static/js/manageDepartments.js
@@ -52,11 +52,11 @@ function attachModalToDepartment() {
 
 $("#supervisorModalSelect").on('change', function() {
   let supervisorID = $('#supervisorModalSelect :selected').val()
-  let supervisor_FirstName = $('#supervisorModalSelect :selected').data("firstname")
-  let supervisor_LastName = $('#supervisorModalSelect :selected').data("lastname")
+  let supervisorFirstName = $('#supervisorModalSelect :selected').data("firstname")
+  let supervisorLastName = $('#supervisorModalSelect :selected').data("lastname")
 
   let departmentID = $('#departmentModalSelect').data('department-id')
-  addSupervisorToDepartment(supervisorID, departmentID, supervisor_FirstName, supervisor_LastName, ()=>showSupervisorsInDepartment(departmentID))
+  addSupervisorToDepartment(supervisorID, departmentID, supervisorFirstName, supervisorLastName, ()=>showSupervisorsInDepartment(departmentID))
   
 })
 
@@ -75,6 +75,8 @@ function showSupervisorsInDepartment(departmentID) {
                                 <div class='btn btn-danger col-auto removeSupervisorFromDepartment' 
                                   data-supervisor="${supervisors[i]['ID']}" 
                                   data-department="${departmentID}" 
+                                  data-firstname="${supervisorFirstName}" 
+                                  data-lastname="${supervisors[i]['LAST_NAME']}"
                                   id="${supervisors[i]['ID']}-${departmentID}">Remove</div>
                                </span>`)}
       supervisorContent += ("</div>")
@@ -90,8 +92,8 @@ function removeSupervisorFromDepartment () {
   let departmentID = $(`#${this.id}`).data('department')
   let supervisorID = $(`#${this.id}`).data('supervisor')
   let data = {"supervisorID": supervisorID, "departmentID": departmentID}
-  let supervisorfirstName = $(`#${this.id}`).parent().find('div').first().text().split(" ").slice(1, -1).join(" ")
-  let supervisorLastName = $(`#${this.id}`).parent().find('div').first().text().split(" ").slice(-1)[0]
+  let supervisorfirstName = $(`#${this.id}`).data('firstname')
+  let supervisorLastName = $(`#${this.id}`).data('lastname')
   $.ajax({
     method: "POST",
     url: "/admin/manageDepartments/removeSupervisorFromDepartment",

--- a/app/static/js/manageDepartments.js
+++ b/app/static/js/manageDepartments.js
@@ -93,7 +93,7 @@ function removeSupervisorFromDepartment () {
     data: data,
     success: function(response) {
         if (response == "True") {
-          msgFlash("Supervisor has been removed from department.", 'fail')
+          msgFlash("Supervisor has been removed from department.", 'success')
           showSupervisorsInDepartment(departmentID)
         } else {
           msgFlash("Supervisor is not a member of this department.", "warning")

--- a/app/static/js/manageDepartments.js
+++ b/app/static/js/manageDepartments.js
@@ -93,7 +93,7 @@ function removeSupervisorFromDepartment () {
     data: data,
     success: function(response) {
         if (response == "True") {
-          msgFlash("Supervisor has been removed from department.", 'success')
+          msgFlash("Supervisor has been removed from department.", 'fail')
           showSupervisorsInDepartment(departmentID)
         } else {
           msgFlash("Supervisor is not a member of this department.", "warning")

--- a/app/static/js/manageDepartments.js
+++ b/app/static/js/manageDepartments.js
@@ -52,8 +52,11 @@ function attachModalToDepartment() {
 
 $("#supervisorModalSelect").on('change', function() {
   let supervisorID = $('#supervisorModalSelect :selected').val()
+  let supervisor_FirstName = $('#supervisorModalSelect :selected').data("firstname")
+  let supervisor_LastName = $('#supervisorModalSelect :selected').data("lastname")
+
   let departmentID = $('#departmentModalSelect').data('department-id')
-  addSupervisorToDepartment(supervisorID, departmentID, ()=>showSupervisorsInDepartment(departmentID))
+  addSupervisorToDepartment(supervisorID, departmentID, supervisor_FirstName, supervisor_LastName, ()=>showSupervisorsInDepartment(departmentID))
   
 })
 
@@ -87,16 +90,18 @@ function removeSupervisorFromDepartment () {
   let departmentID = $(`#${this.id}`).data('department')
   let supervisorID = $(`#${this.id}`).data('supervisor')
   let data = {"supervisorID": supervisorID, "departmentID": departmentID}
+  let supervisorfirstName = $(`#${this.id}`).parent().find('div').first().text().split(" ").slice(1, -1).join(" ")
+  let supervisorLastName = $(`#${this.id}`).parent().find('div').first().text().split(" ").slice(-1)[0]
   $.ajax({
     method: "POST",
     url: "/admin/manageDepartments/removeSupervisorFromDepartment",
     data: data,
     success: function(response) {
         if (response == "True") {
-          msgFlash("Supervisor has been removed from department.", 'success')
+          msgFlash(`Supervisor ${supervisorfirstName} ${supervisorLastName} (${supervisorID}) has been removed from department. `, 'success')
           showSupervisorsInDepartment(departmentID)
         } else {
-          msgFlash("Supervisor is not a member of this department.", "warning")
+          msgFlash(`Supervisor ${supervisorfirstName} ${supervisorLastName} is not a member of this department.`, "warning")
         }
     },
     error: function() {

--- a/app/static/js/termManagement.js
+++ b/app/static/js/termManagement.js
@@ -111,7 +111,7 @@ function termStatus(term) {
         $(termBtnID).removeClass("btn-success");
         $(termBtnID).addClass("btn-danger");
         $(termBtnID).text("Closed");
-        category = "danger";
+        category = "success";
         state = "'Closed'.";
         } else {
         $(termBtnID).removeClass("btn-danger");

--- a/app/templates/admin/manageDepartments.html
+++ b/app/templates/admin/manageDepartments.html
@@ -118,7 +118,7 @@
           title='Supervisor'>
         {% for supervisor in allSupervisors  %}
           <option value="{{supervisor.ID}}"
-                  data-content="{{supervisor.FIRST_NAME}} {{supervisor.LAST_NAME}}<small class='text-muted'> ({{supervisor.ID}})</small>">
+                  data-content="{{supervisor.FIRST_NAME}} {{supervisor.LAST_NAME}}<small class='text-muted'> ({{supervisor.ID}})</small>" data-firstname="{{supervisor.FIRST_NAME}}"  data-lastname="{{supervisor.LAST_NAME}}">
             {{supervisor.FIRST_NAME}} {{supervisor.LAST_NAME}}
           </option>
         {% endfor %}


### PR DESCRIPTION
## Fixes #531 issue number

* Inconsistent message flash on removed and discarded messages

## Changes
* updated the manage terms to have a green ( success ) pop-up when closed and opened 
* Departments have success when a supervisor is added and removed.
* To be more explicit, the supervisor's name and ID are shown when removed and added
* Administrations now show success when admins are added in each of the sections ( Labor, Financial, SAAS ) 
* Email template shows success when the email is discarded and a warning when the save button is clicked when there is nothing to save/

## Testing
* Test by manipulating adding and removing, saving and discarding events, and making sure they are functional as programmed.  