### PR TITLE
Add Department Actions Menu (#621)

### DIFF
--- a/app/models/allocation.py
+++ b/app/models/allocation.py
@@ -1,0 +1,23 @@
+from app.models import *
+from app.models.department import Department
+from app.models.supervisor import Supervisor
+from app.models.term import Term
+
+class Allocation(baseModel):
+    termCode       = ForeignKeyField(Term)
+    department     = ForeignKeyField(Department)
+    isFinal        = BooleanField(default=False)
+    approvedOn     = DateField(null=True)
+    approvedBy     = ForeignKeyField(Supervisor, null=True)
+    justification  = TextField()
+    primary_10     = IntegerField()
+    primary_12     = IntegerField()
+    primary_15     = IntegerField()
+    primary_20     = IntegerField()
+    secondary_5    = IntegerField()
+    secondary_10   = IntegerField()
+    breakHours     = IntegerField()
+
+    class Meta:
+        indexes = ( (('termCode', 'department', 'isFinal'), True), )
+

--- a/app/models/positionHistory.py
+++ b/app/models/positionHistory.py
@@ -1,0 +1,14 @@
+from app.models import *
+from app.models.department import Department
+
+class PositionHistory(baseModel):
+    positionCode       = CharField()
+    department         = ForeignKeyField(Department)
+    status             = CharField()
+    wls                = IntegerField()
+    revisionDate       = DateField()
+    description        = TextField(default=None)
+
+    class Meta:
+        indexes = ( (('positionCode', 'revisionDate', 'status'), True), )
+

--- a/app/models/supervisor.py
+++ b/app/models/supervisor.py
@@ -16,6 +16,7 @@ class Supervisor(baseModel):
     legal_name      = CharField(null=True)
     preferred_name  = CharField(null=True)
     isActive        = BooleanField(default=False)
+    isBanned        = BooleanField(default=False)
 
 
     @property

--- a/app/models/supervisorDepartment.py
+++ b/app/models/supervisorDepartment.py
@@ -3,5 +3,6 @@ from app.models.supervisor import Supervisor
 from app.models.department import Department
 
 class SupervisorDepartment(baseModel):
-    supervisor = ForeignKeyField(Supervisor, null=True)
+    supervisor = ForeignKeyField(Supervisor)
     department = ForeignKeyField(Department)
+    isCoordinator = BooleanField(default=False)

--- a/app/templates/admin/manageDepartments.html
+++ b/app/templates/admin/manageDepartments.html
@@ -168,13 +168,9 @@
                     <span class="sr-only">Toggle Dropdown</span>
                   </button>
                   <ul class="dropdown-menu">
-                    <li><a href="#">Allocation History</a></li>
+                    <li><a href="{{ url_for('main.departmentPortal', org=department.ORG, account=department.ACCOUNT) }}">Allocation History</a></li>
                     <li role="separator" class="divider"></li>
-                    <li><a href="#">Position Review</a></li>
-                    <li role="separator" class="divider"></li>
-                    <li><a href="#">Edit Dept Member</a></li>
-                    <li role="separator" class="divider"></li>
-                    <li><a href="#">Allocation Review</a></li>
+                    <li><a href="{{ url_for('main.departmentPortal', org=department.ORG, account=department.ACCOUNT) }}">Department Personnel</a></li>
                   </ul>
                 </div>
               </td>

--- a/database/demo_data.py
+++ b/database/demo_data.py
@@ -507,6 +507,15 @@ current_year = today.year - (today.month < 8)
 
 terms = [
     {
+        "termCode": f"202000",
+        "termName": f"AY 2020-2021",
+        "termStart": f"2020-08-01",
+        "termEnd": f"2021-05-01",
+        "termState": 0,
+        "primaryCutOff": f"2020-09-01",
+        "adjustmentCutOff": f"2020-10-01",
+    },
+    {
         "termCode": f"{current_year}00",
         "termName": f"AY {current_year}-{current_year+1}",
         "termStart": f"{current_year}-08-01",

--- a/database/demo_data.py
+++ b/database/demo_data.py
@@ -546,7 +546,7 @@ today = datetime.now()
 current_year = today.year - (today.month < 8)
 LaborStatusForm.insert([{
             "laborStatusFormID": 2,
-            "termCode_id": f"{current_year}00",
+            "termCode_id": f"202000",
             "studentName": "Alex Bryant",
             "studentSupervisee_id": "B00841417",
             "supervisor_id": "B12361006",
@@ -556,8 +556,8 @@ LaborStatusForm.insert([{
             "POSN_TITLE": "Student Programmer",
             "POSN_CODE": "S61407",
             "weeklyHours": 10,
-            "startDate": f"{current_year}-04-01",
-            "endDate": f"{current_year}-09-01"
+            "startDate": f"2020-04-01",
+            "endDate": f"2020-09-01"
         }]).on_conflict_replace().execute()
 FormHistory.insert([{
             "formHistoryID": 2,

--- a/database/migrate_db.sh
+++ b/database/migrate_db.sh
@@ -30,6 +30,8 @@ pem add app.models.supervisor.Supervisor
 pem add app.models.supervisorDepartment.SupervisorDepartment
 pem add app.models.studentLaborEvaluation.StudentLaborEvaluation
 pem add app.models.formSearchResult.FormSearchResult
+pem add app.models.positionHistory.PositionHistory
+pem add app.models.allocation.Allocation
 
 pem watch
 pem migrate

--- a/tests/code/test_adminManagement.py
+++ b/tests/code/test_adminManagement.py
@@ -1,46 +1,44 @@
 import pytest
 from app.controllers.admin_routes.adminManagement import addAdmin, removeAdmin
 from app.models.user import User
+from app.models import mainDB
 from peewee import DoesNotExist
 
 @pytest.mark.integration
 def test_addAdmin():
-    newAdmin = "pearcej"
-    user = User.get(User.username == newAdmin)
+    with mainDB.atomic() as transaction:
+        newAdmin = "pearcej"
+        user = User.get(User.username == newAdmin)
 
-    # Before adding user as admin
-    assert not user.isLaborAdmin 
-    # Test adding labor admin
-    addAdmin(user, 'labor')
-    assert user.isLaborAdmin
+        # Before adding user as admin
+        assert not user.isLaborAdmin 
+        addAdmin(user, 'Labor')
+        user = User.get(User.username == newAdmin) # check if the db is actually changed
+        assert user.isLaborAdmin
 
-    assert not user.isFinancialAidAdmin
-    # Test adding financial aid admin
-    addAdmin(user, 'finAid')
-    assert user.isFinancialAidAdmin
+        assert not user.isFinancialAidAdmin
+        addAdmin(user, 'FinancialAid')
+        assert user.isFinancialAidAdmin
 
-    assert not user.isSaasAdmin
-    # Test adding saas admin
-    addAdmin(user, 'saas')
-    assert user.isSaasAdmin
+        assert not user.isSaasAdmin
+        addAdmin(user, 'Saas')
+        assert user.isSaasAdmin
 
 @pytest.mark.integration
 def test_removeAdmin():
-    oldAdmin = "pearcej"
-    user = User.get(User.username == oldAdmin)
+    with mainDB.atomic() as transaction:
+        oldAdmin = "pearcej"
+        user = User.get(User.username == oldAdmin)
 
-    # Before removing user as admin
-    assert user.isLaborAdmin
-    # Test removing labor admin
-    removeAdmin(user, 'labor')
-    assert not user.isLaborAdmin
+        assert user.isLaborAdmin
+        removeAdmin(user, 'Labor')
+        user = User.get(User.username == oldAdmin) # check if the db is actually changed
+        assert not user.isLaborAdmin
 
-    assert user.isFinancialAidAdmin
-    # Test removing financial aid admin
-    removeAdmin(user, 'finAid')
-    assert not user.isFinancialAidAdmin
+        assert user.isFinancialAidAdmin
+        removeAdmin(user, 'FinancialAid')
+        assert not user.isFinancialAidAdmin
 
-    assert user.isSaasAdmin
-    # Test removing saas admin
-    removeAdmin(user, 'saas')
-    assert not user.isSaasAdmin
+        assert user.isSaasAdmin
+        removeAdmin(user, 'Saas')
+        assert not user.isSaasAdmin

--- a/tests/code/test_apiEndpoint.py
+++ b/tests/code/test_apiEndpoint.py
@@ -35,6 +35,7 @@ def test_getLaborInformation():
             response = getLaborInformation(orgCode = 2114, bNumber="B00841417")
 
             responseData = response.get_json()
+            print(responseData['B00841417'])
             assert responseData['B00841417'][0]['jobType'] == "Primary"
             assert responseData['B00841417'][0]['termName'] == "AY 2020-2021"
         

--- a/tests/code/test_tracy.py
+++ b/tests/code/test_tracy.py
@@ -1,4 +1,5 @@
 import pytest
+from app import app
 from app.logic.tracy import Tracy
 from app.logic.tracy import InvalidQueryException
 
@@ -15,132 +16,144 @@ class Test_Tracy:
 
     @pytest.mark.integration
     def test_getStudents(self, tracy):
-        students = tracy.getStudents()
-        assert ['Elaheh','Guillermo','Jeremiah','Kat', 'Oluwagbayi', 'Test', 'Tyler'] == [s.FIRST_NAME for s in students]
-        assert ['718','300','420','420', '883', '700', '420'] == [s.STU_CPO for s in students]
+        with app.app_context():
+            students = tracy.getStudents()
+            assert ['Elaheh','Guillermo','Jeremiah','Kat', 'Oluwagbayi', 'Test', 'Tyler'] == [s.FIRST_NAME for s in students]
+            assert ['718','300','420','420', '883', '700', '420'] == [s.STU_CPO for s in students]
 
     @pytest.mark.integration
     def test_getStudentFromBNumber(self, tracy):
-        student = tracy.getStudentFromBNumber("B00734292")
-        assert 'Guillermo' == student.FIRST_NAME
+        with app.app_context():
+            student = tracy.getStudentFromBNumber("B00734292")
+            assert 'Guillermo' == student.FIRST_NAME
 
-        student = tracy.getStudentFromBNumber("  B00734292")
-        assert 'Guillermo' == student.FIRST_NAME
+            student = tracy.getStudentFromBNumber("  B00734292")
+            assert 'Guillermo' == student.FIRST_NAME
 
-        student = tracy.getStudentFromBNumber("B00888329  ")
-        assert 'Jeremiah' == student.FIRST_NAME
+            student = tracy.getStudentFromBNumber("B00888329  ")
+            assert 'Jeremiah' == student.FIRST_NAME
 
-        with pytest.raises(InvalidQueryException):
-            student = tracy.getStudentFromBNumber("B0000000")
+            with pytest.raises(InvalidQueryException):
+                student = tracy.getStudentFromBNumber("B0000000")
 
-        with pytest.raises(InvalidQueryException):
-            student = tracy.getStudentFromBNumber(17)
+            with pytest.raises(InvalidQueryException):
+                student = tracy.getStudentFromBNumber(17)
 
     @pytest.mark.integration
     def test_getStudentFromEmail(self, tracy):
-        student = tracy.getStudentFromEmail("cruzg@berea.edu")
-        assert 'Guillermo' == student.FIRST_NAME
+        with app.app_context():
+            student = tracy.getStudentFromEmail("cruzg@berea.edu")
+            assert 'Guillermo' == student.FIRST_NAME
 
-        with pytest.raises(InvalidQueryException):
-            student = tracy.getStudentFromEmail("jimmyjoe@place.biz")
+            with pytest.raises(InvalidQueryException):
+                student = tracy.getStudentFromEmail("jimmyjoe@place.biz")
 
-        with pytest.raises(InvalidQueryException):
-            student = tracy.getStudentFromEmail(17)
+            with pytest.raises(InvalidQueryException):
+                student = tracy.getStudentFromEmail(17)
 
     @pytest.mark.integration
     def test_getSupervisors(self, tracy):
-        supervisors = tracy.getSupervisors()
+        with app.app_context():
+            supervisors = tracy.getSupervisors()
 
-        for s in supervisors:
-            assert s.FIRST_NAME in ['Alex','Brian','Jan','Jasmine','Mario','Megan','Scott','Madina']
-            assert s.CPO in ['420','6305','6301','6301','6302','6303','6300']
+            for s in supervisors:
+                assert s.FIRST_NAME in ['Alex','Brian','Jan','Jasmine','Mario','Megan','Scott','Madina']
+                assert s.CPO in ['420','6305','6301','6301','6302','6303','6300']
 
     @pytest.mark.integration
     def test_getSupervisorFromID(self, tracy):
-        supervisor = tracy.getSupervisorFromID("B1236237")
-        assert 'Megan' == supervisor.FIRST_NAME
+        with app.app_context():
+            supervisor = tracy.getSupervisorFromID("B1236237")
+            assert 'Megan' == supervisor.FIRST_NAME
 
-        with pytest.raises(InvalidQueryException):
-            supervisor = tracy.getSupervisorFromID("eleven")
+            with pytest.raises(InvalidQueryException):
+                supervisor = tracy.getSupervisorFromID("eleven")
 
-        with pytest.raises(InvalidQueryException):
-            supervisor = tracy.getSupervisorFromID(17)
+            with pytest.raises(InvalidQueryException):
+                supervisor = tracy.getSupervisorFromID(17)
 
     @pytest.mark.integration
     def test_getSupervisorFromEmail(self, tracy):
-        supervisor = tracy.getSupervisorFromEmail("nakazawam@berea.edu")
-        assert 'Mario' == supervisor.FIRST_NAME
+        with app.app_context():
+            supervisor = tracy.getSupervisorFromEmail("nakazawam@berea.edu")
+            assert 'Mario' == supervisor.FIRST_NAME
 
-        supervisor = tracy.getSupervisorFromEmail("heggens@berea.edu")
-        assert 'Scott' == supervisor.FIRST_NAME
+            supervisor = tracy.getSupervisorFromEmail("heggens@berea.edu")
+            assert 'Scott' == supervisor.FIRST_NAME
 
-        with pytest.raises(InvalidQueryException):
-            supervisor = tracy.getSupervisorFromEmail("nakazawamasdfd.com")
+            with pytest.raises(InvalidQueryException):
+                supervisor = tracy.getSupervisorFromEmail("nakazawamasdfd.com")
 
-        with pytest.raises(InvalidQueryException):
-            supervisor = tracy.getSupervisorFromEmail(17)
+            with pytest.raises(InvalidQueryException):
+                supervisor = tracy.getSupervisorFromEmail(17)
 
     @pytest.mark.integration
     def test_getPositionsFromDepartment(self, tracy):
-        positions = tracy.getPositionsFromDepartment("2114","6740")
-        assert ['S12345','S61408','S61407','S61421','S61419'] == [p.POSN_CODE for p in positions]
-        positions = tracy.getPositionsFromDepartment("2114","0000")
-        assert [] == [p.POSN_CODE for p in positions]
+        with app.app_context():
+            positions = tracy.getPositionsFromDepartment("2114","6740")
+            assert ['S12345','S61408','S61407','S61421','S61419'] == [p.POSN_CODE for p in positions]
+            positions = tracy.getPositionsFromDepartment("2114","0000")
+            assert [] == [p.POSN_CODE for p in positions]
 
     @pytest.mark.integration
     def test_getDepartments(self, tracy):
-        departments = tracy.getDepartments()
-        assert ['Biology','Computer Science', 'Labor Department', 'Mathematics','Technology and Applied Design'] == [d.DEPT_NAME for d in departments]
-        assert '2107' == departments[0].ORG
-        assert '6740' == departments[0].ACCOUNT
+        with app.app_context():
+            departments = tracy.getDepartments()
+            assert ['Biology','Computer Science', 'Labor Department', 'Mathematics','Technology and Applied Design'] == [d.DEPT_NAME for d in departments]
+            assert '2107' == departments[0].ORG
+            assert '6740' == departments[0].ACCOUNT
 
     @pytest.mark.integration
     def test_getPositionFromCode(self, tracy):
-        position = tracy.getPositionFromCode("S61427")
-        assert 'Teaching Associate' == position.POSN_TITLE
-        assert '2' == position.WLS
+        with app.app_context():
+            position = tracy.getPositionFromCode("S61427")
+            assert 'Teaching Associate' == position.POSN_TITLE
+            assert '2' == position.WLS
 
-        with pytest.raises(InvalidQueryException):
-            position = tracy.getPositionFromCode("eleven")
+            with pytest.raises(InvalidQueryException):
+                position = tracy.getPositionFromCode("eleven")
 
-        with pytest.raises(InvalidQueryException):
-            position = tracy.getPositionFromCode(17)
+            with pytest.raises(InvalidQueryException):
+                position = tracy.getPositionFromCode(17)
 
     @pytest.mark.integration
     def test_getSupervisorsFromUserInput(self, tracy):
-        supervisor = tracy.getSupervisorsFromUserInput("Jan Pearce")
-        assert "Jan" == supervisor[0].FIRST_NAME
-        assert 1 == len(supervisor)
+        with app.app_context():
+            supervisor = tracy.getSupervisorsFromUserInput("Jan Pearce")
+            assert "Jan" == supervisor[0].FIRST_NAME
+            assert 1 == len(supervisor)
 
-        supervisor = tracy.getSupervisorsFromUserInput("heggen")
-        assert "Scott" == supervisor[0].FIRST_NAME
-        assert 1 == len(supervisor)
+            supervisor = tracy.getSupervisorsFromUserInput("heggen")
+            assert "Scott" == supervisor[0].FIRST_NAME
+            assert 1 == len(supervisor)
 
-        supervisor = tracy.getSupervisorsFromUserInput("Peter Parker")
-        assert supervisor != True
-        assert 0 == len(supervisor)
+            supervisor = tracy.getSupervisorsFromUserInput("Peter Parker")
+            assert supervisor != True
+            assert 0 == len(supervisor)
 
     @pytest.mark.integration
     def test_getStudentsFromUserInput(self, tracy):
-        students = tracy.getStudentsFromUserInput("Guillermo")
-        assert "Guillermo" == students[0].FIRST_NAME
-        assert 1 == len(students)
+        with app.app_context():
+            students = tracy.getStudentsFromUserInput("Guillermo")
+            assert "Guillermo" == students[0].FIRST_NAME
+            assert 1 == len(students)
 
-        students = tracy.getStudentsFromUserInput("Adams")
-        assert  2 == len(students)
-        assert "Adams" == students[1].LAST_NAME
+            students = tracy.getStudentsFromUserInput("Adams")
+            assert  2 == len(students)
+            assert "Adams" == students[1].LAST_NAME
 
-        students = tracy.getSupervisorsFromUserInput("John Smith")
-        assert students != True
-        assert 0 == len(students)
+            students = tracy.getSupervisorsFromUserInput("John Smith")
+            assert students != True
+            assert 0 == len(students)
 
     @pytest.mark.integration
     def test_checkStudentOrSupervisor(self, tracy):
-        user = tracy.checkStudentOrSupervisor("cruzg")
-        assert "Student" == user
+        with app.app_context():
+            user = tracy.checkStudentOrSupervisor("cruzg")
+            assert "Student" == user
 
-        user = tracy.checkStudentOrSupervisor("heggens")
-        assert "Supervisor" == user
+            user = tracy.checkStudentOrSupervisor("heggens")
+            assert "Supervisor" == user
 
-        with pytest.raises(InvalidQueryException):
-            user = tracy.checkStudentOrSupervisor("smith")
+            with pytest.raises(InvalidQueryException):
+                user = tracy.checkStudentOrSupervisor("smith")

--- a/tests/code/test_userInsertFunctions.py
+++ b/tests/code/test_userInsertFunctions.py
@@ -1,4 +1,5 @@
 import pytest
+from app import app
 from app.models.Tracy.studata import STUDATA
 from app.models.Tracy.stustaff import STUSTAFF
 from app.models import mainDB
@@ -11,211 +12,217 @@ from app.logic.userInsertFunctions import *
 
 @pytest.mark.integration
 def test_createSupervisorFromTracy():
-    # Test fail conditions
-    with pytest.raises(InvalidUserException):
-        supervisor = createSupervisorFromTracy()
+    with app.app_context():
+        # Test fail conditions
+        with pytest.raises(InvalidUserException):
+            supervisor = createSupervisorFromTracy()
 
-    with pytest.raises(InvalidUserException):
-        supervisor = createSupervisorFromTracy("B12361006")
+        with pytest.raises(InvalidUserException):
+            supervisor = createSupervisorFromTracy("B12361006")
 
-    with pytest.raises(InvalidUserException):
-        supervisor = createSupervisorFromTracy(username="B12361006")
+        with pytest.raises(InvalidUserException):
+            supervisor = createSupervisorFromTracy(username="B12361006")
 
-    with pytest.raises(InvalidUserException):
-        supervisor = createSupervisorFromTracy(bnumber="heggens")
+        with pytest.raises(InvalidUserException):
+            supervisor = createSupervisorFromTracy(bnumber="heggens")
 
-    # Test success conditions
-    supervisor = createSupervisorFromTracy(username="heggens", bnumber="B12361006")
-    assert supervisor.FIRST_NAME == "Scott"
+        # Test success conditions
+        supervisor = createSupervisorFromTracy(username="heggens", bnumber="B12361006")
+        assert supervisor.FIRST_NAME == "Scott"
 
-    supervisor = createSupervisorFromTracy(username="", bnumber="B12361006")
-    assert supervisor.FIRST_NAME == "Scott"
+        supervisor = createSupervisorFromTracy(username="", bnumber="B12361006")
+        assert supervisor.FIRST_NAME == "Scott"
 
-    supervisor = createSupervisorFromTracy(bnumber="B12361006")
-    assert supervisor.FIRST_NAME == "Scott"
+        supervisor = createSupervisorFromTracy(bnumber="B12361006")
+        assert supervisor.FIRST_NAME == "Scott"
 
-    supervisor = createSupervisorFromTracy(username="heggens")
-    assert supervisor.FIRST_NAME == "Scott"
+        supervisor = createSupervisorFromTracy(username="heggens")
+        assert supervisor.FIRST_NAME == "Scott"
 
-    supervisor = createSupervisorFromTracy(username="heggens", bnumber="")
-    assert supervisor.FIRST_NAME == "Scott"
+        supervisor = createSupervisorFromTracy(username="heggens", bnumber="")
+        assert supervisor.FIRST_NAME == "Scott"
 
-    supervisor = createSupervisorFromTracy("heggens")
-    assert supervisor.FIRST_NAME == "Scott"
+        supervisor = createSupervisorFromTracy("heggens")
+        assert supervisor.FIRST_NAME == "Scott"
 
-    # Tests getting a supervisor from TRACY that does not exist in the supervisor table
-    supervisor = createSupervisorFromTracy(username="hoffmanm", bnumber="B1236237")
-    assert supervisor.FIRST_NAME == "Megan"
-    supervisor.delete_instance()
+        # Tests getting a supervisor from TRACY that does not exist in the supervisor table
+        supervisor = createSupervisorFromTracy(username="hoffmanm", bnumber="B1236237")
+        assert supervisor.FIRST_NAME == "Megan"
+        supervisor.delete_instance()
 
-    supervisor = createSupervisorFromTracy(username="", bnumber="B1236237")
-    assert supervisor.FIRST_NAME == "Megan"
-    supervisor.delete_instance()
+        supervisor = createSupervisorFromTracy(username="", bnumber="B1236237")
+        assert supervisor.FIRST_NAME == "Megan"
+        supervisor.delete_instance()
 
-    supervisor = createSupervisorFromTracy(username="hoffmanm")
-    assert supervisor.FIRST_NAME == "Megan"
-    supervisor.delete_instance()
+        supervisor = createSupervisorFromTracy(username="hoffmanm")
+        assert supervisor.FIRST_NAME == "Megan"
+        supervisor.delete_instance()
 
 @pytest.mark.integration
 def test_createStudentFromTracy():
-    # Test fail conditions
-    with pytest.raises(ValueError):
-        student = createStudentFromTracy()
+    with app.app_context():
+        # Test fail conditions
+        with pytest.raises(ValueError):
+            student = createStudentFromTracy()
 
-    with pytest.raises(InvalidUserException):
-        student = createStudentFromTracy("B00730361")
+        with pytest.raises(InvalidUserException):
+            student = createStudentFromTracy("B00730361")
 
-    with pytest.raises(InvalidUserException):
-        student = createStudentFromTracy(username="B00730361")
+        with pytest.raises(InvalidUserException):
+            student = createStudentFromTracy(username="B00730361")
 
-    with pytest.raises(InvalidUserException):
-        student = createStudentFromTracy(bnumber="jamalie")
+        with pytest.raises(InvalidUserException):
+            student = createStudentFromTracy(bnumber="jamalie")
 
-    # Test success conditions
-    student = createStudentFromTracy(username="jamalie", bnumber="B00730361")
-    assert student.FIRST_NAME == "Elaheh"
+        # Test success conditions
+        student = createStudentFromTracy(username="jamalie", bnumber="B00730361")
+        assert student.FIRST_NAME == "Elaheh"
 
-    student = createStudentFromTracy(username="", bnumber="B00730361")
-    assert student.FIRST_NAME == "Elaheh"
+        student = createStudentFromTracy(username="", bnumber="B00730361")
+        assert student.FIRST_NAME == "Elaheh"
 
-    student = createStudentFromTracy(bnumber="B00730361")
-    assert student.FIRST_NAME == "Elaheh"
+        student = createStudentFromTracy(bnumber="B00730361")
+        assert student.FIRST_NAME == "Elaheh"
 
-    student = createStudentFromTracy(username="jamalie")
-    assert student.FIRST_NAME == "Elaheh"
+        student = createStudentFromTracy(username="jamalie")
+        assert student.FIRST_NAME == "Elaheh"
 
-    student = createStudentFromTracy(username="jamalie", bnumber="")
-    assert student.FIRST_NAME == "Elaheh"
+        student = createStudentFromTracy(username="jamalie", bnumber="")
+        assert student.FIRST_NAME == "Elaheh"
 
-    student = createStudentFromTracy("jamalie")
-    assert student.FIRST_NAME == "Elaheh"
+        student = createStudentFromTracy("jamalie")
+        assert student.FIRST_NAME == "Elaheh"
 
-    # Tests getting a student from TRACY that does not exist in the student table
-    student = createStudentFromTracy(username="adamskg", bnumber="B00785329")
-    assert student.FIRST_NAME == "Kat"
-    student.delete_instance()
+        # Tests getting a student from TRACY that does not exist in the student table
+        student = createStudentFromTracy(username="adamskg", bnumber="B00785329")
+        assert student.FIRST_NAME == "Kat"
+        student.delete_instance()
 
-    student = createStudentFromTracy(username="", bnumber="B00785329")
-    assert student.FIRST_NAME == "Kat"
-    student.delete_instance()
+        student = createStudentFromTracy(username="", bnumber="B00785329")
+        assert student.FIRST_NAME == "Kat"
+        student.delete_instance()
 
-    student = createStudentFromTracy(username="adamskg")
-    assert student.FIRST_NAME == "Kat"
-    student.delete_instance()
+        student = createStudentFromTracy(username="adamskg")
+        assert student.FIRST_NAME == "Kat"
+        student.delete_instance()
 
 @pytest.mark.integration
 def test_getOrCreateStudentRecord():
-    # Test fail conditions
-    with pytest.raises(ValueError):
-        student = getOrCreateStudentRecord()
+    with app.app_context():
+        # Test fail conditions
+        with pytest.raises(ValueError):
+            student = getOrCreateStudentRecord()
 
-    with pytest.raises(InvalidUserException):
-        student = getOrCreateStudentRecord("B00730361")
+        with pytest.raises(InvalidUserException):
+            student = getOrCreateStudentRecord("B00730361")
 
-    with pytest.raises(InvalidUserException):
-        student = getOrCreateStudentRecord(username="B00730361")
+        with pytest.raises(InvalidUserException):
+            student = getOrCreateStudentRecord(username="B00730361")
 
-    with pytest.raises(InvalidUserException):
-        student = getOrCreateStudentRecord(bnumber="jamalie")
+        with pytest.raises(InvalidUserException):
+            student = getOrCreateStudentRecord(bnumber="jamalie")
 
-    # Test success conditions
-    student = getOrCreateStudentRecord(username="jamalie", bnumber="B00730361")
-    assert student.FIRST_NAME == "Elaheh"
+        # Test success conditions
+        student = getOrCreateStudentRecord(username="jamalie", bnumber="B00730361")
+        assert student.FIRST_NAME == "Elaheh"
 
-    student = getOrCreateStudentRecord(username="", bnumber="B00730361")
-    assert student.FIRST_NAME == "Elaheh"
+        student = getOrCreateStudentRecord(username="", bnumber="B00730361")
+        assert student.FIRST_NAME == "Elaheh"
 
-    student = getOrCreateStudentRecord(bnumber="B00730361")
-    assert student.FIRST_NAME == "Elaheh"
+        student = getOrCreateStudentRecord(bnumber="B00730361")
+        assert student.FIRST_NAME == "Elaheh"
 
-    student = getOrCreateStudentRecord(username="jamalie")
-    assert student.FIRST_NAME == "Elaheh"
+        student = getOrCreateStudentRecord(username="jamalie")
+        assert student.FIRST_NAME == "Elaheh"
 
-    student = getOrCreateStudentRecord(username="jamalie", bnumber="")
-    assert student.FIRST_NAME == "Elaheh"
+        student = getOrCreateStudentRecord(username="jamalie", bnumber="")
+        assert student.FIRST_NAME == "Elaheh"
 
-    student = getOrCreateStudentRecord("jamalie")
-    assert student.FIRST_NAME == "Elaheh"
+        student = getOrCreateStudentRecord("jamalie")
+        assert student.FIRST_NAME == "Elaheh"
 
-    # Test getting a student that does not exist in Tracy
-    student = getOrCreateStudentRecord(bnumber="B00841417")
-    assert student.FIRST_NAME == "Alex"
+        # Test getting a student that does not exist in Tracy
+        student = getOrCreateStudentRecord(bnumber="B00841417")
+        assert student.FIRST_NAME == "Alex"
 
-    student = getOrCreateStudentRecord(username="bryantal")
-    assert student.FIRST_NAME == "Alex"
+        student = getOrCreateStudentRecord(username="bryantal")
+        assert student.FIRST_NAME == "Alex"
 
 
-    # Tests getting a student from TRACY that does not exist in the student table
-    student = getOrCreateStudentRecord(username="adamskg", bnumber="B00785329")
-    assert student.FIRST_NAME == "Kat"
-    student.delete_instance()
+        # Tests getting a student from TRACY that does not exist in the student table
+        student = getOrCreateStudentRecord(username="adamskg", bnumber="B00785329")
+        assert student.FIRST_NAME == "Kat"
+        student.delete_instance()
 
-    student = getOrCreateStudentRecord(username="", bnumber="B00785329")
-    assert student.FIRST_NAME == "Kat"
-    student.delete_instance()
+        student = getOrCreateStudentRecord(username="", bnumber="B00785329")
+        assert student.FIRST_NAME == "Kat"
+        student.delete_instance()
 
-    student = getOrCreateStudentRecord(username="adamskg")
-    assert student.FIRST_NAME == "Kat"
-    student.delete_instance()
+        student = getOrCreateStudentRecord(username="adamskg")
+        assert student.FIRST_NAME == "Kat"
+        student.delete_instance()
 
 @pytest.mark.integration
 def test_updateSupervisorFromTracy():
-    user = User.get(username="heggens")
-    assert user.fullName == "Scott Heggen"
+    with app.app_context():
+        user = User.get(username="heggens")
+        assert user.fullName == "Scott Heggen"
 
-    tracyEntry = Tracy().getSupervisorFromID(user.supervisor_id)
-    tracyEntry.FIRST_NAME="NotScott"
-    tracyEntry.LAST_NAME="NotHeggen"
-    db.session.commit()
+        tracyEntry = Tracy().getSupervisorFromID(user.supervisor_id)
+        tracyEntry.FIRST_NAME="NotScott"
+        tracyEntry.LAST_NAME="NotHeggen"
+        db.session.commit()
 
-    user = updateUserFromTracy(user)
-    assert user.fullName == "NotScott NotHeggen"
+        user = updateUserFromTracy(user)
+        assert user.fullName == "NotScott NotHeggen"
 
-    dbuser = User.get(username="heggens")
-    assert dbuser.fullName == "NotScott NotHeggen", "The object changed but not the database"
+        dbuser = User.get(username="heggens")
+        assert dbuser.fullName == "NotScott NotHeggen", "The object changed but not the database"
 
-    tracyEntry.FIRST_NAME="Scott"
-    tracyEntry.LAST_NAME="Heggen"
-    db.session.commit()
+        tracyEntry.FIRST_NAME="Scott"
+        tracyEntry.LAST_NAME="Heggen"
+        db.session.commit()
 
-    dbuser.supervisor.legal_name="Scott"
-    dbuser.supervisor.LAST_NAME="Heggen"
-    dbuser.supervisor.save()
+        dbuser.supervisor.legal_name="Scott"
+        dbuser.supervisor.LAST_NAME="Heggen"
+        dbuser.supervisor.save()
 
 @pytest.mark.integration
 def test_updateStudentFromTracy():
-    user = User.get(username="jamalie")
-    assert user.fullName == "Elaheh Jamali"
+    with app.app_context():
+        user = User.get(username="jamalie")
+        assert user.fullName == "Elaheh Jamali"
 
-    tracyEntry = Tracy().getStudentFromBNumber(user.student_id)
-    tracyEntry.FIRST_NAME="NotElaheh"
-    tracyEntry.LAST_NAME="NotJamali"
-    db.session.commit()
+        tracyEntry = Tracy().getStudentFromBNumber(user.student_id)
+        tracyEntry.FIRST_NAME="NotElaheh"
+        tracyEntry.LAST_NAME="NotJamali"
+        db.session.commit()
 
-    user = updateUserFromTracy(user)
-    assert user.fullName == "NotElaheh NotJamali"
+        user = updateUserFromTracy(user)
+        assert user.fullName == "NotElaheh NotJamali"
 
-    dbuser = User.get(username="jamalie")
-    assert dbuser.fullName == "NotElaheh NotJamali", "The object changed but not the database"
+        dbuser = User.get(username="jamalie")
+        assert dbuser.fullName == "NotElaheh NotJamali", "The object changed but not the database"
 
-    tracyEntry.FIRST_NAME="Elaheh"
-    tracyEntry.LAST_NAME="Jamali"
-    db.session.commit()
+        tracyEntry.FIRST_NAME="Elaheh"
+        tracyEntry.LAST_NAME="Jamali"
+        db.session.commit()
 
-    dbuser.student.legal_name="Elaheh"
-    dbuser.student.LAST_NAME="Jamali"
-    dbuser.student.save()
+        dbuser.student.legal_name="Elaheh"
+        dbuser.student.LAST_NAME="Jamali"
+        dbuser.student.save()
 
 @pytest.mark.integration
 def test_updateStudentDBRecords():
     with mainDB.atomic() as transaction:
-        incorrectStudent = Student.create(ID="B00751360", PIDM=2345, legal_name="NotTyler", LAST_NAME="Parton")
-        updateRecordIncorrectly = Supervisor.update(legal_name="NotMadina").where(Supervisor.ID == "B00769499").execute()
-        incorrectSupervisor = Supervisor.get(Supervisor.ID == "B00769499")
-        updateStudentRecord(incorrectStudent)
-        updateSupervisorRecord(incorrectSupervisor)
+        with app.app_context():
+            incorrectStudent = Student.create(ID="B00751360", PIDM=2345, legal_name="NotTyler", LAST_NAME="Parton")
+            updateRecordIncorrectly = Supervisor.update(legal_name="NotMadina").where(Supervisor.ID == "B00769499").execute()
+            incorrectSupervisor = Supervisor.get(Supervisor.ID == "B00769499")
+            updateStudentRecord(incorrectStudent)
+            updateSupervisorRecord(incorrectSupervisor)
 
-        assert incorrectStudent.FIRST_NAME == "Tyler"
-        assert incorrectSupervisor.FIRST_NAME == "Madina"
+            assert incorrectStudent.FIRST_NAME == "Tyler"
+            assert incorrectSupervisor.FIRST_NAME == "Madina"
 
-        transaction.rollback()
+            transaction.rollback()

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -57,4 +57,7 @@ case "$1" in
 	no-ui)
 		no_ui
 		;;
+    *) # assume it is a file or flag
+        python -m pytest $FLAGS -m "unit or integration" $1
+        ;;
 esac


### PR DESCRIPTION
Closes #621

Wires the Actions dropdown on the Manage Departments page to real navigation:
- Trimmed the 4 placeholder links down to the 2 items the issue asked for: **Allocation History** and **Department Personnel**.
- Both now link to that row's Department Portal page (/department/<org>/<account>), so the selected department is preserved through navigation instead of landing on a dead # link.

Branched off dep_portal_ad since that's where the current Manage Departments page redesign (with the placeholder dropdown) lives.

Tested locally end-to-end in the devcontainer: clicking the dropdown links navigates to the correct department's portal page, with that department pre-selected in the portal's department picker.