### PR TITLE
Default Error for department 

### DIFF
--- a/app/controllers/main_routes/alterLSF.py
+++ b/app/controllers/main_routes/alterLSF.py
@@ -46,6 +46,7 @@ def alterLSF(laborStatusKey):
     prefillsupervisorPIDM = form.supervisor.PIDM
     superviser_id = form.supervisor.ID
     prefilldepartment = form.department.ORG
+    prefilldepartmentaccount = form.department.ACCOUNT
     prefillposition = form
     prefilljobtype = form.jobType
     prefillterm = form.termCode
@@ -85,6 +86,7 @@ def alterLSF(laborStatusKey):
                             prefillsupervisor = prefillsupervisor,
                             prefillsupervisorPIDM = prefillsupervisorPIDM,
                             prefilldepartment = prefilldepartment,
+                            prefilldepartmentaccount = prefilldepartmentaccount,
                             prefillposition = prefillposition,
                             prefilljobtype = prefilljobtype,
                             prefillterm = prefillterm,

--- a/app/templates/main/alterLSF.html
+++ b/app/templates/main/alterLSF.html
@@ -52,7 +52,7 @@
                 id="department"
                 data-live-search="true">
                 {% for department in departments %}
-                  <option value="{{department.ORG}}" data-account="{{department.ACCOUNT}}" {% if department.ORG == prefilldepartment %} selected {% endif %}>{{department.DEPT_NAME}}</option>
+                  <option value="{{department.ORG}}" data-account="{{department.ACCOUNT}}" {% if department.ORG == prefilldepartment and department.ACCOUNT == prefilldepartmentaccount %} selected {% endif %}>{{department.DEPT_NAME}}</option>
                 {% endfor %}
            </select>
            <input hidden class="oldValue" id="prefilldepartment" value="{{prefilldepartment}}" />


### PR DESCRIPTION
issue number: #547 Academic Vice Pres/Provost & Dean Default Error #547

Changes:
Updated the adjustment form department default logic to match departments based on both ORG and ACCOUNT, rather than ORG only. This prevents SSDT forms from defaulting to the wrong department when creating an adjustment form.

Testing:
To test this fix, look at what was there in staging and create an LSF form with a department that has a sub-department. After the form is created, open the adjustment form for that same LSF. Check the department dropdown and confirm it defaults to Computer Science-Student Software Development Team instead of Academic Vice Pres/Provost & Dean or the first thing. You can also check this in/home/vscode/lsf/app/controllers/main_routes/alterLSF.py and/home/vscode/lsf/app/templates/main/alterLSF.html. This way, you can see what was changed and added. The biggest thing is that it was only checking for ORG.