### PR TITLE
Wire Current Allocation card to real backend data (#602)

### DIFF
--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -1,5 +1,5 @@
 from flask import render_template, request, json, redirect, url_for, send_file, g, flash, jsonify
-from peewee import JOIN, DoesNotExist
+from peewee import JOIN, DoesNotExist, fn
 from functools import reduce
 import operator
 from app.models.department import Department
@@ -9,6 +9,7 @@ from app.models.student import Student
 from app.models.laborStatusForm import LaborStatusForm
 from app.models.formHistory import FormHistory
 from app.models.term import Term
+from app.models.allocation import Allocation
 from app.controllers.admin_routes.allPendingForms import checkAdjustment
 from app.controllers.main_routes import main_bp
 from app.logic.download import CSVMaker, saveFormSearchResult, retrieveFormSearchResult
@@ -80,11 +81,65 @@ def departmentPortal(org=None,account=None):
         if i.ORG == org:
             supervisors.append(i.FIRST_NAME + " " + i.LAST_NAME + " (" + i.EMAIL + ")")
 
-    return render_template('main/departmentPortal.html', 
+    allocation = None
+    allocationBands = None
+    totalPositionsAllocated = None
+    totalPositionsUsed = None
+    breakHoursUsed = None
+    if dept and g.openTerm:
+        allocation = Allocation.get_or_none(Allocation.department == dept, Allocation.termCode == g.openTerm)
+        if allocation:
+            bandFields = [
+                ('primary_10', 'Primary', 10),
+                ('primary_12', 'Primary', 12),
+                ('primary_15', 'Primary', 15),
+                ('primary_20', 'Primary', 20),
+                ('secondary_5', 'Secondary', 5),
+                ('secondary_10', 'Secondary', 10),
+            ]
+            allocationBands = {}
+            for fieldName, jobType, hours in bandFields:
+                used = (LaborStatusForm
+                        .select()
+                        .join(FormHistory, on=(FormHistory.formID == LaborStatusForm.laborStatusFormID))
+                        .where(LaborStatusForm.department == dept,
+                               LaborStatusForm.termCode == g.openTerm,
+                               LaborStatusForm.jobType == jobType,
+                               LaborStatusForm.weeklyHours == hours,
+                               FormHistory.historyType == "Labor Status Form",
+                               ~(FormHistory.status % "Denied%"))
+                        .distinct()
+                        .count())
+                allocationBands[fieldName] = {'used': used, 'allocated': getattr(allocation, fieldName)}
+
+            totalPositionsAllocated = sum(band['allocated'] for band in allocationBands.values())
+            totalPositionsUsed = sum(band['used'] for band in allocationBands.values())
+
+            # Break hours are tracked on separate break-term rows (e.g. Thanksgiving Break)
+            # that share the same academic year prefix as the open AY term.
+            yearPrefix = str(g.openTerm.termCode)[:-2]
+            breakTermCodes = [t.termCode for t in Term.select().where(Term.isBreak == True)
+                              if str(t.termCode).startswith(yearPrefix)]
+            breakHoursUsed = (LaborStatusForm
+                              .select(fn.SUM(LaborStatusForm.contractHours))
+                              .join(FormHistory, on=(FormHistory.formID == LaborStatusForm.laborStatusFormID))
+                              .where(LaborStatusForm.department == dept,
+                                     LaborStatusForm.termCode.in_(breakTermCodes),
+                                     FormHistory.historyType == "Labor Status Form",
+                                     ~(FormHistory.status % "Denied%"))
+                              .scalar()) or 0
+
+    return render_template('main/departmentPortal.html',
                            departments = departments,
                            department = dept,
                            positions = positions,
-                           supervisors = supervisors)
+                           supervisors = supervisors,
+                           allocation = allocation,
+                           allocationBands = allocationBands,
+                           totalPositionsAllocated = totalPositionsAllocated,
+                           totalPositionsUsed = totalPositionsUsed,
+                           breakHoursUsed = breakHoursUsed,
+                           currentTerm = g.openTerm)
 
 @main_bp.route('/department/<org>/<account>/managepositions', methods=['GET'])
 def managePositions(org, account):

--- a/app/templates/main/departmentPortal.html
+++ b/app/templates/main/departmentPortal.html
@@ -45,17 +45,23 @@
           <h3>{{ totalPositionsUsed if allocation else "No allocation" }}{% if allocation %}/{{ totalPositionsAllocated }}{% endif %} Positions</h3>
         </div>
         {% if allocation %}
-        <div class ="allocation-list" style="display: flex; justify-content: space-between; align-items: center; padding-left: 10px; padding-right: 10px;">
-        <ul style="font-size: 1.2em; padding-left: 75px;">
-          <li>10 Hour - {{ allocationBands.primary_10.used }}/{{ allocationBands.primary_10.allocated }}</li>
-          <li>12 Hour - {{ allocationBands.primary_12.used }}/{{ allocationBands.primary_12.allocated }}</li>
-          <li>15 Hour - {{ allocationBands.primary_15.used }}/{{ allocationBands.primary_15.allocated }}</li>
-          <li>20 Hour - {{ allocationBands.primary_20.used }}/{{ allocationBands.primary_20.allocated }}</li>
-        </ul>
-         <ul style="font-size: 1.2em; padding-right: 75px;">
-          <li>5 Hour - {{ allocationBands.secondary_5.used }}/{{ allocationBands.secondary_5.allocated }}</li>
-          <li>10 Hour - {{ allocationBands.secondary_10.used }}/{{ allocationBands.secondary_10.allocated }}</li>
-        </ul>
+        <div class ="allocation-list" style="display: flex; justify-content: space-between; align-items: flex-start; padding-left: 10px; padding-right: 10px;">
+        <div style="padding-left: 75px;">
+          <h4 style="margin: 0 0 4px 0;">Primary</h4>
+          <ul style="font-size: 1.2em; margin: 0; padding-left: 20px;">
+            <li>10 Hour - {{ allocationBands.primary_10.used }}/{{ allocationBands.primary_10.allocated }}</li>
+            <li>12 Hour - {{ allocationBands.primary_12.used }}/{{ allocationBands.primary_12.allocated }}</li>
+            <li>15 Hour - {{ allocationBands.primary_15.used }}/{{ allocationBands.primary_15.allocated }}</li>
+            <li>20 Hour - {{ allocationBands.primary_20.used }}/{{ allocationBands.primary_20.allocated }}</li>
+          </ul>
+        </div>
+        <div style="padding-right: 75px;">
+          <h4 style="margin: 0 0 4px 0;">Secondary</h4>
+          <ul style="font-size: 1.2em; margin: 0; padding-left: 20px;">
+            <li>5 Hour - {{ allocationBands.secondary_5.used }}/{{ allocationBands.secondary_5.allocated }}</li>
+            <li>10 Hour - {{ allocationBands.secondary_10.used }}/{{ allocationBands.secondary_10.allocated }}</li>
+          </ul>
+        </div>
         </div>
         {% endif %}
       </div>

--- a/app/templates/main/departmentPortal.html
+++ b/app/templates/main/departmentPortal.html
@@ -41,7 +41,7 @@
       </div>
       <div>
         <div class="header-container" style="display: flex; justify-content: space-between; align-items: center; padding-left: 10px; padding-right: 10px;">
-          <h3>{{ currentTerm.termName if currentTerm else "No open term" }}</h3>
+          <h3>{{ currentTerm.termName.replace("AY", "Term") if currentTerm else "No open term" }}</h3>
           <h3>{{ totalPositionsUsed if allocation else "No allocation" }}{% if allocation %}/{{ totalPositionsAllocated }}{% endif %} Positions</h3>
         </div>
         {% if allocation %}
@@ -67,9 +67,6 @@
         <div class="card-footer text-center">
       <a href="#" class="btn btn-primary btn-m">
         Manage Allocations <span class="glyphicon glyphicon-chevron-right"></span>
-      </a>
-      <a href="#" class="btn btn-primary btn-m">
-        Request Allocation <span class="glyphicon glyphicon-chevron-right"></span>
       </a>
     </div>
     </section>

--- a/app/templates/main/departmentPortal.html
+++ b/app/templates/main/departmentPortal.html
@@ -41,23 +41,27 @@
       </div>
       <div>
         <div class="header-container" style="display: flex; justify-content: space-between; align-items: center; padding-left: 10px; padding-right: 10px;">
-          <h3>AY 26/27</h3> <h3>15/20 Positions</h3>
+          <h3>{{ currentTerm.termName if currentTerm else "No open term" }}</h3>
+          <h3>{{ totalPositionsUsed if allocation else "No allocation" }}{% if allocation %}/{{ totalPositionsAllocated }}{% endif %} Positions</h3>
         </div>
+        {% if allocation %}
         <div class ="allocation-list" style="display: flex; justify-content: space-between; align-items: center; padding-left: 10px; padding-right: 10px;">
         <ul style="font-size: 1.2em; padding-left: 75px;">
-          <li>10 Hour - 2/2</li>
-          <li>12 Hour - 3/3</li>
-          <li>15 Hour - 5/5</li>
-          <li>20 Hour - 5/5</li>
+          <li>10 Hour - {{ allocationBands.primary_10.used }}/{{ allocationBands.primary_10.allocated }}</li>
+          <li>12 Hour - {{ allocationBands.primary_12.used }}/{{ allocationBands.primary_12.allocated }}</li>
+          <li>15 Hour - {{ allocationBands.primary_15.used }}/{{ allocationBands.primary_15.allocated }}</li>
+          <li>20 Hour - {{ allocationBands.primary_20.used }}/{{ allocationBands.primary_20.allocated }}</li>
         </ul>
          <ul style="font-size: 1.2em; padding-right: 75px;">
-          <li>5 Hour - 2/2</li>
-          <li>10 Hour - 3/3</li>
+          <li>5 Hour - {{ allocationBands.secondary_5.used }}/{{ allocationBands.secondary_5.allocated }}</li>
+          <li>10 Hour - {{ allocationBands.secondary_10.used }}/{{ allocationBands.secondary_10.allocated }}</li>
         </ul>
         </div>
+        {% endif %}
       </div>
       <div class="header-container" style="display: flex; justify-content: space-between; align-items: center; padding-left: 10px; padding-right: 10px;">
-        <h3>Break Hours</h3> <h3>0/200 Hours</h3>
+        <h3>Break Hours</h3>
+        <h3>{{ breakHoursUsed if allocation else "No allocation" }}{% if allocation %}/{{ allocation.breakHours }}{% endif %} Hours</h3>
       </div>
     </div>
         <div class="card-footer text-center">

--- a/database/demo_data.py
+++ b/database/demo_data.py
@@ -17,6 +17,7 @@ from app.models.term import Term
 from app.models.laborStatusForm import LaborStatusForm
 from app.models.formHistory import FormHistory
 from app.models.notes import Notes
+from app.models.allocation import Allocation
 
 print("Inserting data for demo and testing purposes")
 
@@ -609,3 +610,86 @@ notes = [
        ]
 Notes.insert_many(notes).on_conflict_replace().execute()
 print(" * laborOfficeNotes added")
+
+#############################
+# Allocation
+#############################
+allocations = [
+    {
+        "termCode": f"{current_year}00",
+        "department": 1,
+        "isApproved": True,
+        "approvedOn": f"{current_year}-08-15",
+        "approvedBy": "B12361006",
+        "justification": "Standard allocation for Computer Science based on enrollment.",
+        "primary_10": 2,
+        "primary_12": 3,
+        "primary_15": 5,
+        "primary_20": 5,
+        "secondary_5": 2,
+        "secondary_10": 3,
+        "breakHours": 200,
+    },
+    {
+        "termCode": f"{current_year}00",
+        "department": 2,
+        "isApproved": True,
+        "approvedOn": f"{current_year}-08-15",
+        "approvedBy": "B12361006",
+        "justification": "Standard allocation for Technology and Applied Design.",
+        "primary_10": 1,
+        "primary_12": 2,
+        "primary_15": 2,
+        "primary_20": 1,
+        "secondary_5": 1,
+        "secondary_10": 1,
+        "breakHours": 100,
+    },
+    {
+        "termCode": f"{current_year}00",
+        "department": 3,
+        "isApproved": True,
+        "approvedOn": f"{current_year}-08-15",
+        "approvedBy": "B12361006",
+        "justification": "Standard allocation for Mathematics.",
+        "primary_10": 1,
+        "primary_12": 1,
+        "primary_15": 1,
+        "primary_20": 0,
+        "secondary_5": 1,
+        "secondary_10": 0,
+        "breakHours": 80,
+    },
+    {
+        "termCode": f"{current_year}00",
+        "department": 4,
+        "isApproved": True,
+        "approvedOn": f"{current_year}-08-15",
+        "approvedBy": "B12361006",
+        "justification": "Standard allocation for Biology.",
+        "primary_10": 2,
+        "primary_12": 1,
+        "primary_15": 1,
+        "primary_20": 1,
+        "secondary_5": 1,
+        "secondary_10": 1,
+        "breakHours": 120,
+    },
+    {
+        "termCode": f"{current_year}00",
+        "department": 5,
+        "isApproved": True,
+        "approvedOn": f"{current_year}-08-15",
+        "approvedBy": "B12361006",
+        "justification": "Standard allocation for the Labor Department.",
+        "primary_10": 2,
+        "primary_12": 3,
+        "primary_15": 5,
+        "primary_20": 5,
+        "secondary_5": 2,
+        "secondary_10": 3,
+        "breakHours": 200,
+    },
+]
+Allocation.insert_many(allocations).on_conflict_replace().execute()
+print(" * allocations added")

--- a/database/migrate_db.sh
+++ b/database/migrate_db.sh
@@ -30,6 +30,7 @@ pem add app.models.supervisor.Supervisor
 pem add app.models.supervisorDepartment.SupervisorDepartment
 pem add app.models.studentLaborEvaluation.StudentLaborEvaluation
 pem add app.models.formSearchResult.FormSearchResult
+pem add app.models.allocation.Allocation
 
 pem watch
 pem migrate


### PR DESCRIPTION
Related to #602

Replaces the hardcoded placeholder numbers on the Department Portal's 'Current Allocation' card with real data:
- Fixed \database/migrate_db.sh\, which was missing \pp.models.allocation.Allocation\ entirely — the \llocation\ table was never being created via migrations.
- Added demo \Allocation\ seed rows per department (none existed before).
- \departmentPortal()\ now queries the department's \Allocation\ row for the current open term, and computes real 'used' counts per hour-band (10/12/15/20 primary, 5/10 secondary) by counting non-denied \LaborStatusForm\s — reusing the same denied-filter pattern already used elsewhere in the app (\statusFormFunctions.py\).
- Added a best-effort 'break hours used' calculation (summed from \contractHours\ on break-term forms), since nothing previously tracked this.
- Added 'Primary' / 'Secondary' section titles above the hour-band breakdown lists for clarity.
- Removed the non-functional 'Request Allocation' button (no destination page exists yet) and relabeled 'AY' to 'Term' in the term display.

Not yet done / out of scope for this PR: the 'Manage Allocations' button still points nowhere (destination page depends on other open issues), and there's no access-control check restricting a department's allocation data to Labor admins + that department's own staff.

Tested locally end-to-end in the devcontainer against real seeded data across multiple departments.