### PR TITLE
Members card

### DIFF
--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -61,7 +61,7 @@ def departmentPortal(org=None,account=None):
     else:
         departments = list(getDepartmentsForSupervisor(g.currentUser).order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
     
-    supervisor_departments = (
+    supervisorDepartments = (
         SupervisorDepartment
         .select()
         .join(Supervisor)
@@ -75,35 +75,35 @@ def departmentPortal(org=None,account=None):
     )
     )
 
-    labor_coordinators = []
+    laborCoordinators = []
     supervisors = []
 
-    for supervisor_department in supervisor_departments:
-        supervisor = supervisor_department.supervisor
+    for supervisorDepartment in supervisorDepartments:
+        supervisor = supervisorDepartment.supervisor
 
         if supervisor is None:
             continue
 
-        first_name = supervisor.preferred_name or supervisor.legal_name or ""
-        last_name = supervisor.LAST_NAME or ""
+        firstName = supervisor.preferred_name or supervisor.legal_name or ""
+        lastName = supervisor.LAST_NAME or ""
 
-        supervisor_name = f"{first_name} {last_name}".strip()
+        supervisorName = f"{firstName} {lastName}".strip()
 
-        supervisor_display = {
-            "name": supervisor_name,
+        supervisorDisplay = {
+            "name": supervisorName,
             "email": supervisor.EMAIL
         }
 
-        if supervisor_department.isCoordinator:
-            labor_coordinators.append(supervisor_display)
+        if supervisorDepartment.isCoordinator:
+            laborCoordinators.append(supervisorDisplay)
         else:
-            supervisors.append(supervisor_display)
+            supervisors.append(supervisorDisplay)
 
     return render_template('main/departmentPortal.html', 
                            departments = departments,
                            department = dept,
                            supervisors = supervisors,
-                           labor_coordinators=labor_coordinators,
+                           laborCoordinators=laborCoordinators,
                            currentUser=g.currentUser
                            )
 

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -107,20 +107,6 @@ def departmentPortal(org=None,account=None):
                            currentUser=g.currentUser
                            )
 
-@main_bp.route('/department/<org>/<account>/managepositions', methods=['GET'])
-def managePositions(org, account):
-    try:
-        dept = Department.get(Department.ORG == org, Department.ACCOUNT == account)
-    except DoesNotExist:
-        return render_template('errors/404.html'), 404
-
-    positions = Tracy().getPositionsFromDepartment(org, account)
-    print(positions)
-    return render_template('main/managepositions.html',
-                           department = dept,
-                           department_name = dept.DEPT_NAME,
-                           positions = positions
-                           )
 
 @main_bp.route('/supervisorPortal/addUserToDept', methods=['GET', 'POST'])
 def addUserToDept():

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -1,5 +1,5 @@
 from flask import render_template, request, json, redirect, url_for, send_file, g, flash, jsonify
-from peewee import JOIN, DoesNotExist
+from peewee import JOIN, DoesNotExist, fn
 from functools import reduce
 import operator
 from app.models.department import Department
@@ -56,16 +56,73 @@ def departmentPortal(org=None,account=None):
     except (NameError, DoesNotExist):
         dept = None
 
-
+    currentUser = require_login()
 
     if g.currentUser.isLaborAdmin:
         departments = list(Department.select().order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
     else:
         departments = list(getDepartmentsForSupervisor(g.currentUser).order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
+    
+    supervisor_departments = (
+        SupervisorDepartment
+        .select()
+        .join(Supervisor)
+        .where(SupervisorDepartment.department == dept)
+        .order_by(
+          fn.COALESCE(
+            Supervisor.preferred_name,
+            Supervisor.legal_name,
+            Supervisor.LAST_NAME
+        ).asc()
+    )
+    )
+
+    labor_coordinators = []
+    supervisors = []
+
+    for supervisor_department in supervisor_departments:
+        supervisor = supervisor_department.supervisor
+
+        if supervisor is None:
+            continue
+
+        first_name = supervisor.preferred_name or supervisor.legal_name or ""
+        last_name = supervisor.LAST_NAME or ""
+
+        supervisor_name = f"{first_name} {last_name}".strip()
+
+        supervisor_display = {
+            "name": supervisor_name,
+            "email": supervisor.EMAIL
+        }
+
+        if supervisor_department.isCoordinator:
+            labor_coordinators.append(supervisor_display)
+        else:
+            supervisors.append(supervisor_display)
 
     return render_template('main/departmentPortal.html', 
                            departments = departments,
-                           department = dept)
+                           department = dept,
+                           supervisors = supervisors,
+                           labor_coordinators=labor_coordinators,
+                           currentUser=currentUser
+                           )
+
+@main_bp.route('/department/<org>/<account>/managepositions', methods=['GET'])
+def managePositions(org, account):
+    try:
+        dept = Department.get(Department.ORG == org, Department.ACCOUNT == account)
+    except DoesNotExist:
+        return render_template('errors/404.html'), 404
+
+    positions = Tracy().getPositionsFromDepartment(org, account)
+    print(positions)
+    return render_template('main/managepositions.html',
+                           department = dept,
+                           department_name = dept.DEPT_NAME,
+                           positions = positions
+                           )
 
 @main_bp.route('/supervisorPortal/addUserToDept', methods=['GET', 'POST'])
 def addUserToDept():

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -63,19 +63,8 @@ def departmentPortal(org=None,account=None):
     else:
         departments = list(getDepartmentsForSupervisor(g.currentUser).order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
     
-    supervisorDepartments = (
-        SupervisorDepartment
-        .select()
-        .join(Supervisor)
-        .where(SupervisorDepartment.department == dept)
-        .order_by(
-          fn.COALESCE(
-            Supervisor.preferred_name,
-            Supervisor.legal_name,
-            Supervisor.LAST_NAME
-        ).asc()
-    )
-    )
+    supervisorDepartments = (SupervisorDepartment.select().join(Supervisor).where(SupervisorDepartment.department == dept)
+        .order_by(fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name, Supervisor.LAST_NAME).asc()))
 
     laborCoordinators = []
     supervisors = []

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -56,8 +56,6 @@ def departmentPortal(org=None,account=None):
     except (NameError, DoesNotExist):
         dept = None
 
-    currentUser = require_login()
-
     if g.currentUser.isLaborAdmin:
         departments = list(Department.select().order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
     else:
@@ -106,7 +104,7 @@ def departmentPortal(org=None,account=None):
                            department = dept,
                            supervisors = supervisors,
                            labor_coordinators=labor_coordinators,
-                           currentUser=currentUser
+                           currentUser=g.currentUser
                            )
 
 @main_bp.route('/department/<org>/<account>/managepositions', methods=['GET'])

--- a/app/static/css/base.css
+++ b/app/static/css/base.css
@@ -268,3 +268,7 @@ a {
   border-top-left-radius: calc(0.25rem - 1px);
   border-top-right-radius: calc(0.25rem - 1px);
 }
+
+.members-icon {
+  font-size: 36px;
+}

--- a/app/static/css/base.css
+++ b/app/static/css/base.css
@@ -192,33 +192,6 @@ a {
   z-index:999;
 }
 
-.site-footer {
-  position: fixed;
-  left: 280px;
-  right: 0;
-  bottom: 0;
-
-  background-color: #e9ebec;
-  color: #1e2433;
-
-  padding: 8px 15px;
-  line-height: 1.4;
-  box-sizing: border-box;
-  z-index: 101;
-
-}
-
-.sidebar-push {
-  padding-bottom: 85px;
-}
-
-@media (max-width: 991px) {
-  .site-footer {
-    left: 0;
-    width: 100%;
-  }
-}
-
 .card {
   position: relative;
   display: -webkit-box;

--- a/app/static/css/base.css
+++ b/app/static/css/base.css
@@ -192,6 +192,33 @@ a {
   z-index:999;
 }
 
+.site-footer {
+  position: fixed;
+  left: 280px;
+  right: 0;
+  bottom: 0;
+
+  background-color: #e9ebec;
+  color: #1e2433;
+
+  padding: 8px 15px;
+  line-height: 1.4;
+  box-sizing: border-box;
+  z-index: 101;
+
+}
+
+.sidebar-push {
+  padding-bottom: 85px;
+}
+
+@media (max-width: 991px) {
+  .site-footer {
+    left: 0;
+    width: 100%;
+  }
+}
+
 .card {
   position: relative;
   display: -webkit-box;
@@ -207,6 +234,7 @@ a {
   background-clip: border-box;
   border: 1px solid rgba(0, 0, 0, 0.125);
   border-radius: 0.25rem;
+  overflow: hidden;
 }
 
 .card-body {
@@ -250,6 +278,9 @@ a {
   padding: 0.5rem 1rem;
   background-color: rgba(0, 0, 0, 0.03);
   border-top: 1px solid rgba(0, 0, 0, 0.125);
+  border-bottom-left-radius: 1rem;
+  border-bottom-right-radius: 1rem;
+  
 }
 
 .card-footer:last-child {

--- a/app/templates/main/departmentPortal.html
+++ b/app/templates/main/departmentPortal.html
@@ -30,12 +30,12 @@
 <div class="card-group" style="display:inline-flex; gap: 1rem">
   
  <!-- ------------------------Members_Card Started----------------------- -->
-  <section class="card "style="width:90%; border-radius: 1rem;" aria-labelledby="members-title">
+  <section class="card">
     <div class="card-body">
       <div class="media">
          <div class="media-left media-middle">
-          <span aria-hidden="true" style="color: #000; font-size: 24px;">
-            <i class="bi bi-people-fill" style="border: 1px solid #c0c0c0; border-radius: 12px; padding: 3px 3.5px 1.5px 3.5px; font-size: 1.5em; color: #6e6e6e"></i>
+          <span>
+            <i class="bi bi-people-fill"></i>
           </span>
         </div>
 

--- a/app/templates/main/departmentPortal.html
+++ b/app/templates/main/departmentPortal.html
@@ -82,8 +82,7 @@
       <h4> <b>{% if supervisors|length <= 1 %} Supervisor{% else %} Supervisors{% endif %}</b></h4>
 
       {% if supervisors %}
-        {% for s in supervisors %}
-          {% if loop.index0 < 3 %}
+        {% for s in supervisors[:3] %}
             <p>
               {{ s.name }}
 
@@ -97,10 +96,12 @@
                 
               {% endif %}
             </p>
-          {% elif loop.index0 == 3 %}
-            <p>and {{ supervisors|length - 3 }} more...</p>
-          {% endif %}
-        {% endfor %}
+            {% endfor %}
+
+            {% if supervisors|length > 3 %}
+              <p>and {{ supervisors|length - 3 }} more...</p>
+            {% endif %}
+
       {% elif not laborCoordinators and currentUser.isLaborAdmin %}
         <p>No active supervisors assigned. <a href="#" >Add one?</a>  </p>
       {% else  %}

--- a/app/templates/main/departmentPortal.html
+++ b/app/templates/main/departmentPortal.html
@@ -3,13 +3,14 @@
 {% block scripts %}
 {{super()}}
     <script type="text/javascript" src="{{url_for('static', filename='js/departmentPortal.js') }}?u={{lastStaticUpdate}}"></script>
+    <link rel="stylesheet" type="text/css"
 {% endblock %}
-
 {% block app_content %}
 <h2 class="text-center">{% if department %} {{department.DEPT_NAME}} Portal {% else %} Choose a Department: {% endif %} </h2>
 
+
   <!--selectpicker for department-->
-  <div class="form-group">
+  <div class="form-group" style="width:65rem; margin-left: auto; margin-right:auto">
     <select class="selectpicker"
             name='department'
             id='selectedDepartment'
@@ -24,4 +25,87 @@
     </select>
 
   </div>
-{% endblock %}
+
+{% if department %}
+<div class="card-group" style="display:inline-flex; gap: 1rem">
+  
+ <!-- ------------------------Members_Card Started----------------------- -->
+  <section class="card "style="width:90%; border-radius: 1rem;" aria-labelledby="members-title">
+    <div class="card-body">
+      <div class="media">
+         <div class="media-left media-middle">
+          <span aria-hidden="true" style="color: #000; font-size: 24px;">
+            <i class="bi bi-people-fill" style="border: 1px solid #c0c0c0; border-radius: 12px; padding: 3px 3.5px 1.5px 3.5px; font-size: 1.5em; color: #6e6e6e"></i>
+          </span>
+        </div>
+
+        <div class="media-body media-middle">
+          <h1>
+            Members
+          </h1>
+        </div>
+      </div>
+      <h4> <b>{% if labor_coordinators|length <= 1 %} Labor Coordinator {% else %} Labor Coordinators{% endif %}</b></h4>
+      {% if labor_coordinators %}
+        {% for coordinator in labor_coordinators %}
+          <p>
+            {{ coordinator.name }}
+
+            {% if coordinator.email %}
+                 <a href="mailto:{{ coordinator.email }}"
+                      data-toggle="tooltip"
+                      data-placement="bottom"
+                      title="{{ coordinator.email }}">
+                      <i class="bi bi-envelope-fill"></i>
+                  </a>
+            {% endif %}
+          </p>
+        {% endfor %}
+      {% else %}
+        <p>None assigned. <a href="#" >Add one?</a> </p> 
+        <!-- href will be the link same as view members because we already have the logci to add labor coordinator and supervisor there and we don't want the card to be clsutered -->
+          
+      {% endif %}
+
+    
+      <h4> <b>{% if supervisors|length <= 1 %} Supervisor{% else %} Supervisors{% endif %}</b></h4>
+
+      {% if supervisors %}
+        {% for s in supervisors %}
+          {% if loop.index0 < 3 %}
+            <p>
+              {{ s.name }}
+
+              {% if s.email %}
+                  <a href="mailto:{{ s.email }}"
+                      data-toggle="tooltip"
+                      data-placement="bottom"
+                      title="{{ s.email }}">
+                      <i class="bi bi-envelope-fill"></i>
+                  </a>
+                
+              {% endif %}
+            </p>
+          {% elif loop.index0 == 3 %}
+            <p>and {{ supervisors|length - 3 }} more...</p>
+          {% endif %}
+        {% endfor %}
+      {% elif not labor_coordinators and currentUser.isLaborAdmin %}
+        <p>No active supervisors assigned. <a href="#" >Add one?</a>  </p>
+      {% else  %}
+        <p>No active supervisors assigned.</p>
+      {% endif %}
+
+    </div>
+
+    <div class="card-footer text-center">
+      <a href="#" class="btn btn-primary">View Members
+         <span class="glyphicon glyphicon-chevron-right"></span>
+      </a>
+    </div>
+  </section>
+  <!-- ------------------------Members_Card Ended----------------------- -->
+
+{% endif %}
+
+{% endblock %}\

--- a/app/templates/main/departmentPortal.html
+++ b/app/templates/main/departmentPortal.html
@@ -34,7 +34,7 @@
     <div class="card-body">
       <div class="media">
          <div class="media-left media-middle">
-          <span>
+          <span class="members-icon">
             <i class="bi bi-people-fill"></i>
           </span>
         </div>

--- a/app/templates/main/departmentPortal.html
+++ b/app/templates/main/departmentPortal.html
@@ -45,9 +45,9 @@
           </h1>
         </div>
       </div>
-      <h4> <b>{% if labor_coordinators|length <= 1 %} Labor Coordinator {% else %} Labor Coordinators{% endif %}</b></h4>
-      {% if labor_coordinators %}
-        {% for coordinator in labor_coordinators %}
+      <h4> <b>{% if laborCoordinators|length <= 1 %} Labor Coordinator {% else %} Labor Coordinators{% endif %}</b></h4>
+      {% if laborCoordinators %}
+        {% for coordinator in laborCoordinators %}
           <p>
             {{ coordinator.name }}
 
@@ -90,7 +90,7 @@
             <p>and {{ supervisors|length - 3 }} more...</p>
           {% endif %}
         {% endfor %}
-      {% elif not labor_coordinators and currentUser.isLaborAdmin %}
+      {% elif not laborCoordinators and currentUser.isLaborAdmin %}
         <p>No active supervisors assigned. <a href="#" >Add one?</a>  </p>
       {% else  %}
         <p>No active supervisors assigned.</p>

--- a/app/templates/main/departmentPortal.html
+++ b/app/templates/main/departmentPortal.html
@@ -134,8 +134,7 @@
 
             </div>
             <ul style="line-height:2;">
-            {% for p in positions %}
-              {% if 7 > loop.index0 %}
+            {% for p in positions[:7] %}
                   {% if p == "No active positions in this department" %}
                     <li class="card-text">
                     <p> {{ p }} </p>
@@ -145,12 +144,10 @@
                       <a href= "/department/{{ department.ORG }}/{{ department.ACCOUNT }}/positions/{{posUrl[loop.index0]}}">{{ p }}</a>
                     </li>
                   {% endif %}
-
-              {% elif 7 == loop.index0 %}
+            {% endfor %}
+            {% if positions| length >7 %}
                 </ul><p class="card-text">and {{ (positions | length) - 7}} more...</p>
               {% endif %}
-            {% endfor %}
-            </ul>
             
           </div>
               <div class="card-footer text-center">


### PR DESCRIPTION
## Issue Description

Fixes #603 
- The Department Portal should include a Members card that provides a quick overview of department staff assigned to the department. The card should display the department's Labor Coordinator(s) if there is one and a list of Department member to give users an immediate understanding of who is in the department.

## Changes

- Added a "Members" card to the Department Portal page that shows after a department has been selected. 
- The card lists the Labor Coordinators and Supervisors that are members of the selected department
- There's a clickable email icon next to each name

## Testing

- select different departments and ensure demo data shows up correctly. 