### PR TITLE
Add Visual Indicators for Administration Nav Menu Fix

### DIFF
--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -41,9 +41,9 @@ function closeSidebar() {
 }
 // Change the text of the admin-toggle pannel when the user clicks on it to the open unicode character.
 function toggleAdminPanelOpen() {
-  $('#admin-toggle h4').html('Administration 🢑');
+  $('#admin-toggle h4').html('Administration ⯅');
 }
 // Change the text of the admin-toggle pannel when the user clicks on it to the close unicode character.
 function toggleAdminPanelClose() {
-  $('#admin-toggle h4').html('Administration 🢓');
+  $('#admin-toggle h4').html('Administration ⯆');
 }

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -38,11 +38,9 @@ function closeSidebar() {
   $('body').removeClass('sidebar-is-open');
   $('#sidebar-toggle').attr('aria-expanded', false);
 }
-// Change the text of the admin-toggle pannel when the user clicks on it to the open unicode character.
 function toggleAdminPanelOpen() {
   $('#admin-toggle h4').html('Administration ⯅');
 }
-// Change the text of the admin-toggle pannel when the user clicks on it to the close unicode character.
 function toggleAdminPanelClose() {
   $('#admin-toggle h4').html('Administration ⯆');
 }

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -39,8 +39,8 @@ function closeSidebar() {
   $('#sidebar-toggle').attr('aria-expanded', false);
 }
 function toggleAdminPanelOpen() {
-  $('#admin-toggle h4').html('Administration <i class="bi bi-chevron-up"></i>');
+  $('#admin-toggle h4 i').removeClass('bi-chevron-down').addClass('bi-chevron-up');
 }
 function toggleAdminPanelClose() {
-  $('#admin-toggle h4').html('Administration <i class="bi bi-chevron-down"></i>');
+  $('#admin-toggle h4 i').removeClass('bi-chevron-up').addClass('bi-chevron-down');
 }

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -17,9 +17,8 @@ $(document).ready(function() {
   $('#sidebar-overlay').on('click', function() {
     closeSidebar();
   });
-  // Change the text of the admin-toggle pannel when the user clicks on it to the change unicode character.
   $('#admin-toggle').on('click', function() {
-    if ($('#admin').hasClass('in')) { //Check if its class in or colapse in
+    if ($('#admin').hasClass('in')) { 
       toggleAdminPanelClose();
     } else {
       toggleAdminPanelOpen();

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -39,8 +39,8 @@ function closeSidebar() {
   $('#sidebar-toggle').attr('aria-expanded', false);
 }
 function toggleAdminPanelOpen() {
-  $('#admin-toggle h4').html('Administration ⯅');
+  $('#admin-toggle h4').html('Administration <i class="bi bi-chevron-up"></i>');
 }
 function toggleAdminPanelClose() {
-  $('#admin-toggle h4').html('Administration ⯆');
+  $('#admin-toggle h4').html('Administration <i class="bi bi-chevron-down"></i>');
 }

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -17,6 +17,14 @@ $(document).ready(function() {
   $('#sidebar-overlay').on('click', function() {
     closeSidebar();
   });
+  // Change the text of the admin-toggle pannel when the user clicks on it to the change unicode character.
+  $('#admin-toggle').on('click', function() {
+    if ($('#admin').hasClass('in')) { //Check if its class in or colapse in
+      toggleAdminPanelClose();
+    } else {
+      toggleAdminPanelOpen();
+    }
+  });
   });
 
 function openSidebar() {
@@ -31,6 +39,11 @@ function closeSidebar() {
   $('body').removeClass('sidebar-is-open');
   $('#sidebar-toggle').attr('aria-expanded', false);
 }
-
-
-
+// Change the text of the admin-toggle pannel when the user clicks on it to the open unicode character.
+function toggleAdminPanelOpen() {
+  $('#admin-toggle h4').html('Administration 🢑');
+}
+// Change the text of the admin-toggle pannel when the user clicks on it to the close unicode character.
+function toggleAdminPanelClose() {
+  $('#admin-toggle h4').html('Administration 🢓');
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="{{url_for('static', filename ='css/base.css') }}?u={{lastStaticUpdate}}">
     <link rel="stylesheet" href="/static/css/tooltip.css?u={{lastStaticUpdate}}" type="text/css"/>
     <link rel="stylesheet" href="{{url_for('static', filename ='css/sidebar.css') }}?u={{lastStaticUpdate}}">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.css">
 
 {% endblock %}
 

--- a/app/templates/sidebar.html
+++ b/app/templates/sidebar.html
@@ -87,7 +87,7 @@
             <div class="panel panel-default">
                 <a id="admin-toggle" data-toggle="collapse" href="#admin">
                     <div class="panel-heading"tabindex="8">
-                        <h4>Administration</h4>
+                        <h4>Administration 🢓</h4>
                     </div>
                 </a>
                 <div id="admin" class='panel-collapse {% if request.path[:6] != "/admin"%} collapse {% endif %}'>

--- a/app/templates/sidebar.html
+++ b/app/templates/sidebar.html
@@ -87,7 +87,7 @@
             <div class="panel panel-default">
                 <a id="admin-toggle" data-toggle="collapse" href="#admin">
                     <div class="panel-heading"tabindex="8">
-                        <h4>Administration 🢓</h4>
+                        <h4>Administration ⯆</h4>
                     </div>
                 </a>
                 <div id="admin" class='panel-collapse {% if request.path[:6] != "/admin"%} collapse {% endif %}'>

--- a/app/templates/sidebar.html
+++ b/app/templates/sidebar.html
@@ -87,7 +87,7 @@
             <div class="panel panel-default">
                 <a id="admin-toggle" data-toggle="collapse" href="#admin">
                     <div class="panel-heading"tabindex="8">
-                        <h4>Administration ⯆</h4>
+                        <h4>Administration <i class="bi bi-chevron-down"></i></h4>
                     </div>
                 </a>
                 <div id="admin" class='panel-collapse {% if request.path[:6] != "/admin"%} collapse {% endif %}'>


### PR DESCRIPTION
## Issue Description

Fixes for Issue https://github.com/BCStudentSoftwareDevTeam/lsf/issues/515
- Add Visual Indicators for Administration Nav Menu

## Changes

- Changed default html text in line 90 of sidebar.html from "Administration" to "Administration ⯆"
-  Added two function and one function call in sidbar.js that changes "⯆" to "⯅" and "⯅" to "⯆" depending on if the panel is opened or closed.
## Testing

- Visual testing was done to see if the changes properly occurred on the port website. 
- DevTools via inspect were used to observe live changes within the html and js script to ensure that the UI changed as intended. 