### PR TITLE
Display allocation warning during pending LSF approval (#622)

### DIFF
--- a/app/controllers/main_routes/departmentPortal.py
+++ b/app/controllers/main_routes/departmentPortal.py
@@ -1,0 +1,1 @@
+from flask import render_template

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -1,16 +1,12 @@
 from flask import render_template, request, json, redirect, url_for, send_file, g, flash, jsonify
-from peewee import JOIN, DoesNotExist, fn
+from peewee import JOIN, DoesNotExist
 from functools import reduce
 import operator
-from app.models.allocation import Allocation
 from app.models.department import Department
 from app.models.supervisor import Supervisor
 from app.models.supervisorDepartment import SupervisorDepartment
 from app.models.student import Student
-from app.models.laborStatusForm import LaborStatusForm
 from app.models.formHistory import FormHistory
-from app.models.term import Term
-from app.models.allocation import Allocation
 from app.controllers.admin_routes.allPendingForms import checkAdjustment
 from app.controllers.main_routes import main_bp
 from app.logic.download import CSVMaker, saveFormSearchResult, retrieveFormSearchResult
@@ -19,6 +15,7 @@ from app.login_manager import require_login, logout
 from app.logic.getTableData import getDatatableData
 from app.logic.banner import Banner
 from app.logic.tracy import Tracy
+from app.logic.allocation import getAllocationSummary
 
 @main_bp.route('/logout', methods=['GET'])
 def triggerLogout():
@@ -82,64 +79,18 @@ def departmentPortal(org=None,account=None):
         if i.ORG == org:
             supervisors.append(i.FIRST_NAME + " " + i.LAST_NAME + " (" + i.EMAIL + ")")
 
-    allocation = None
-    allocationBands = None
-    totalPositionsAllocated = None
-    totalPositionsUsed = None
-    breakHoursUsed = None
-    if dept and g.openTerm:
-        allocation = Allocation.get_or_none(Allocation.department == dept, Allocation.termCode == g.openTerm)
-        if allocation:
-            bandFields = [
-                ('primary_10', 'Primary', 10),
-                ('primary_12', 'Primary', 12),
-                ('primary_15', 'Primary', 15),
-                ('primary_20', 'Primary', 20),
-                ('secondary_5', 'Secondary', 5),
-                ('secondary_10', 'Secondary', 10),
-            ]
-            allocationBands = {}
-            for fieldName, jobType, hours in bandFields:
-                used = (LaborStatusForm
-                        .select()
-                        .join(FormHistory, on=(FormHistory.formID == LaborStatusForm.laborStatusFormID))
-                        .where(LaborStatusForm.department == dept,
-                               LaborStatusForm.termCode == g.openTerm,
-                               LaborStatusForm.jobType == jobType,
-                               LaborStatusForm.weeklyHours == hours,
-                               FormHistory.historyType == "Labor Status Form",
-                               ~(FormHistory.status % "Denied%"))
-                        .distinct()
-                        .count())
-                allocationBands[fieldName] = {'used': used, 'allocated': getattr(allocation, fieldName)}
-
-            totalPositionsAllocated = sum(band['allocated'] for band in allocationBands.values())
-            totalPositionsUsed = sum(band['used'] for band in allocationBands.values())
-
-            # Break hours are tracked on separate break-term rows (e.g. Thanksgiving Break)
-            # that share the same academic year prefix as the open AY term.
-            yearPrefix = str(g.openTerm.termCode)[:-2]
-            breakTermCodes = [t.termCode for t in Term.select().where(Term.isBreak == True)
-                              if str(t.termCode).startswith(yearPrefix)]
-            breakHoursUsed = (LaborStatusForm
-                              .select(fn.SUM(LaborStatusForm.contractHours))
-                              .join(FormHistory, on=(FormHistory.formID == LaborStatusForm.laborStatusFormID))
-                              .where(LaborStatusForm.department == dept,
-                                     LaborStatusForm.termCode.in_(breakTermCodes),
-                                     FormHistory.historyType == "Labor Status Form",
-                                     ~(FormHistory.status % "Denied%"))
-                              .scalar()) or 0
+    allocationSummary = getAllocationSummary(dept, g.openTerm)
 
     return render_template('main/departmentPortal.html',
                            departments = departments,
                            department = dept,
                            positions = positions,
                            supervisors = supervisors,
-                           allocation = allocation,
-                           allocationBands = allocationBands,
-                           totalPositionsAllocated = totalPositionsAllocated,
-                           totalPositionsUsed = totalPositionsUsed,
-                           breakHoursUsed = breakHoursUsed,
+                           allocation = allocationSummary['allocation'],
+                           allocationBands = allocationSummary['allocationBands'],
+                           totalPositionsAllocated = allocationSummary['totalPositionsAllocated'],
+                           totalPositionsUsed = allocationSummary['totalPositionsUsed'],
+                           breakHoursUsed = allocationSummary['breakHoursUsed'],
                            currentTerm = g.openTerm)
 
 @main_bp.route('/department/<org>/<account>/managepositions', methods=['GET'])

--- a/app/logic/allPendingForms.py
+++ b/app/logic/allPendingForms.py
@@ -89,12 +89,10 @@ def saveStatus(new_status, formHistoryIds, currentUser):
     for dept in approvedDepartments.values():
         warning = getAllocationWarning(dept, g.openTerm)
         if warning and warning['isOverAllocated']:
-            messageParts = []
-            if warning['isPositionsOverAllocated']:
-                messageParts.append(f"{warning['totalPositionsUsed']}/{warning['totalPositionsAllocated']} positions")
+            messageParts = [f"{b['label']} ({b['used']}/{b['allocated']})" for b in warning['overAllocatedBands']]
             if warning['isBreakHoursOverAllocated']:
-                messageParts.append(f"{warning['breakHoursUsed']}/{warning['breakHoursAllocated']} break hours")
-            flash(f"{dept.DEPT_NAME} is now over its allocation ({' and '.join(messageParts)}).", "warning")
+                messageParts.append(f"break hours ({warning['breakHoursUsed']}/{warning['breakHoursAllocated']})")
+            flash(f"{dept.DEPT_NAME} is now over its allocation for: {', '.join(messageParts)}.", "warning")
 
     return jsonify({"success": True})
 
@@ -212,9 +210,6 @@ def laborAdminOverloadApproval(rsp, historyForm, status, currentUser, currentDat
 
 # extract data from the database to populate pending form approval modal
 def modal_approval_and_denial_data(formHistoryIdList):
-    ''' This method grabs the data that populated the on approve modal for lsf,
-    plus an over-allocation warning per unique department among the selected forms. '''
-
     details_list = []
     allocationWarningsByDept = {}
     for fhID in formHistoryIdList:

--- a/app/logic/allPendingForms.py
+++ b/app/logic/allPendingForms.py
@@ -1,6 +1,6 @@
 import json
 from datetime import date
-from flask import jsonify
+from flask import jsonify, g
 from app.models.formHistory import FormHistory
 from app.models.status import Status
 from app.logic.banner import Banner
@@ -14,6 +14,7 @@ from app.logic.tracy import Tracy
 from app.models.overloadForm import OverloadForm
 from app.models.notes import Notes
 from app.login_manager import DoesNotExist, render_template
+from app.logic.allocation import getAllocationWarning
 
 
 def saveStatus(new_status, formHistoryIds, currentUser):
@@ -196,9 +197,11 @@ def laborAdminOverloadApproval(rsp, historyForm, status, currentUser, currentDat
 
 # extract data from the database to populate pending form approval modal
 def modal_approval_and_denial_data(formHistoryIdList):
-    ''' This method grabs the data that populated the on approve modal for lsf'''
+    ''' This method grabs the data that populated the on approve modal for lsf,
+    plus an over-allocation warning per unique department among the selected forms. '''
 
     details_list = []
+    allocationWarningsByDept = {}
     for fhID in formHistoryIdList:
         formHistory = FormHistory.get(FormHistory.formHistoryID == fhID)
         lsf = formHistory.formID
@@ -208,7 +211,8 @@ def modal_approval_and_denial_data(formHistoryIdList):
         supervisorName = f"{lsf.supervisor.FIRST_NAME} {lsf.supervisor.LAST_NAME}"
         weeklyHours = lsf.weeklyHours
         contractHours = lsf.contractHours
-        deptName = lsf.department.DEPT_NAME
+        dept = lsf.department
+        deptName = dept.DEPT_NAME
 
         if formHistory.adjustedForm:
             match formHistory.adjustedForm.fieldAdjusted:
@@ -223,11 +227,17 @@ def modal_approval_and_denial_data(formHistoryIdList):
                 case "contractHours":
                     contractHours = formHistory.adjustedForm.newValue
                 case "department":
-                    deptName = Department.get(Department.ORG==formHistory.adjustedForm.newValue).DEPT_NAME
+                    dept = Department.get(Department.ORG==formHistory.adjustedForm.newValue)
+                    deptName = dept.DEPT_NAME
 
         details_list.append([studentName, deptName, position, str(weeklyHours),str(contractHours), supervisorName])
 
-    return details_list
+        if dept.departmentID not in allocationWarningsByDept:
+            warning = getAllocationWarning(dept, g.openTerm)
+            if warning:
+                allocationWarningsByDept[dept.departmentID] = warning
+
+    return {"details": details_list, "allocationWarnings": list(allocationWarningsByDept.values())}
 
 
 def financialAidSAASOverloadApproval(historyForm, rsp, status, currentUser, currentDate):

--- a/app/logic/allPendingForms.py
+++ b/app/logic/allPendingForms.py
@@ -1,6 +1,6 @@
 import json
 from datetime import date
-from flask import jsonify, g
+from flask import jsonify, g, flash
 from app.models.formHistory import FormHistory
 from app.models.status import Status
 from app.logic.banner import Banner
@@ -18,6 +18,7 @@ from app.logic.allocation import getAllocationWarning
 
 
 def saveStatus(new_status, formHistoryIds, currentUser):
+    approvedDepartments = {}
     try:
         if new_status == 'Denied by Admin':
             # Index 1 will always hold the reject reason in the list, so we can
@@ -67,6 +68,8 @@ def saveStatus(new_status, formHistoryIds, currentUser):
                     email.laborStatusFormRejected()
                 if new_status == "Approved" and formType == "Labor Status Form":
                     email.laborStatusFormApproved()
+                    dept = formHistory.formID.department
+                    approvedDepartments[dept.departmentID] = dept
                 if new_status == "Approved" and formType == "Labor Adjustment Form":
                     # This function is triggered whenever an adjustment form is approved.
                     # The following function overrides the original data in lsf with the new data from adjustment form.
@@ -80,6 +83,18 @@ def saveStatus(new_status, formHistoryIds, currentUser):
     except Exception as e:
         print("Error preparing form for status update:", e)
         return jsonify({"success": False}), 500
+
+    # After approving, let the admin know right away if any affected department
+    # is now over its allocated positions or break hours (informational only).
+    for dept in approvedDepartments.values():
+        warning = getAllocationWarning(dept, g.openTerm)
+        if warning and warning['isOverAllocated']:
+            messageParts = []
+            if warning['isPositionsOverAllocated']:
+                messageParts.append(f"{warning['totalPositionsUsed']}/{warning['totalPositionsAllocated']} positions")
+            if warning['isBreakHoursOverAllocated']:
+                messageParts.append(f"{warning['breakHoursUsed']}/{warning['breakHoursAllocated']} break hours")
+            flash(f"{dept.DEPT_NAME} is now over its allocation ({' and '.join(messageParts)}).", "warning")
 
     return jsonify({"success": True})
 

--- a/app/logic/allocation.py
+++ b/app/logic/allocation.py
@@ -14,17 +14,10 @@ ALLOCATION_BAND_FIELDS = [
     ('secondary_10', 'Secondary', 10),
 ]
 
+BAND_LABELS = {fieldName: f"{hours} Hour {jobType}" for fieldName, jobType, hours in ALLOCATION_BAND_FIELDS}
+
 
 def getAllocationSummary(dept, term):
-    """
-    Returns a dict describing a department's allocation vs. actual usage for the given term:
-      - allocation: the Allocation row for this dept/term, or None if none exists
-      - allocationBands: {fieldName: {'used': int, 'allocated': int}} per hour-band, or None
-      - totalPositionsAllocated / totalPositionsUsed: ints, or None
-      - breakHoursUsed: int, or None
-    'used' counts are non-denied LaborStatusForms, matching the same filter pattern
-    used elsewhere in the app (see app/logic/statusFormFunctions.py).
-    """
     summary = {
         'allocation': None,
         'allocationBands': None,
@@ -78,22 +71,22 @@ def getAllocationSummary(dept, term):
 
 
 def getAllocationWarning(dept, term):
-    """
-    Returns a summary dict for displaying an over-allocation warning for the given
-    department/term (e.g. in the pending-LSF approval modal), or None if there's no
-    allocation on record for that department/term to compare against.
-
-    Note: 'used' counts (from getAllocationSummary) include Pending as well as
-    Approved forms, so a form currently Pending already occupies a slot here -
-    these numbers already reflect what utilization would be once it's approved.
-    """
     summary = getAllocationSummary(dept, term)
     if not summary['allocation']:
         return None
 
     positionsRemaining = summary['totalPositionsAllocated'] - summary['totalPositionsUsed']
     breakHoursRemaining = summary['allocation'].breakHours - summary['breakHoursUsed']
-    isPositionsOverAllocated = positionsRemaining < 0
+
+    # A department can be within its total position count while still exceeding
+    # one specific hour-band (e.g. over on 10-hour Primary but under on others),
+    # so each band needs to be checked individually, not just the aggregate total.
+    overAllocatedBands = [
+        {'label': BAND_LABELS[fieldName], 'used': band['used'], 'allocated': band['allocated']}
+        for fieldName, band in summary['allocationBands'].items()
+        if band['used'] > band['allocated']
+    ]
+    isPositionsOverAllocated = positionsRemaining < 0 or bool(overAllocatedBands)
     isBreakHoursOverAllocated = breakHoursRemaining < 0
 
     return {
@@ -102,6 +95,7 @@ def getAllocationWarning(dept, term):
         'totalPositionsUsed': summary['totalPositionsUsed'],
         'positionsRemaining': positionsRemaining,
         'isPositionsOverAllocated': isPositionsOverAllocated,
+        'overAllocatedBands': overAllocatedBands,
         'breakHoursAllocated': summary['allocation'].breakHours,
         'breakHoursUsed': summary['breakHoursUsed'],
         'breakHoursRemaining': breakHoursRemaining,

--- a/app/logic/allocation.py
+++ b/app/logic/allocation.py
@@ -93,14 +93,18 @@ def getAllocationWarning(dept, term):
 
     positionsRemaining = summary['totalPositionsAllocated'] - summary['totalPositionsUsed']
     breakHoursRemaining = summary['allocation'].breakHours - summary['breakHoursUsed']
+    isPositionsOverAllocated = positionsRemaining < 0
+    isBreakHoursOverAllocated = breakHoursRemaining < 0
 
     return {
         'departmentName': dept.DEPT_NAME,
         'totalPositionsAllocated': summary['totalPositionsAllocated'],
         'totalPositionsUsed': summary['totalPositionsUsed'],
         'positionsRemaining': positionsRemaining,
+        'isPositionsOverAllocated': isPositionsOverAllocated,
         'breakHoursAllocated': summary['allocation'].breakHours,
         'breakHoursUsed': summary['breakHoursUsed'],
         'breakHoursRemaining': breakHoursRemaining,
-        'isOverAllocated': positionsRemaining < 0 or breakHoursRemaining < 0,
+        'isBreakHoursOverAllocated': isBreakHoursOverAllocated,
+        'isOverAllocated': isPositionsOverAllocated or isBreakHoursOverAllocated,
     }

--- a/app/logic/allocation.py
+++ b/app/logic/allocation.py
@@ -1,0 +1,106 @@
+from peewee import fn
+from app.models.allocation import Allocation
+from app.models.laborStatusForm import LaborStatusForm
+from app.models.formHistory import FormHistory
+from app.models.term import Term
+
+# Each entry is (Allocation field name, LaborStatusForm.jobType, LaborStatusForm.weeklyHours)
+ALLOCATION_BAND_FIELDS = [
+    ('primary_10', 'Primary', 10),
+    ('primary_12', 'Primary', 12),
+    ('primary_15', 'Primary', 15),
+    ('primary_20', 'Primary', 20),
+    ('secondary_5', 'Secondary', 5),
+    ('secondary_10', 'Secondary', 10),
+]
+
+
+def getAllocationSummary(dept, term):
+    """
+    Returns a dict describing a department's allocation vs. actual usage for the given term:
+      - allocation: the Allocation row for this dept/term, or None if none exists
+      - allocationBands: {fieldName: {'used': int, 'allocated': int}} per hour-band, or None
+      - totalPositionsAllocated / totalPositionsUsed: ints, or None
+      - breakHoursUsed: int, or None
+    'used' counts are non-denied LaborStatusForms, matching the same filter pattern
+    used elsewhere in the app (see app/logic/statusFormFunctions.py).
+    """
+    summary = {
+        'allocation': None,
+        'allocationBands': None,
+        'totalPositionsAllocated': None,
+        'totalPositionsUsed': None,
+        'breakHoursUsed': None,
+    }
+
+    if not (dept and term):
+        return summary
+
+    allocation = Allocation.get_or_none(Allocation.department == dept, Allocation.termCode == term)
+    summary['allocation'] = allocation
+    if not allocation:
+        return summary
+
+    allocationBands = {}
+    for fieldName, jobType, hours in ALLOCATION_BAND_FIELDS:
+        used = (LaborStatusForm
+                .select()
+                .join(FormHistory, on=(FormHistory.formID == LaborStatusForm.laborStatusFormID))
+                .where(LaborStatusForm.department == dept,
+                       LaborStatusForm.termCode == term,
+                       LaborStatusForm.jobType == jobType,
+                       LaborStatusForm.weeklyHours == hours,
+                       FormHistory.historyType == "Labor Status Form",
+                       ~(FormHistory.status % "Denied%"))
+                .distinct()
+                .count())
+        allocationBands[fieldName] = {'used': used, 'allocated': getattr(allocation, fieldName)}
+
+    summary['allocationBands'] = allocationBands
+    summary['totalPositionsAllocated'] = sum(band['allocated'] for band in allocationBands.values())
+    summary['totalPositionsUsed'] = sum(band['used'] for band in allocationBands.values())
+
+    # Break hours are tracked on separate break-term rows (e.g. Thanksgiving Break)
+    # that share the same academic year prefix as the given AY term.
+    yearPrefix = str(term.termCode)[:-2]
+    breakTermCodes = [t.termCode for t in Term.select().where(Term.isBreak == True)
+                      if str(t.termCode).startswith(yearPrefix)]
+    summary['breakHoursUsed'] = (LaborStatusForm
+                                 .select(fn.SUM(LaborStatusForm.contractHours))
+                                 .join(FormHistory, on=(FormHistory.formID == LaborStatusForm.laborStatusFormID))
+                                 .where(LaborStatusForm.department == dept,
+                                        LaborStatusForm.termCode.in_(breakTermCodes),
+                                        FormHistory.historyType == "Labor Status Form",
+                                        ~(FormHistory.status % "Denied%"))
+                                 .scalar()) or 0
+
+    return summary
+
+
+def getAllocationWarning(dept, term):
+    """
+    Returns a summary dict for displaying an over-allocation warning for the given
+    department/term (e.g. in the pending-LSF approval modal), or None if there's no
+    allocation on record for that department/term to compare against.
+
+    Note: 'used' counts (from getAllocationSummary) include Pending as well as
+    Approved forms, so a form currently Pending already occupies a slot here -
+    these numbers already reflect what utilization would be once it's approved.
+    """
+    summary = getAllocationSummary(dept, term)
+    if not summary['allocation']:
+        return None
+
+    positionsRemaining = summary['totalPositionsAllocated'] - summary['totalPositionsUsed']
+    breakHoursRemaining = summary['allocation'].breakHours - summary['breakHoursUsed']
+
+    return {
+        'departmentName': dept.DEPT_NAME,
+        'totalPositionsAllocated': summary['totalPositionsAllocated'],
+        'totalPositionsUsed': summary['totalPositionsUsed'],
+        'positionsRemaining': positionsRemaining,
+        'breakHoursAllocated': summary['allocation'].breakHours,
+        'breakHoursUsed': summary['breakHoursUsed'],
+        'breakHoursRemaining': breakHoursRemaining,
+        'isOverAllocated': positionsRemaining < 0 or breakHoursRemaining < 0,
+    }

--- a/app/models/allocation.py
+++ b/app/models/allocation.py
@@ -1,0 +1,23 @@
+from app.models import *
+from app.models.department import Department
+from app.models.supervisor import Supervisor
+from app.models.term import Term
+
+class Allocation(baseModel):
+    termCode       = ForeignKeyField(Term)
+    department     = ForeignKeyField(Department)
+    isFinal        = BooleanField(default=False)
+    approvedOn     = DateField(null=True)
+    approvedBy     = ForeignKeyField(Supervisor, null=True)
+    justification  = TextField()
+    primary_10     = IntegerField()
+    primary_12     = IntegerField()
+    primary_15     = IntegerField()
+    primary_20     = IntegerField()
+    secondary_5    = IntegerField()
+    secondary_10   = IntegerField()
+    breakHours     = IntegerField()
+
+    class Meta:
+        indexes = ( (('termCode', 'department', 'isFinal'), True), )
+

--- a/app/models/positionHistory.py
+++ b/app/models/positionHistory.py
@@ -1,0 +1,14 @@
+from app.models import *
+from app.models.department import Department
+
+class PositionHistory(baseModel):
+    positionCode       = CharField()
+    department         = ForeignKeyField(Department)
+    status             = CharField()
+    wls                = IntegerField()
+    revisionDate       = DateField()
+    description        = TextField(default=None)
+
+    class Meta:
+        indexes = ( (('positionCode', 'revisionDate', 'status'), True), )
+

--- a/app/models/supervisor.py
+++ b/app/models/supervisor.py
@@ -16,6 +16,7 @@ class Supervisor(baseModel):
     legal_name      = CharField(null=True)
     preferred_name  = CharField(null=True)
     isActive        = BooleanField(default=False)
+    isBanned        = BooleanField(default=False)
 
 
     @property

--- a/app/models/supervisorDepartment.py
+++ b/app/models/supervisorDepartment.py
@@ -3,5 +3,6 @@ from app.models.supervisor import Supervisor
 from app.models.department import Department
 
 class SupervisorDepartment(baseModel):
-    supervisor = ForeignKeyField(Supervisor, null=True)
+    supervisor = ForeignKeyField(Supervisor)
     department = ForeignKeyField(Department)
+    isCoordinator = BooleanField(default=False)

--- a/app/static/js/allPendingForms.js
+++ b/app/static/js/allPendingForms.js
@@ -87,8 +87,8 @@ function insertApprovals(laborHistoryId = null) {
     contentType: 'application/json',
     success: function(response) {
       if (response) {
-        var returned_details = response;
-        updateApproveTableData(returned_details);
+        updateApproveTableData(response.details);
+        updateAllocationWarnings(response.allocationWarnings);
       }
     }
   });
@@ -112,6 +112,24 @@ function updateApproveTableData(returned_details) {
   }
 }
 
+// Shows a non-blocking allocation warning per department represented among the
+// selected forms, so admins can see the impact of approval before confirming.
+function updateAllocationWarnings(allocationWarnings) {
+  if (!allocationWarnings) { return; }
+  for (var i = 0; i < allocationWarnings.length; i++) {
+    var w = allocationWarnings[i];
+    var alertClass = w.isOverAllocated ? 'alert-danger' : 'alert-info';
+    var html = '<div class="alert ' + alertClass + '" role="alert">' +
+      '<strong>' + w.departmentName + ' Allocation</strong><br>' +
+      'Positions: ' + w.totalPositionsUsed + ' / ' + w.totalPositionsAllocated +
+      ' allocated (' + w.positionsRemaining + ' remaining)<br>' +
+      'Break Hours: ' + w.breakHoursUsed + ' / ' + w.breakHoursAllocated +
+      ' allocated (' + w.breakHoursRemaining + ' remaining)' +
+      '</div>';
+    $('#allocationWarnings').append(html);
+  }
+}
+
 
 $('#approvalModal').on('hidden.bs.modal', function () {// Makes the close functionality work when clicking outside of the modal
   approvalModalClose();
@@ -120,6 +138,7 @@ $('#approvalModal').on('hidden.bs.modal', function () {// Makes the close functi
 
 function approvalModalClose(){// on close of approval modal we are clearing the table to prevent duplicate data.
   $('#classTableBody').empty();
+  $('#allocationWarnings').empty();
   labor_details_ids = [] // emptying the list, becuase otherwise will cause duplicate data.
 }
 

--- a/app/static/js/allPendingForms.js
+++ b/app/static/js/allPendingForms.js
@@ -126,10 +126,19 @@ function updateAllocationWarnings(allocationWarnings) {
     var breakHoursStyle = w.isBreakHoursOverAllocated ? overStyle : '';
     var positionsFlag = w.isPositionsOverAllocated ? ' &#9888; Over allocation' : '';
     var breakHoursFlag = w.isBreakHoursOverAllocated ? ' &#9888; Over allocation' : '';
+    // A department can look fine in total while one specific hour-band is over,
+    // so call those bands out by name instead of only showing the aggregate.
+    var bandDetail = '';
+    if (w.overAllocatedBands && w.overAllocatedBands.length > 0) {
+      var bandStrings = w.overAllocatedBands.map(function(b) {
+        return b.label + ' (' + b.used + '/' + b.allocated + ')';
+      });
+      bandDetail = '<br><span style="' + overStyle + '">Over on: ' + bandStrings.join(', ') + '</span>';
+    }
     var html = '<div class="alert ' + boxClass + '" role="alert">' +
       '<strong>' + w.departmentName + ' Allocation</strong><br>' +
       '<span style="' + positionsStyle + '">Positions: ' + w.totalPositionsUsed + ' / ' + w.totalPositionsAllocated +
-      ' allocated (' + w.positionsRemaining + ' remaining)' + positionsFlag + '</span><br>' +
+      ' allocated (' + w.positionsRemaining + ' remaining)' + positionsFlag + '</span>' + bandDetail + '<br>' +
       '<span style="' + breakHoursStyle + '">Break Hours: ' + w.breakHoursUsed + ' / ' + w.breakHoursAllocated +
       ' allocated (' + w.breakHoursRemaining + ' remaining)' + breakHoursFlag + '</span>' +
       '</div>';

--- a/app/static/js/allPendingForms.js
+++ b/app/static/js/allPendingForms.js
@@ -114,17 +114,24 @@ function updateApproveTableData(returned_details) {
 
 // Shows a non-blocking allocation warning per department represented among the
 // selected forms, so admins can see the impact of approval before confirming.
+// Each category (positions / break hours) is highlighted independently, since
+// a department can be over on one and fine on the other.
 function updateAllocationWarnings(allocationWarnings) {
   if (!allocationWarnings) { return; }
   for (var i = 0; i < allocationWarnings.length; i++) {
     var w = allocationWarnings[i];
-    var alertClass = w.isOverAllocated ? 'alert-danger' : 'alert-info';
-    var html = '<div class="alert ' + alertClass + '" role="alert">' +
+    var boxClass = w.isOverAllocated ? 'alert-warning' : 'alert-info';
+    var overStyle = 'color:#a94442; font-weight:bold;';
+    var positionsStyle = w.isPositionsOverAllocated ? overStyle : '';
+    var breakHoursStyle = w.isBreakHoursOverAllocated ? overStyle : '';
+    var positionsFlag = w.isPositionsOverAllocated ? ' &#9888; Over allocation' : '';
+    var breakHoursFlag = w.isBreakHoursOverAllocated ? ' &#9888; Over allocation' : '';
+    var html = '<div class="alert ' + boxClass + '" role="alert">' +
       '<strong>' + w.departmentName + ' Allocation</strong><br>' +
-      'Positions: ' + w.totalPositionsUsed + ' / ' + w.totalPositionsAllocated +
-      ' allocated (' + w.positionsRemaining + ' remaining)<br>' +
-      'Break Hours: ' + w.breakHoursUsed + ' / ' + w.breakHoursAllocated +
-      ' allocated (' + w.breakHoursRemaining + ' remaining)' +
+      '<span style="' + positionsStyle + '">Positions: ' + w.totalPositionsUsed + ' / ' + w.totalPositionsAllocated +
+      ' allocated (' + w.positionsRemaining + ' remaining)' + positionsFlag + '</span><br>' +
+      '<span style="' + breakHoursStyle + '">Break Hours: ' + w.breakHoursUsed + ' / ' + w.breakHoursAllocated +
+      ' allocated (' + w.breakHoursRemaining + ' remaining)' + breakHoursFlag + '</span>' +
       '</div>';
     $('#allocationWarnings').append(html);
   }

--- a/app/templates/snips/pendingApprovalModal.html
+++ b/app/templates/snips/pendingApprovalModal.html
@@ -10,6 +10,7 @@
       </button>
     </div>
     <div class="modal-body" style="overflow: auto;height: 350px" id="approveModalBody">
+      <div id="allocationWarnings"></div>
       <!-- putting info into modal using table for better viewing -->
       <table id="classTable" class="table table-bordered">
         <thead>

--- a/database/demo_data.py
+++ b/database/demo_data.py
@@ -507,6 +507,15 @@ current_year = today.year - (today.month < 8)
 
 terms = [
     {
+        "termCode": f"202000",
+        "termName": f"AY 2020-2021",
+        "termStart": f"2020-08-01",
+        "termEnd": f"2021-05-01",
+        "termState": 0,
+        "primaryCutOff": f"2020-09-01",
+        "adjustmentCutOff": f"2020-10-01",
+    },
+    {
         "termCode": f"{current_year}00",
         "termName": f"AY {current_year}-{current_year+1}",
         "termStart": f"{current_year}-08-01",

--- a/database/demo_data.py
+++ b/database/demo_data.py
@@ -662,7 +662,6 @@ supervisorDepartmentMembers = [
 SupervisorDepartment.insert_many(supervisorDepartmentMembers).on_conflict_replace().execute()
 print(" * Department members added")
 print(f"termCode_id being used: {202500!r}")
-print(list(Term.select(Term.termCode)))
 
 ############################
 # Allocation Dummy Data:
@@ -747,8 +746,7 @@ allocations = [
     ]
 Allocation.insert_many(allocations).on_conflict_replace().execute()
 
-print("Data insertion complete :)")
-print(PositionHistory())
+print(" * allocation added")
 
 
 #############################
@@ -801,3 +799,4 @@ positionHistory = [
     
 ]
 PositionHistory.insert_many(positionHistory).on_conflict_replace().execute()
+print(" * position history added")

--- a/database/demo_data.py
+++ b/database/demo_data.py
@@ -2,7 +2,6 @@
 Chech phpmyadmin to see if your changes are reflected
 This file will need to be changed if the format of models changes (new fields, dropping fields, renaming...)'''
 
-from datetime import *
 from app import app
 
 from app.models.Tracy import db
@@ -505,8 +504,7 @@ print(" * departments added")
 #############################
 # Term
 #############################
-today = datetime.now()
-current_year = today.year - (today.month < 8)
+
 
 terms = [
     {
@@ -545,8 +543,7 @@ print(f" * terms for 2025-2026 added")
 #############################
 # Create a Pending Labor Status Form
 #############################
-today = datetime.now()
-current_year = today.year - (today.month < 8)
+
 LaborStatusForm.insert([{
             "laborStatusFormID": 2,
             "termCode_id": f"202000",

--- a/database/demo_data.py
+++ b/database/demo_data.py
@@ -168,6 +168,7 @@ for student in (localStudents + bothStudents):
     student['ID'] = student['ID'].strip()
     student['legal_name'] = student['FIRST_NAME'].strip()
     del student['FIRST_NAME']
+    student['isActive'] = True
 
     students.append(student)
 Student.insert_many(students).on_conflict_replace().execute()
@@ -365,6 +366,7 @@ with app.app_context():
 
         staff['legal_name'] = staff['FIRST_NAME'].strip()
         del staff['FIRST_NAME']
+        staff['isActive'] = True
         Supervisor.get_or_create(**staff)
 
     # Add non Supervisor staffs to Tracy db

--- a/database/demo_data.py
+++ b/database/demo_data.py
@@ -519,28 +519,28 @@ terms = [
         "adjustmentCutOff": f"2020-10-01",
     },
     {
-        "termCode": f"{current_year}00",
-        "termName": f"AY {current_year}-{current_year+1}",
-        "termStart": f"{current_year}-08-01",
-        "termEnd": f"{current_year+1}-05-01",
+        "termCode": f"202500",
+        "termName": f"AY 2025-2026",
+        "termStart": f"2025-08-01",
+        "termEnd": f"2026-05-01",
         "termState": 1,
-        "primaryCutOff": f"{current_year}-09-01",
-        "adjustmentCutOff": f"{current_year}-09-01",
+        "primaryCutOff": f"2025-09-01",
+        "adjustmentCutOff": f"2025-09-01",
     },
     {
-        "termCode": f"{current_year}01",
-        "termName": f"Thanksgiving Break {current_year}",
-        "termStart": f"{current_year}-08-01",
-        "termEnd": f"{current_year+1}-05-01",
+        "termCode": f"202501",
+        "termName": f"Thanksgiving Break 2025",
+        "termStart": f"2025-08-01",
+        "termEnd": f"2026-05-01",
         "termState": 0,
-        "primaryCutOff": f"{current_year}-09-01",
-        "adjustmentCutOff": f"{current_year}-09-01",
+        "primaryCutOff": f"2025-09-01",
+        "adjustmentCutOff": f"2025-09-01",
         "isBreak": 1,
     },
 ]
 
 Term.insert_many(terms).on_conflict_replace().execute()
-print(f" * terms for {current_year}-{current_year+1} added")
+print(f" * terms for 2025-2026 added")
 
 #############################
 # Create a Pending Labor Status Form
@@ -567,13 +567,13 @@ FormHistory.insert([{
             "formID_id": "2",
             "historyType_id": "Labor Status Form",
             "createdBy_id": 1,
-            "createdDate": f"{current_year}-04-14",
+            "createdDate": f"2025-04-14",
             "status_id": "Pending"
         }]).on_conflict_replace().execute()
 
 LaborStatusForm.insert([{
             "laborStatusFormID": 3,
-            "termCode_id": f"{current_year}00",
+            "termCode_id": f"202500",
             "studentName": "Test Taker",
             "studentSupervisee_id": "B12345773",
             "supervisor_id": "B12361006",
@@ -583,7 +583,7 @@ LaborStatusForm.insert([{
             "POSN_TITLE": "Labor Workers",
             "POSN_CODE": "S61409",
             "weeklyHours": 10,
-            "startDate": f"{current_year}-04-01",
+            "startDate": f"2025-04-01",
             "endDate": "2025-09-01"
         }]).on_conflict_replace().execute()  
 
@@ -592,7 +592,7 @@ FormHistory.insert([{
             "formID_id": "3",
             "historyType_id": "Labor Status Form",
             "createdBy_id": 1,
-            "createdDate": f"{current_year}-04-14",
+            "createdDate": f"2025-04-14",
             "status_id": "Approved"
         }]).on_conflict_replace().execute()    
 
@@ -627,59 +627,51 @@ print(" * laborOfficeNotes added")
 # Departement Members 
 ##############################
 
-department_members = [
+supervisorDepartmentMembers = [
     {
         "supervisor": "B12361006",
         "department": 1,
-        "banStatus": False,
-        "isActive": True,
         "isCoordinator": True
     }, 
 
     {
         "supervisor": "B12365892",
         "department": 1,
-        "banStatus": True,
-        "isActive": True,
         "isCoordinator": False
     }, 
 
     {
         "supervisor": "B12365893",
         "department": 1,
-        "banStatus": False,
-        "isActive": False,
         "isCoordinator": False
     }, 
 
     {
         "supervisor": "B00763721",
         "department": 1,
-        "banStatus": False,
-        "isActive": True,
         "isCoordinator": False
     },
 
     {
         "supervisor": "B00841417",
         "department": 1,
-        "banStatus": False,
-        "isActive": True,
         "isCoordinator": True
     }
 ]
 
-SupervisorDepartment.insert_many(department_members).on_conflict_replace().execute()
+SupervisorDepartment.insert_many(supervisorDepartmentMembers).on_conflict_replace().execute()
 print(" * Department members added")
+print(f"termCode_id being used: {202500!r}")
+print(list(Term.select(Term.termCode)))
 
 ############################
 # Allocation Dummy Data:
 ###########################
 allocations = [ 
     {
-    "termCode":         202200,
+    "termCode":         202500,
     "department":       3,
-    "isApproved":       False,
+    "isFinal":          False,
     "approvedOn":       None,
     "approvedBy":       None,
     "justification":    "Downscaling due to decrease in student enrollment caused by current economic conditions",
@@ -692,9 +684,9 @@ allocations = [
     "breakHours":       260,
     },
     {
-    "termCode":        202300,
+    "termCode":        202500,
     "department":       2,
-    "isApproved":       False,
+    "isFinal":          False,
     "approvedOn":       None,
     "approvedBy":       None,
     "justification":    "Increase in student enrollment due to exodous from CS department",
@@ -707,9 +699,9 @@ allocations = [
     "breakHours":       750,
     },
     {
-    "termCode":         202400,
+    "termCode":         202500,
     "department":       1,
-    "isApproved":       False,
+    "isFinal":          False,
     "approvedOn":       None,
     "approvedBy":       None,
     "justification":    "We are hiring more students to help with the increased workload in the department",
@@ -724,7 +716,7 @@ allocations = [
     {
     "termCode":         202500,
     "department":       4,
-    "isApproved":       False,
+    "isFinal":          False,
     "approvedOn":       None,
     "approvedBy":       None,
     "justification":    "Downscaling the number of students in the department due to budget cuts",
@@ -739,7 +731,7 @@ allocations = [
     {
     "termCode":         202500,
     "department":       5,
-    "isApproved":      False,
+    "isFinal":          False,
     "approvedOn":       None,
     "approvedBy":       None,
     "justification":    "Due to rapid department growth, we need to hire more students to help with the increased workload",
@@ -756,40 +748,6 @@ allocations = [
 Allocation.insert_many(allocations).on_conflict_replace().execute()
 
 print("Data insertion complete :)")
-allocation =[
-                {
-                    "termCode":f"{current_year}00",
-                    "department": 3,
-                    "isApproved": True,
-                    "approvedOn": f"{current_year}-06-30",
-                    "approvedBy": "B12365892",
-                    "justification": "We just want it for fun", 
-                    "primary_10": 2,
-                    "primary_12": 3,
-                    "primary_15": 1, 
-                    "primary_20": 6, 
-                    "secondary_5": 2,
-                    "secondary_10": 0,
-                    "breakHours": 500
-                },
-                {
-                    "termCode":f"{current_year}00",
-                    "department": 2,
-                    "isApproved": False,
-                    "approvedOn": f"{current_year}-06-20",
-                    "approvedBy": "B00763721",
-                    "justification": "We need it to lower the amount of allocations we have", 
-                    "primary_10": 1,
-                    "primary_12": 2,
-                    "primary_15": 5, 
-                    "primary_20": 2, 
-                    "secondary_5": 10,
-                    "secondary_10": 0,
-                    "breakHours": 1500
-                }
-            ]
-Allocation.insert_many(allocation).on_conflict_replace().execute()
-print(" * allocation added")
 print(PositionHistory())
 
 
@@ -797,49 +755,49 @@ print(PositionHistory())
 # Position History
 #############################
 
-positionhistory = [
+positionHistory = [
     {
-        "positioncode": "S61407",
+        "positionCode": "S61407",
         "status": "Active",
-        "WLS": 1,
-        "revisiondate": f"{current_year}-07-01",
-        "Description": "",
-        "Department_id": 1
+        "wls": 1,
+        "revisionDate": f"2025-07-01",
+        "description": "",
+        "department": 1
     },
     {
         
-        "positioncode": "S61408",
+        "positionCode": "S61408",
         "status": "Active",
-        "WLS": 2,
-        "revisiondate": f"{current_year}-09-01",
-        "Description": "",
-        "Department_id": 1
+        "wls": 2,
+        "revisionDate": f"2025-09-01",
+        "description": "",
+        "department": 1
     },
     {
-        "positioncode": "S61409",
+        "positionCode": "S61409",
         "status": "Active",
-        "WLS": 3,
-        "revisiondate": f"{current_year}-07-01",
-        "Description": "",
-        "Department_id": 1
+        "wls": 3,
+        "revisionDate": f"2025-07-01",
+        "description": "",
+        "department": 1
     },
     {
-        "positioncode": "S61411",
+        "positionCode": "S61411",
         "status": "Active",
-        "WLS":3,
-        "revisiondate" : f"{current_year}-01-01",
-        "Description": "",
-        "Department_id" : 1
+        "wls":3,
+        "revisionDate" : f"2025-01-01",
+        "description": "",
+        "department" : 1
 
         },
         {
-        "positioncode": "S61410",
+        "positionCode": "S61410",
         "status": "Inactive",
-        "WLS":2,
-        "revisiondate" : f"{current_year}-01-01",
-        "Description": "",
-        "Department_id" : 1
+        "wls":2,
+        "revisionDate" : f"2025-01-01",
+        "description": "",
+        "department" : 1
         },
     
 ]
-PositionHistory.insert_many(positionhistory).on_conflict_replace().execute()
+PositionHistory.insert_many(positionHistory).on_conflict_replace().execute()

--- a/database/demo_data.py
+++ b/database/demo_data.py
@@ -17,7 +17,10 @@ from app.models.term import Term
 from app.models.laborStatusForm import LaborStatusForm
 from app.models.formHistory import FormHistory
 from app.models.notes import Notes
-
+from app.models.supervisorDepartment import SupervisorDepartment
+from app.models.allocation import Allocation
+from app.models.positionHistory import PositionHistory
+ 
 print("Inserting data for demo and testing purposes")
 
 #############################
@@ -618,3 +621,225 @@ notes = [
        ]
 Notes.insert_many(notes).on_conflict_replace().execute()
 print(" * laborOfficeNotes added")
+
+
+##############################
+# Departement Members 
+##############################
+
+department_members = [
+    {
+        "supervisor": "B12361006",
+        "department": 1,
+        "banStatus": False,
+        "isActive": True,
+        "isCoordinator": True
+    }, 
+
+    {
+        "supervisor": "B12365892",
+        "department": 1,
+        "banStatus": True,
+        "isActive": True,
+        "isCoordinator": False
+    }, 
+
+    {
+        "supervisor": "B12365893",
+        "department": 1,
+        "banStatus": False,
+        "isActive": False,
+        "isCoordinator": False
+    }, 
+
+    {
+        "supervisor": "B00763721",
+        "department": 1,
+        "banStatus": False,
+        "isActive": True,
+        "isCoordinator": False
+    },
+
+    {
+        "supervisor": "B00841417",
+        "department": 1,
+        "banStatus": False,
+        "isActive": True,
+        "isCoordinator": True
+    }
+]
+
+SupervisorDepartment.insert_many(department_members).on_conflict_replace().execute()
+print(" * Department members added")
+
+############################
+# Allocation Dummy Data:
+###########################
+allocations = [ 
+    {
+    "termCode":         202200,
+    "department":       3,
+    "isApproved":       False,
+    "approvedOn":       None,
+    "approvedBy":       None,
+    "justification":    "Downscaling due to decrease in student enrollment caused by current economic conditions",
+    "primary_10":       2,
+    "primary_12":       2,
+    "primary_15":       1,
+    "primary_20":       0,
+    "secondary_5":      1,
+    "secondary_10":     0,
+    "breakHours":       260,
+    },
+    {
+    "termCode":        202300,
+    "department":       2,
+    "isApproved":       False,
+    "approvedOn":       None,
+    "approvedBy":       None,
+    "justification":    "Increase in student enrollment due to exodous from CS department",
+    "primary_10":       4,
+    "primary_12":       2,
+    "primary_15":       7,
+    "primary_20":       4,
+    "secondary_5":      2,
+    "secondary_10":     0,
+    "breakHours":       750,
+    },
+    {
+    "termCode":         202400,
+    "department":       1,
+    "isApproved":       False,
+    "approvedOn":       None,
+    "approvedBy":       None,
+    "justification":    "We are hiring more students to help with the increased workload in the department",
+    "primary_10":       5,
+    "primary_12":       6,
+    "primary_15":       4,
+    "primary_20":       1,
+    "secondary_5":      7,
+    "secondary_10":     0,
+    "breakHours":       550,
+    },
+    {
+    "termCode":         202500,
+    "department":       4,
+    "isApproved":       False,
+    "approvedOn":       None,
+    "approvedBy":       None,
+    "justification":    "Downscaling the number of students in the department due to budget cuts",
+    "primary_10":       4,
+    "primary_12":       5,
+    "primary_15":       0,
+    "primary_20":       0,
+    "secondary_5":      1,
+    "secondary_10":     0,
+    "breakHours":       300,
+    },
+    {
+    "termCode":         202500,
+    "department":       5,
+    "isApproved":      False,
+    "approvedOn":       None,
+    "approvedBy":       None,
+    "justification":    "Due to rapid department growth, we need to hire more students to help with the increased workload",
+    "primary_10":       8,
+    "primary_12":       10,
+    "primary_15":       7,
+    "primary_20":       4,
+    "secondary_5":      5,
+    "secondary_10":     1,
+    "breakHours":       900,
+    },
+                
+    ]
+Allocation.insert_many(allocations).on_conflict_replace().execute()
+
+print("Data insertion complete :)")
+allocation =[
+                {
+                    "termCode":f"{current_year}00",
+                    "department": 3,
+                    "isApproved": True,
+                    "approvedOn": f"{current_year}-06-30",
+                    "approvedBy": "B12365892",
+                    "justification": "We just want it for fun", 
+                    "primary_10": 2,
+                    "primary_12": 3,
+                    "primary_15": 1, 
+                    "primary_20": 6, 
+                    "secondary_5": 2,
+                    "secondary_10": 0,
+                    "breakHours": 500
+                },
+                {
+                    "termCode":f"{current_year}00",
+                    "department": 2,
+                    "isApproved": False,
+                    "approvedOn": f"{current_year}-06-20",
+                    "approvedBy": "B00763721",
+                    "justification": "We need it to lower the amount of allocations we have", 
+                    "primary_10": 1,
+                    "primary_12": 2,
+                    "primary_15": 5, 
+                    "primary_20": 2, 
+                    "secondary_5": 10,
+                    "secondary_10": 0,
+                    "breakHours": 1500
+                }
+            ]
+Allocation.insert_many(allocation).on_conflict_replace().execute()
+print(" * allocation added")
+print(PositionHistory())
+
+
+#############################
+# Position History
+#############################
+
+positionhistory = [
+    {
+        "positioncode": "S61407",
+        "status": "Active",
+        "WLS": 1,
+        "revisiondate": f"{current_year}-07-01",
+        "Description": "",
+        "Department_id": 1
+    },
+    {
+        
+        "positioncode": "S61408",
+        "status": "Active",
+        "WLS": 2,
+        "revisiondate": f"{current_year}-09-01",
+        "Description": "",
+        "Department_id": 1
+    },
+    {
+        "positioncode": "S61409",
+        "status": "Active",
+        "WLS": 3,
+        "revisiondate": f"{current_year}-07-01",
+        "Description": "",
+        "Department_id": 1
+    },
+    {
+        "positioncode": "S61411",
+        "status": "Active",
+        "WLS":3,
+        "revisiondate" : f"{current_year}-01-01",
+        "Description": "",
+        "Department_id" : 1
+
+        },
+        {
+        "positioncode": "S61410",
+        "status": "Inactive",
+        "WLS":2,
+        "revisiondate" : f"{current_year}-01-01",
+        "Description": "",
+        "Department_id" : 1
+        },
+    
+]
+PositionHistory.insert_many(positionhistory).on_conflict_replace().execute()

--- a/database/demo_data.py
+++ b/database/demo_data.py
@@ -546,7 +546,7 @@ today = datetime.now()
 current_year = today.year - (today.month < 8)
 LaborStatusForm.insert([{
             "laborStatusFormID": 2,
-            "termCode_id": f"{current_year}00",
+            "termCode_id": f"202000",
             "studentName": "Alex Bryant",
             "studentSupervisee_id": "B00841417",
             "supervisor_id": "B12361006",
@@ -556,8 +556,8 @@ LaborStatusForm.insert([{
             "POSN_TITLE": "Student Programmer",
             "POSN_CODE": "S61407",
             "weeklyHours": 10,
-            "startDate": f"{current_year}-04-01",
-            "endDate": f"{current_year}-09-01"
+            "startDate": f"2020-04-01",
+            "endDate": f"2020-09-01"
         }]).on_conflict_replace().execute()
 FormHistory.insert([{
             "formHistoryID": 2,

--- a/database/migrate_db.sh
+++ b/database/migrate_db.sh
@@ -30,6 +30,8 @@ pem add app.models.supervisor.Supervisor
 pem add app.models.supervisorDepartment.SupervisorDepartment
 pem add app.models.studentLaborEvaluation.StudentLaborEvaluation
 pem add app.models.formSearchResult.FormSearchResult
+pem add app.models.positionHistory.PositionHistory
+pem add app.models.allocation.Allocation
 
 pem watch
 pem migrate

--- a/tests/code/test_adminManagement.py
+++ b/tests/code/test_adminManagement.py
@@ -1,46 +1,44 @@
 import pytest
 from app.controllers.admin_routes.adminManagement import addAdmin, removeAdmin
 from app.models.user import User
+from app.models import mainDB
 from peewee import DoesNotExist
 
 @pytest.mark.integration
 def test_addAdmin():
-    newAdmin = "pearcej"
-    user = User.get(User.username == newAdmin)
+    with mainDB.atomic() as transaction:
+        newAdmin = "pearcej"
+        user = User.get(User.username == newAdmin)
 
-    # Before adding user as admin
-    assert not user.isLaborAdmin 
-    # Test adding labor admin
-    addAdmin(user, 'labor')
-    assert user.isLaborAdmin
+        # Before adding user as admin
+        assert not user.isLaborAdmin 
+        addAdmin(user, 'Labor')
+        user = User.get(User.username == newAdmin) # check if the db is actually changed
+        assert user.isLaborAdmin
 
-    assert not user.isFinancialAidAdmin
-    # Test adding financial aid admin
-    addAdmin(user, 'finAid')
-    assert user.isFinancialAidAdmin
+        assert not user.isFinancialAidAdmin
+        addAdmin(user, 'FinancialAid')
+        assert user.isFinancialAidAdmin
 
-    assert not user.isSaasAdmin
-    # Test adding saas admin
-    addAdmin(user, 'saas')
-    assert user.isSaasAdmin
+        assert not user.isSaasAdmin
+        addAdmin(user, 'Saas')
+        assert user.isSaasAdmin
 
 @pytest.mark.integration
 def test_removeAdmin():
-    oldAdmin = "pearcej"
-    user = User.get(User.username == oldAdmin)
+    with mainDB.atomic() as transaction:
+        oldAdmin = "pearcej"
+        user = User.get(User.username == oldAdmin)
 
-    # Before removing user as admin
-    assert user.isLaborAdmin
-    # Test removing labor admin
-    removeAdmin(user, 'labor')
-    assert not user.isLaborAdmin
+        assert user.isLaborAdmin
+        removeAdmin(user, 'Labor')
+        user = User.get(User.username == oldAdmin) # check if the db is actually changed
+        assert not user.isLaborAdmin
 
-    assert user.isFinancialAidAdmin
-    # Test removing financial aid admin
-    removeAdmin(user, 'finAid')
-    assert not user.isFinancialAidAdmin
+        assert user.isFinancialAidAdmin
+        removeAdmin(user, 'FinancialAid')
+        assert not user.isFinancialAidAdmin
 
-    assert user.isSaasAdmin
-    # Test removing saas admin
-    removeAdmin(user, 'saas')
-    assert not user.isSaasAdmin
+        assert user.isSaasAdmin
+        removeAdmin(user, 'Saas')
+        assert not user.isSaasAdmin

--- a/tests/code/test_apiEndpoint.py
+++ b/tests/code/test_apiEndpoint.py
@@ -35,6 +35,7 @@ def test_getLaborInformation():
             response = getLaborInformation(orgCode = 2114, bNumber="B00841417")
 
             responseData = response.get_json()
+            print(responseData['B00841417'])
             assert responseData['B00841417'][0]['jobType'] == "Primary"
             assert responseData['B00841417'][0]['termName'] == "AY 2020-2021"
         

--- a/tests/code/test_search.py
+++ b/tests/code/test_search.py
@@ -228,7 +228,7 @@ def test_getSupervisorsForDepartment():
         SupervisorDepartment.create(supervisor = 'B12361006', department = 1)
 
         supervisors = getSupervisorsForDepartment(1)
-        assert len(supervisors) == 2
+        assert len(supervisors) == 7
 
         testDept = Department.create(DEPT_NAME="supervisorDept", ACCOUNT="6740", ORG="2114", departmentCompliance = 1)
         supervisors = getSupervisorsForDepartment(testDept)

--- a/tests/code/test_tracy.py
+++ b/tests/code/test_tracy.py
@@ -1,4 +1,5 @@
 import pytest
+from app import app
 from app.logic.tracy import Tracy
 from app.logic.tracy import InvalidQueryException
 
@@ -15,132 +16,144 @@ class Test_Tracy:
 
     @pytest.mark.integration
     def test_getStudents(self, tracy):
-        students = tracy.getStudents()
-        assert ['Elaheh','Guillermo','Jeremiah','Kat', 'Oluwagbayi', 'Test', 'Tyler'] == [s.FIRST_NAME for s in students]
-        assert ['718','300','420','420', '883', '700', '420'] == [s.STU_CPO for s in students]
+        with app.app_context():
+            students = tracy.getStudents()
+            assert ['Elaheh','Guillermo','Jeremiah','Kat', 'Oluwagbayi', 'Test', 'Tyler'] == [s.FIRST_NAME for s in students]
+            assert ['718','300','420','420', '883', '700', '420'] == [s.STU_CPO for s in students]
 
     @pytest.mark.integration
     def test_getStudentFromBNumber(self, tracy):
-        student = tracy.getStudentFromBNumber("B00734292")
-        assert 'Guillermo' == student.FIRST_NAME
+        with app.app_context():
+            student = tracy.getStudentFromBNumber("B00734292")
+            assert 'Guillermo' == student.FIRST_NAME
 
-        student = tracy.getStudentFromBNumber("  B00734292")
-        assert 'Guillermo' == student.FIRST_NAME
+            student = tracy.getStudentFromBNumber("  B00734292")
+            assert 'Guillermo' == student.FIRST_NAME
 
-        student = tracy.getStudentFromBNumber("B00888329  ")
-        assert 'Jeremiah' == student.FIRST_NAME
+            student = tracy.getStudentFromBNumber("B00888329  ")
+            assert 'Jeremiah' == student.FIRST_NAME
 
-        with pytest.raises(InvalidQueryException):
-            student = tracy.getStudentFromBNumber("B0000000")
+            with pytest.raises(InvalidQueryException):
+                student = tracy.getStudentFromBNumber("B0000000")
 
-        with pytest.raises(InvalidQueryException):
-            student = tracy.getStudentFromBNumber(17)
+            with pytest.raises(InvalidQueryException):
+                student = tracy.getStudentFromBNumber(17)
 
     @pytest.mark.integration
     def test_getStudentFromEmail(self, tracy):
-        student = tracy.getStudentFromEmail("cruzg@berea.edu")
-        assert 'Guillermo' == student.FIRST_NAME
+        with app.app_context():
+            student = tracy.getStudentFromEmail("cruzg@berea.edu")
+            assert 'Guillermo' == student.FIRST_NAME
 
-        with pytest.raises(InvalidQueryException):
-            student = tracy.getStudentFromEmail("jimmyjoe@place.biz")
+            with pytest.raises(InvalidQueryException):
+                student = tracy.getStudentFromEmail("jimmyjoe@place.biz")
 
-        with pytest.raises(InvalidQueryException):
-            student = tracy.getStudentFromEmail(17)
+            with pytest.raises(InvalidQueryException):
+                student = tracy.getStudentFromEmail(17)
 
     @pytest.mark.integration
     def test_getSupervisors(self, tracy):
-        supervisors = tracy.getSupervisors()
+        with app.app_context():
+            supervisors = tracy.getSupervisors()
 
-        for s in supervisors:
-            assert s.FIRST_NAME in ['Alex','Brian','Jan','Jasmine','Mario','Megan','Scott','Madina']
-            assert s.CPO in ['420','6305','6301','6301','6302','6303','6300']
+            for s in supervisors:
+                assert s.FIRST_NAME in ['Alex','Brian','Jan','Jasmine','Mario','Megan','Scott','Madina']
+                assert s.CPO in ['420','6305','6301','6301','6302','6303','6300']
 
     @pytest.mark.integration
     def test_getSupervisorFromID(self, tracy):
-        supervisor = tracy.getSupervisorFromID("B1236237")
-        assert 'Megan' == supervisor.FIRST_NAME
+        with app.app_context():
+            supervisor = tracy.getSupervisorFromID("B1236237")
+            assert 'Megan' == supervisor.FIRST_NAME
 
-        with pytest.raises(InvalidQueryException):
-            supervisor = tracy.getSupervisorFromID("eleven")
+            with pytest.raises(InvalidQueryException):
+                supervisor = tracy.getSupervisorFromID("eleven")
 
-        with pytest.raises(InvalidQueryException):
-            supervisor = tracy.getSupervisorFromID(17)
+            with pytest.raises(InvalidQueryException):
+                supervisor = tracy.getSupervisorFromID(17)
 
     @pytest.mark.integration
     def test_getSupervisorFromEmail(self, tracy):
-        supervisor = tracy.getSupervisorFromEmail("nakazawam@berea.edu")
-        assert 'Mario' == supervisor.FIRST_NAME
+        with app.app_context():
+            supervisor = tracy.getSupervisorFromEmail("nakazawam@berea.edu")
+            assert 'Mario' == supervisor.FIRST_NAME
 
-        supervisor = tracy.getSupervisorFromEmail("heggens@berea.edu")
-        assert 'Scott' == supervisor.FIRST_NAME
+            supervisor = tracy.getSupervisorFromEmail("heggens@berea.edu")
+            assert 'Scott' == supervisor.FIRST_NAME
 
-        with pytest.raises(InvalidQueryException):
-            supervisor = tracy.getSupervisorFromEmail("nakazawamasdfd.com")
+            with pytest.raises(InvalidQueryException):
+                supervisor = tracy.getSupervisorFromEmail("nakazawamasdfd.com")
 
-        with pytest.raises(InvalidQueryException):
-            supervisor = tracy.getSupervisorFromEmail(17)
+            with pytest.raises(InvalidQueryException):
+                supervisor = tracy.getSupervisorFromEmail(17)
 
     @pytest.mark.integration
     def test_getPositionsFromDepartment(self, tracy):
-        positions = tracy.getPositionsFromDepartment("2114","6740")
-        assert ['S12345','S61408','S61407','S61421','S61419'] == [p.POSN_CODE for p in positions]
-        positions = tracy.getPositionsFromDepartment("2114","0000")
-        assert [] == [p.POSN_CODE for p in positions]
+        with app.app_context():
+            positions = tracy.getPositionsFromDepartment("2114","6740")
+            assert ['S12345','S61408','S61407','S61421','S61419'] == [p.POSN_CODE for p in positions]
+            positions = tracy.getPositionsFromDepartment("2114","0000")
+            assert [] == [p.POSN_CODE for p in positions]
 
     @pytest.mark.integration
     def test_getDepartments(self, tracy):
-        departments = tracy.getDepartments()
-        assert ['Biology','Computer Science', 'Labor Department', 'Mathematics','Technology and Applied Design'] == [d.DEPT_NAME for d in departments]
-        assert '2107' == departments[0].ORG
-        assert '6740' == departments[0].ACCOUNT
+        with app.app_context():
+            departments = tracy.getDepartments()
+            assert ['Biology','Computer Science', 'Labor Department', 'Mathematics','Technology and Applied Design'] == [d.DEPT_NAME for d in departments]
+            assert '2107' == departments[0].ORG
+            assert '6740' == departments[0].ACCOUNT
 
     @pytest.mark.integration
     def test_getPositionFromCode(self, tracy):
-        position = tracy.getPositionFromCode("S61427")
-        assert 'Teaching Associate' == position.POSN_TITLE
-        assert '2' == position.WLS
+        with app.app_context():
+            position = tracy.getPositionFromCode("S61427")
+            assert 'Teaching Associate' == position.POSN_TITLE
+            assert '2' == position.WLS
 
-        with pytest.raises(InvalidQueryException):
-            position = tracy.getPositionFromCode("eleven")
+            with pytest.raises(InvalidQueryException):
+                position = tracy.getPositionFromCode("eleven")
 
-        with pytest.raises(InvalidQueryException):
-            position = tracy.getPositionFromCode(17)
+            with pytest.raises(InvalidQueryException):
+                position = tracy.getPositionFromCode(17)
 
     @pytest.mark.integration
     def test_getSupervisorsFromUserInput(self, tracy):
-        supervisor = tracy.getSupervisorsFromUserInput("Jan Pearce")
-        assert "Jan" == supervisor[0].FIRST_NAME
-        assert 1 == len(supervisor)
+        with app.app_context():
+            supervisor = tracy.getSupervisorsFromUserInput("Jan Pearce")
+            assert "Jan" == supervisor[0].FIRST_NAME
+            assert 1 == len(supervisor)
 
-        supervisor = tracy.getSupervisorsFromUserInput("heggen")
-        assert "Scott" == supervisor[0].FIRST_NAME
-        assert 1 == len(supervisor)
+            supervisor = tracy.getSupervisorsFromUserInput("heggen")
+            assert "Scott" == supervisor[0].FIRST_NAME
+            assert 1 == len(supervisor)
 
-        supervisor = tracy.getSupervisorsFromUserInput("Peter Parker")
-        assert supervisor != True
-        assert 0 == len(supervisor)
+            supervisor = tracy.getSupervisorsFromUserInput("Peter Parker")
+            assert supervisor != True
+            assert 0 == len(supervisor)
 
     @pytest.mark.integration
     def test_getStudentsFromUserInput(self, tracy):
-        students = tracy.getStudentsFromUserInput("Guillermo")
-        assert "Guillermo" == students[0].FIRST_NAME
-        assert 1 == len(students)
+        with app.app_context():
+            students = tracy.getStudentsFromUserInput("Guillermo")
+            assert "Guillermo" == students[0].FIRST_NAME
+            assert 1 == len(students)
 
-        students = tracy.getStudentsFromUserInput("Adams")
-        assert  2 == len(students)
-        assert "Adams" == students[1].LAST_NAME
+            students = tracy.getStudentsFromUserInput("Adams")
+            assert  2 == len(students)
+            assert "Adams" == students[1].LAST_NAME
 
-        students = tracy.getSupervisorsFromUserInput("John Smith")
-        assert students != True
-        assert 0 == len(students)
+            students = tracy.getSupervisorsFromUserInput("John Smith")
+            assert students != True
+            assert 0 == len(students)
 
     @pytest.mark.integration
     def test_checkStudentOrSupervisor(self, tracy):
-        user = tracy.checkStudentOrSupervisor("cruzg")
-        assert "Student" == user
+        with app.app_context():
+            user = tracy.checkStudentOrSupervisor("cruzg")
+            assert "Student" == user
 
-        user = tracy.checkStudentOrSupervisor("heggens")
-        assert "Supervisor" == user
+            user = tracy.checkStudentOrSupervisor("heggens")
+            assert "Supervisor" == user
 
-        with pytest.raises(InvalidQueryException):
-            user = tracy.checkStudentOrSupervisor("smith")
+            with pytest.raises(InvalidQueryException):
+                user = tracy.checkStudentOrSupervisor("smith")

--- a/tests/code/test_userInsertFunctions.py
+++ b/tests/code/test_userInsertFunctions.py
@@ -1,4 +1,5 @@
 import pytest
+from app import app
 from app.models.Tracy.studata import STUDATA
 from app.models.Tracy.stustaff import STUSTAFF
 from app.models import mainDB
@@ -11,211 +12,217 @@ from app.logic.userInsertFunctions import *
 
 @pytest.mark.integration
 def test_createSupervisorFromTracy():
-    # Test fail conditions
-    with pytest.raises(InvalidUserException):
-        supervisor = createSupervisorFromTracy()
+    with app.app_context():
+        # Test fail conditions
+        with pytest.raises(InvalidUserException):
+            supervisor = createSupervisorFromTracy()
 
-    with pytest.raises(InvalidUserException):
-        supervisor = createSupervisorFromTracy("B12361006")
+        with pytest.raises(InvalidUserException):
+            supervisor = createSupervisorFromTracy("B12361006")
 
-    with pytest.raises(InvalidUserException):
-        supervisor = createSupervisorFromTracy(username="B12361006")
+        with pytest.raises(InvalidUserException):
+            supervisor = createSupervisorFromTracy(username="B12361006")
 
-    with pytest.raises(InvalidUserException):
-        supervisor = createSupervisorFromTracy(bnumber="heggens")
+        with pytest.raises(InvalidUserException):
+            supervisor = createSupervisorFromTracy(bnumber="heggens")
 
-    # Test success conditions
-    supervisor = createSupervisorFromTracy(username="heggens", bnumber="B12361006")
-    assert supervisor.FIRST_NAME == "Scott"
+        # Test success conditions
+        supervisor = createSupervisorFromTracy(username="heggens", bnumber="B12361006")
+        assert supervisor.FIRST_NAME == "Scott"
 
-    supervisor = createSupervisorFromTracy(username="", bnumber="B12361006")
-    assert supervisor.FIRST_NAME == "Scott"
+        supervisor = createSupervisorFromTracy(username="", bnumber="B12361006")
+        assert supervisor.FIRST_NAME == "Scott"
 
-    supervisor = createSupervisorFromTracy(bnumber="B12361006")
-    assert supervisor.FIRST_NAME == "Scott"
+        supervisor = createSupervisorFromTracy(bnumber="B12361006")
+        assert supervisor.FIRST_NAME == "Scott"
 
-    supervisor = createSupervisorFromTracy(username="heggens")
-    assert supervisor.FIRST_NAME == "Scott"
+        supervisor = createSupervisorFromTracy(username="heggens")
+        assert supervisor.FIRST_NAME == "Scott"
 
-    supervisor = createSupervisorFromTracy(username="heggens", bnumber="")
-    assert supervisor.FIRST_NAME == "Scott"
+        supervisor = createSupervisorFromTracy(username="heggens", bnumber="")
+        assert supervisor.FIRST_NAME == "Scott"
 
-    supervisor = createSupervisorFromTracy("heggens")
-    assert supervisor.FIRST_NAME == "Scott"
+        supervisor = createSupervisorFromTracy("heggens")
+        assert supervisor.FIRST_NAME == "Scott"
 
-    # Tests getting a supervisor from TRACY that does not exist in the supervisor table
-    supervisor = createSupervisorFromTracy(username="hoffmanm", bnumber="B1236237")
-    assert supervisor.FIRST_NAME == "Megan"
-    supervisor.delete_instance()
+        # Tests getting a supervisor from TRACY that does not exist in the supervisor table
+        supervisor = createSupervisorFromTracy(username="hoffmanm", bnumber="B1236237")
+        assert supervisor.FIRST_NAME == "Megan"
+        supervisor.delete_instance()
 
-    supervisor = createSupervisorFromTracy(username="", bnumber="B1236237")
-    assert supervisor.FIRST_NAME == "Megan"
-    supervisor.delete_instance()
+        supervisor = createSupervisorFromTracy(username="", bnumber="B1236237")
+        assert supervisor.FIRST_NAME == "Megan"
+        supervisor.delete_instance()
 
-    supervisor = createSupervisorFromTracy(username="hoffmanm")
-    assert supervisor.FIRST_NAME == "Megan"
-    supervisor.delete_instance()
+        supervisor = createSupervisorFromTracy(username="hoffmanm")
+        assert supervisor.FIRST_NAME == "Megan"
+        supervisor.delete_instance()
 
 @pytest.mark.integration
 def test_createStudentFromTracy():
-    # Test fail conditions
-    with pytest.raises(ValueError):
-        student = createStudentFromTracy()
+    with app.app_context():
+        # Test fail conditions
+        with pytest.raises(ValueError):
+            student = createStudentFromTracy()
 
-    with pytest.raises(InvalidUserException):
-        student = createStudentFromTracy("B00730361")
+        with pytest.raises(InvalidUserException):
+            student = createStudentFromTracy("B00730361")
 
-    with pytest.raises(InvalidUserException):
-        student = createStudentFromTracy(username="B00730361")
+        with pytest.raises(InvalidUserException):
+            student = createStudentFromTracy(username="B00730361")
 
-    with pytest.raises(InvalidUserException):
-        student = createStudentFromTracy(bnumber="jamalie")
+        with pytest.raises(InvalidUserException):
+            student = createStudentFromTracy(bnumber="jamalie")
 
-    # Test success conditions
-    student = createStudentFromTracy(username="jamalie", bnumber="B00730361")
-    assert student.FIRST_NAME == "Elaheh"
+        # Test success conditions
+        student = createStudentFromTracy(username="jamalie", bnumber="B00730361")
+        assert student.FIRST_NAME == "Elaheh"
 
-    student = createStudentFromTracy(username="", bnumber="B00730361")
-    assert student.FIRST_NAME == "Elaheh"
+        student = createStudentFromTracy(username="", bnumber="B00730361")
+        assert student.FIRST_NAME == "Elaheh"
 
-    student = createStudentFromTracy(bnumber="B00730361")
-    assert student.FIRST_NAME == "Elaheh"
+        student = createStudentFromTracy(bnumber="B00730361")
+        assert student.FIRST_NAME == "Elaheh"
 
-    student = createStudentFromTracy(username="jamalie")
-    assert student.FIRST_NAME == "Elaheh"
+        student = createStudentFromTracy(username="jamalie")
+        assert student.FIRST_NAME == "Elaheh"
 
-    student = createStudentFromTracy(username="jamalie", bnumber="")
-    assert student.FIRST_NAME == "Elaheh"
+        student = createStudentFromTracy(username="jamalie", bnumber="")
+        assert student.FIRST_NAME == "Elaheh"
 
-    student = createStudentFromTracy("jamalie")
-    assert student.FIRST_NAME == "Elaheh"
+        student = createStudentFromTracy("jamalie")
+        assert student.FIRST_NAME == "Elaheh"
 
-    # Tests getting a student from TRACY that does not exist in the student table
-    student = createStudentFromTracy(username="adamskg", bnumber="B00785329")
-    assert student.FIRST_NAME == "Kat"
-    student.delete_instance()
+        # Tests getting a student from TRACY that does not exist in the student table
+        student = createStudentFromTracy(username="adamskg", bnumber="B00785329")
+        assert student.FIRST_NAME == "Kat"
+        student.delete_instance()
 
-    student = createStudentFromTracy(username="", bnumber="B00785329")
-    assert student.FIRST_NAME == "Kat"
-    student.delete_instance()
+        student = createStudentFromTracy(username="", bnumber="B00785329")
+        assert student.FIRST_NAME == "Kat"
+        student.delete_instance()
 
-    student = createStudentFromTracy(username="adamskg")
-    assert student.FIRST_NAME == "Kat"
-    student.delete_instance()
+        student = createStudentFromTracy(username="adamskg")
+        assert student.FIRST_NAME == "Kat"
+        student.delete_instance()
 
 @pytest.mark.integration
 def test_getOrCreateStudentRecord():
-    # Test fail conditions
-    with pytest.raises(ValueError):
-        student = getOrCreateStudentRecord()
+    with app.app_context():
+        # Test fail conditions
+        with pytest.raises(ValueError):
+            student = getOrCreateStudentRecord()
 
-    with pytest.raises(InvalidUserException):
-        student = getOrCreateStudentRecord("B00730361")
+        with pytest.raises(InvalidUserException):
+            student = getOrCreateStudentRecord("B00730361")
 
-    with pytest.raises(InvalidUserException):
-        student = getOrCreateStudentRecord(username="B00730361")
+        with pytest.raises(InvalidUserException):
+            student = getOrCreateStudentRecord(username="B00730361")
 
-    with pytest.raises(InvalidUserException):
-        student = getOrCreateStudentRecord(bnumber="jamalie")
+        with pytest.raises(InvalidUserException):
+            student = getOrCreateStudentRecord(bnumber="jamalie")
 
-    # Test success conditions
-    student = getOrCreateStudentRecord(username="jamalie", bnumber="B00730361")
-    assert student.FIRST_NAME == "Elaheh"
+        # Test success conditions
+        student = getOrCreateStudentRecord(username="jamalie", bnumber="B00730361")
+        assert student.FIRST_NAME == "Elaheh"
 
-    student = getOrCreateStudentRecord(username="", bnumber="B00730361")
-    assert student.FIRST_NAME == "Elaheh"
+        student = getOrCreateStudentRecord(username="", bnumber="B00730361")
+        assert student.FIRST_NAME == "Elaheh"
 
-    student = getOrCreateStudentRecord(bnumber="B00730361")
-    assert student.FIRST_NAME == "Elaheh"
+        student = getOrCreateStudentRecord(bnumber="B00730361")
+        assert student.FIRST_NAME == "Elaheh"
 
-    student = getOrCreateStudentRecord(username="jamalie")
-    assert student.FIRST_NAME == "Elaheh"
+        student = getOrCreateStudentRecord(username="jamalie")
+        assert student.FIRST_NAME == "Elaheh"
 
-    student = getOrCreateStudentRecord(username="jamalie", bnumber="")
-    assert student.FIRST_NAME == "Elaheh"
+        student = getOrCreateStudentRecord(username="jamalie", bnumber="")
+        assert student.FIRST_NAME == "Elaheh"
 
-    student = getOrCreateStudentRecord("jamalie")
-    assert student.FIRST_NAME == "Elaheh"
+        student = getOrCreateStudentRecord("jamalie")
+        assert student.FIRST_NAME == "Elaheh"
 
-    # Test getting a student that does not exist in Tracy
-    student = getOrCreateStudentRecord(bnumber="B00841417")
-    assert student.FIRST_NAME == "Alex"
+        # Test getting a student that does not exist in Tracy
+        student = getOrCreateStudentRecord(bnumber="B00841417")
+        assert student.FIRST_NAME == "Alex"
 
-    student = getOrCreateStudentRecord(username="bryantal")
-    assert student.FIRST_NAME == "Alex"
+        student = getOrCreateStudentRecord(username="bryantal")
+        assert student.FIRST_NAME == "Alex"
 
 
-    # Tests getting a student from TRACY that does not exist in the student table
-    student = getOrCreateStudentRecord(username="adamskg", bnumber="B00785329")
-    assert student.FIRST_NAME == "Kat"
-    student.delete_instance()
+        # Tests getting a student from TRACY that does not exist in the student table
+        student = getOrCreateStudentRecord(username="adamskg", bnumber="B00785329")
+        assert student.FIRST_NAME == "Kat"
+        student.delete_instance()
 
-    student = getOrCreateStudentRecord(username="", bnumber="B00785329")
-    assert student.FIRST_NAME == "Kat"
-    student.delete_instance()
+        student = getOrCreateStudentRecord(username="", bnumber="B00785329")
+        assert student.FIRST_NAME == "Kat"
+        student.delete_instance()
 
-    student = getOrCreateStudentRecord(username="adamskg")
-    assert student.FIRST_NAME == "Kat"
-    student.delete_instance()
+        student = getOrCreateStudentRecord(username="adamskg")
+        assert student.FIRST_NAME == "Kat"
+        student.delete_instance()
 
 @pytest.mark.integration
 def test_updateSupervisorFromTracy():
-    user = User.get(username="heggens")
-    assert user.fullName == "Scott Heggen"
+    with app.app_context():
+        user = User.get(username="heggens")
+        assert user.fullName == "Scott Heggen"
 
-    tracyEntry = Tracy().getSupervisorFromID(user.supervisor_id)
-    tracyEntry.FIRST_NAME="NotScott"
-    tracyEntry.LAST_NAME="NotHeggen"
-    db.session.commit()
+        tracyEntry = Tracy().getSupervisorFromID(user.supervisor_id)
+        tracyEntry.FIRST_NAME="NotScott"
+        tracyEntry.LAST_NAME="NotHeggen"
+        db.session.commit()
 
-    user = updateUserFromTracy(user)
-    assert user.fullName == "NotScott NotHeggen"
+        user = updateUserFromTracy(user)
+        assert user.fullName == "NotScott NotHeggen"
 
-    dbuser = User.get(username="heggens")
-    assert dbuser.fullName == "NotScott NotHeggen", "The object changed but not the database"
+        dbuser = User.get(username="heggens")
+        assert dbuser.fullName == "NotScott NotHeggen", "The object changed but not the database"
 
-    tracyEntry.FIRST_NAME="Scott"
-    tracyEntry.LAST_NAME="Heggen"
-    db.session.commit()
+        tracyEntry.FIRST_NAME="Scott"
+        tracyEntry.LAST_NAME="Heggen"
+        db.session.commit()
 
-    dbuser.supervisor.legal_name="Scott"
-    dbuser.supervisor.LAST_NAME="Heggen"
-    dbuser.supervisor.save()
+        dbuser.supervisor.legal_name="Scott"
+        dbuser.supervisor.LAST_NAME="Heggen"
+        dbuser.supervisor.save()
 
 @pytest.mark.integration
 def test_updateStudentFromTracy():
-    user = User.get(username="jamalie")
-    assert user.fullName == "Elaheh Jamali"
+    with app.app_context():
+        user = User.get(username="jamalie")
+        assert user.fullName == "Elaheh Jamali"
 
-    tracyEntry = Tracy().getStudentFromBNumber(user.student_id)
-    tracyEntry.FIRST_NAME="NotElaheh"
-    tracyEntry.LAST_NAME="NotJamali"
-    db.session.commit()
+        tracyEntry = Tracy().getStudentFromBNumber(user.student_id)
+        tracyEntry.FIRST_NAME="NotElaheh"
+        tracyEntry.LAST_NAME="NotJamali"
+        db.session.commit()
 
-    user = updateUserFromTracy(user)
-    assert user.fullName == "NotElaheh NotJamali"
+        user = updateUserFromTracy(user)
+        assert user.fullName == "NotElaheh NotJamali"
 
-    dbuser = User.get(username="jamalie")
-    assert dbuser.fullName == "NotElaheh NotJamali", "The object changed but not the database"
+        dbuser = User.get(username="jamalie")
+        assert dbuser.fullName == "NotElaheh NotJamali", "The object changed but not the database"
 
-    tracyEntry.FIRST_NAME="Elaheh"
-    tracyEntry.LAST_NAME="Jamali"
-    db.session.commit()
+        tracyEntry.FIRST_NAME="Elaheh"
+        tracyEntry.LAST_NAME="Jamali"
+        db.session.commit()
 
-    dbuser.student.legal_name="Elaheh"
-    dbuser.student.LAST_NAME="Jamali"
-    dbuser.student.save()
+        dbuser.student.legal_name="Elaheh"
+        dbuser.student.LAST_NAME="Jamali"
+        dbuser.student.save()
 
 @pytest.mark.integration
 def test_updateStudentDBRecords():
     with mainDB.atomic() as transaction:
-        incorrectStudent = Student.create(ID="B00751360", PIDM=2345, legal_name="NotTyler", LAST_NAME="Parton")
-        updateRecordIncorrectly = Supervisor.update(legal_name="NotMadina").where(Supervisor.ID == "B00769499").execute()
-        incorrectSupervisor = Supervisor.get(Supervisor.ID == "B00769499")
-        updateStudentRecord(incorrectStudent)
-        updateSupervisorRecord(incorrectSupervisor)
+        with app.app_context():
+            incorrectStudent = Student.create(ID="B00751360", PIDM=2345, legal_name="NotTyler", LAST_NAME="Parton")
+            updateRecordIncorrectly = Supervisor.update(legal_name="NotMadina").where(Supervisor.ID == "B00769499").execute()
+            incorrectSupervisor = Supervisor.get(Supervisor.ID == "B00769499")
+            updateStudentRecord(incorrectStudent)
+            updateSupervisorRecord(incorrectSupervisor)
 
-        assert incorrectStudent.FIRST_NAME == "Tyler"
-        assert incorrectSupervisor.FIRST_NAME == "Madina"
+            assert incorrectStudent.FIRST_NAME == "Tyler"
+            assert incorrectSupervisor.FIRST_NAME == "Madina"
 
-        transaction.rollback()
+            transaction.rollback()

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -57,4 +57,7 @@ case "$1" in
 	no-ui)
 		no_ui
 		;;
+    *) # assume it is a file or flag
+        python -m pytest $FLAGS -m "unit or integration" $1
+        ;;
 esac


### PR DESCRIPTION
Closes #622

Adds a non-blocking over-allocation warning to the pending-LSF approval confirmation modal, so Labor Office admins can see the allocation impact before approving.

- Extracted the allocation-counting logic from #602's Department Portal card into a shared \pp/logic/allocation.py\ (\getAllocationSummary\, \getAllocationWarning\), so this reuses the exact same 'used' counting (non-denied LaborStatusForms) instead of duplicating queries.
- \modal_approval_and_denial_data()\ now returns one allocation warning per unique department among the selected forms, alongside the existing per-form table data.
- The approval modal (\pendingApprovalModal.html\ / \llPendingForms.js\) renders a warning box per department: blue if within allocation, amber if any category is over. Positions and Break Hours are highlighted **independently** per the issue's requirement ('highlight any allocation categories that exceed'), since a department can be over on one and fine on the other.
- Fixed a pre-existing demo-data gap found while testing: no student/supervisor was ever marked \isActive\, so the approval checkbox (which requires both to be active) never rendered at all in this environment.

Branched off \llocation-card-real-data-ruk\ (not \llocation_card\ directly) since this depends on the allocation logic from #636, which hasn't merged yet.

Tested via direct API calls and in-browser: confirmed the warning shows correct numbers, confirmed the red/amber highlighting triggers independently for positions-only and break-hours-only over-allocation scenarios, and confirmed the full approve flow completes correctly end-to-end.