### PR TITLE
Members card

### DIFF
--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -63,37 +63,6 @@ def departmentPortal(org=None,account=None):
     else:
         departments = list(getDepartmentsForSupervisor(currentUser).order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
     
-    # def buildSupervisorDisplay(supervisor):
-    #     firstName = supervisor.preferred_name or supervisor.legal_name or ""
-    #     lastName = supervisor.LAST_NAME or ""
-
-    #     return {
-    #         "name": f"{firstName} {lastName}".strip(),
-    #         "email": supervisor.EMAIL
-    #     }
-        
-    # laborCoordinators = []
-    # supervisors = []
-    
-    # # Avoid querying department members unless the selected department exists.
-    # if dept is not None:
-    #     supervisorDepartments = (SupervisorDepartment.select().join(Supervisor).where(SupervisorDepartment.department == dept)
-    #         .order_by(fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name, Supervisor.LAST_NAME).asc()))
-        
-
-    #     for supervisorDepartment in supervisorDepartments:
-    #         supervisor = supervisorDepartment.supervisor
-
-    #         if supervisor is None:
-    #             continue
-
-    #         supervisorDisplay = buildSupervisorDisplay(supervisor)
-
-    #         if supervisorDepartment.isCoordinator:
-    #             laborCoordinators.append(supervisorDisplay)
-    #         else:
-    #             supervisors.append(supervisorDisplay)
-
     supervisors, laborCoordinators = getSupervisors(dept)
 
     return render_template('main/departmentPortal.html', 

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -67,11 +67,11 @@ def departmentPortal(org=None,account=None):
     if currentUser.isLaborAdmin:
         departments = list(Department.select().order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
     else:
-        departments = list(getDepartmentsForSupervisor(currentUser).order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
+        departments = list(Department.select().join(SupervisorDepartment).where(SupervisorDepartment.supervisor == currentUser.supervisor).order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
     
     supervisors, laborCoordinators = getSupervisors(dept)
 
-    positionsList, posURL = getActivePositions(dept)
+    positionsList, posURL = getActivePositions(dept) 
 
     return render_template('main/departmentPortal.html', 
                            departments = departments,

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -16,6 +16,7 @@ from app.logic.search import getDepartmentsForSupervisor, searchPerson, searchSu
 from app.login_manager import require_login, logout
 from app.logic.getTableData import getDatatableData
 from app.logic.banner import Banner
+from app.logic.getSupervisors import fuck
 
 @main_bp.route('/logout', methods=['GET'])
 def triggerLogout():
@@ -62,36 +63,38 @@ def departmentPortal(org=None,account=None):
     else:
         departments = list(getDepartmentsForSupervisor(currentUser).order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
     
-    def buildSupervisorDisplay(supervisor):
-        firstName = supervisor.preferred_name or supervisor.legal_name or ""
-        lastName = supervisor.LAST_NAME or ""
+    # def buildSupervisorDisplay(supervisor):
+    #     firstName = supervisor.preferred_name or supervisor.legal_name or ""
+    #     lastName = supervisor.LAST_NAME or ""
 
-        return {
-            "name": f"{firstName} {lastName}".strip(),
-            "email": supervisor.EMAIL
-        }
+    #     return {
+    #         "name": f"{firstName} {lastName}".strip(),
+    #         "email": supervisor.EMAIL
+    #     }
         
-    laborCoordinators = []
-    supervisors = []
+    # laborCoordinators = []
+    # supervisors = []
     
-    # Avoid querying department members unless the selected department exists.
-    if dept is not None:
-        supervisorDepartments = (SupervisorDepartment.select().join(Supervisor).where(SupervisorDepartment.department == dept)
-            .order_by(fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name, Supervisor.LAST_NAME).asc()))
+    # # Avoid querying department members unless the selected department exists.
+    # if dept is not None:
+    #     supervisorDepartments = (SupervisorDepartment.select().join(Supervisor).where(SupervisorDepartment.department == dept)
+    #         .order_by(fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name, Supervisor.LAST_NAME).asc()))
         
 
-        for supervisorDepartment in supervisorDepartments:
-            supervisor = supervisorDepartment.supervisor
+    #     for supervisorDepartment in supervisorDepartments:
+    #         supervisor = supervisorDepartment.supervisor
 
-            if supervisor is None:
-                continue
+    #         if supervisor is None:
+    #             continue
 
-            supervisorDisplay = buildSupervisorDisplay(supervisor)
+    #         supervisorDisplay = buildSupervisorDisplay(supervisor)
 
-            if supervisorDepartment.isCoordinator:
-                laborCoordinators.append(supervisorDisplay)
-            else:
-                supervisors.append(supervisorDisplay)
+    #         if supervisorDepartment.isCoordinator:
+    #             laborCoordinators.append(supervisorDisplay)
+    #         else:
+    #             supervisors.append(supervisorDisplay)
+
+    supervisors, laborCoordinators = fuck(dept)
 
     return render_template('main/departmentPortal.html', 
                            departments = departments,

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -63,6 +63,33 @@ def departmentPortal(org=None,account=None):
     
     supervisorDepartments = (SupervisorDepartment.select().join(Supervisor).where(SupervisorDepartment.department == dept)
         .order_by(fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name, Supervisor.LAST_NAME).asc()))
+<<<<<<< HEAD
+=======
+
+    laborCoordinators = []
+    supervisors = []
+
+    for supervisorDepartment in supervisorDepartments:
+        supervisor = supervisorDepartment.supervisor
+
+        if supervisor is None:
+            continue
+
+        firstName = supervisor.preferred_name or supervisor.legal_name or ""
+        lastName = supervisor.LAST_NAME or ""
+
+        supervisorName = f"{firstName} {lastName}".strip()
+
+        supervisorDisplay = {
+            "name": supervisorName,
+            "email": supervisor.EMAIL
+        }
+
+        if supervisorDepartment.isCoordinator:
+            laborCoordinators.append(supervisorDisplay)
+        else:
+            supervisors.append(supervisorDisplay)
+>>>>>>> parent of 78e87860 (Revert "Merge pull request #645 from BCStudentSoftwareDevTeam/MembersCard")
 
     laborCoordinators = []
     supervisors = []

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -63,61 +63,7 @@ def departmentPortal(org=None,account=None):
     
     supervisorDepartments = (SupervisorDepartment.select().join(Supervisor).where(SupervisorDepartment.department == dept)
         .order_by(fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name, Supervisor.LAST_NAME).asc()))
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
-
-    laborCoordinators = []
-    supervisors = []
-
-    for supervisorDepartment in supervisorDepartments:
-        supervisor = supervisorDepartment.supervisor
-
-        if supervisor is None:
-            continue
-
-        firstName = supervisor.preferred_name or supervisor.legal_name or ""
-        lastName = supervisor.LAST_NAME or ""
-
-        supervisorName = f"{firstName} {lastName}".strip()
-
-        supervisorDisplay = {
-            "name": supervisorName,
-            "email": supervisor.EMAIL
-        }
-
-        if supervisorDepartment.isCoordinator:
-            laborCoordinators.append(supervisorDisplay)
-        else:
-            supervisors.append(supervisorDisplay)
->>>>>>> parent of 78e87860 (Revert "Merge pull request #645 from BCStudentSoftwareDevTeam/MembersCard")
-
-    laborCoordinators = []
-    supervisors = []
-
-    for supervisorDepartment in supervisorDepartments:
-        supervisor = supervisorDepartment.supervisor
-
-        if supervisor is None:
-            continue
-
-        firstName = supervisor.preferred_name or supervisor.legal_name or ""
-        lastName = supervisor.LAST_NAME or ""
-
-        supervisorName = f"{firstName} {lastName}".strip()
-
-        supervisorDisplay = {
-            "name": supervisorName,
-            "email": supervisor.EMAIL
-        }
-
-        if supervisorDepartment.isCoordinator:
-            laborCoordinators.append(supervisorDisplay)
-        else:
-            supervisors.append(supervisorDisplay)
->>>>>>> parent of 78e87860 (Revert "Merge pull request #645 from BCStudentSoftwareDevTeam/MembersCard")
-
+    
     laborCoordinators = []
     supervisors = []
 

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -64,7 +64,34 @@ def departmentPortal(org=None,account=None):
     supervisorDepartments = (SupervisorDepartment.select().join(Supervisor).where(SupervisorDepartment.department == dept)
         .order_by(fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name, Supervisor.LAST_NAME).asc()))
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
+=======
+
+    laborCoordinators = []
+    supervisors = []
+
+    for supervisorDepartment in supervisorDepartments:
+        supervisor = supervisorDepartment.supervisor
+
+        if supervisor is None:
+            continue
+
+        firstName = supervisor.preferred_name or supervisor.legal_name or ""
+        lastName = supervisor.LAST_NAME or ""
+
+        supervisorName = f"{firstName} {lastName}".strip()
+
+        supervisorDisplay = {
+            "name": supervisorName,
+            "email": supervisor.EMAIL
+        }
+
+        if supervisorDepartment.isCoordinator:
+            laborCoordinators.append(supervisorDisplay)
+        else:
+            supervisors.append(supervisorDisplay)
+>>>>>>> parent of 78e87860 (Revert "Merge pull request #645 from BCStudentSoftwareDevTeam/MembersCard")
 
     laborCoordinators = []
     supervisors = []

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -16,6 +16,7 @@ from app.logic.search import getDepartmentsForSupervisor, searchPerson, searchSu
 from app.login_manager import require_login, logout
 from app.logic.getTableData import getDatatableData
 from app.logic.banner import Banner
+from app.logic.getSupervisors import getSupervisors
 
 @main_bp.route('/logout', methods=['GET'])
 def triggerLogout():
@@ -62,36 +63,38 @@ def departmentPortal(org=None,account=None):
     else:
         departments = list(getDepartmentsForSupervisor(currentUser).order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
     
-    def buildSupervisorDisplay(supervisor):
-        firstName = supervisor.preferred_name or supervisor.legal_name or ""
-        lastName = supervisor.LAST_NAME or ""
+    # def buildSupervisorDisplay(supervisor):
+    #     firstName = supervisor.preferred_name or supervisor.legal_name or ""
+    #     lastName = supervisor.LAST_NAME or ""
 
-        return {
-            "name": f"{firstName} {lastName}".strip(),
-            "email": supervisor.EMAIL
-        }
+    #     return {
+    #         "name": f"{firstName} {lastName}".strip(),
+    #         "email": supervisor.EMAIL
+    #     }
         
-    laborCoordinators = []
-    supervisors = []
+    # laborCoordinators = []
+    # supervisors = []
     
-    # Avoid querying department members unless the selected department exists.
-    if dept is not None:
-        supervisorDepartments = (SupervisorDepartment.select().join(Supervisor).where(SupervisorDepartment.department == dept)
-            .order_by(fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name, Supervisor.LAST_NAME).asc()))
+    # # Avoid querying department members unless the selected department exists.
+    # if dept is not None:
+    #     supervisorDepartments = (SupervisorDepartment.select().join(Supervisor).where(SupervisorDepartment.department == dept)
+    #         .order_by(fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name, Supervisor.LAST_NAME).asc()))
         
 
-        for supervisorDepartment in supervisorDepartments:
-            supervisor = supervisorDepartment.supervisor
+    #     for supervisorDepartment in supervisorDepartments:
+    #         supervisor = supervisorDepartment.supervisor
 
-            if supervisor is None:
-                continue
+    #         if supervisor is None:
+    #             continue
 
-            supervisorDisplay = buildSupervisorDisplay(supervisor)
+    #         supervisorDisplay = buildSupervisorDisplay(supervisor)
 
-            if supervisorDepartment.isCoordinator:
-                laborCoordinators.append(supervisorDisplay)
-            else:
-                supervisors.append(supervisorDisplay)
+    #         if supervisorDepartment.isCoordinator:
+    #             laborCoordinators.append(supervisorDisplay)
+    #         else:
+    #             supervisors.append(supervisorDisplay)
+
+    supervisors, laborCoordinators = getSupervisors(dept)
 
     return render_template('main/departmentPortal.html', 
                            departments = departments,

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -64,6 +64,15 @@ def departmentPortal(org=None,account=None):
     supervisorDepartments = (SupervisorDepartment.select().join(Supervisor).where(SupervisorDepartment.department == dept)
         .order_by(fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name, Supervisor.LAST_NAME).asc()))
     
+    def buildSupervisorDisplay(supervisor):
+        firstName = supervisor.preferred_name or supervisor.legal_name or ""
+        lastName = supervisor.LAST_NAME or ""
+
+        return {
+            "name": f"{firstName} {lastName}".strip(),
+            "email": supervisor.EMAIL
+        }
+        
     laborCoordinators = []
     supervisors = []
 
@@ -73,15 +82,7 @@ def departmentPortal(org=None,account=None):
         if supervisor is None:
             continue
 
-        firstName = supervisor.preferred_name or supervisor.legal_name or ""
-        lastName = supervisor.LAST_NAME or ""
-
-        supervisorName = f"{firstName} {lastName}".strip()
-
-        supervisorDisplay = {
-            "name": supervisorName,
-            "email": supervisor.EMAIL
-        }
+        supervisorDisplay= buildSupervisorDisplay(supervisor)
 
         if supervisorDepartment.isCoordinator:
             laborCoordinators.append(supervisorDisplay)
@@ -94,8 +95,6 @@ def departmentPortal(org=None,account=None):
                            supervisors = supervisors,
                            laborCoordinators=laborCoordinators,
                            currentUser=g.currentUser,
-                        #    positions = positionsList,
-                        #    posUrl = posUrl
                            )
 @main_bp.route('/supervisorPortal/addUserToDept', methods=['GET', 'POST'])
 def addUserToDept():

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -51,18 +51,16 @@ def supervisorPortal():
 @main_bp.route('/department/<org>', methods=['GET'])
 @main_bp.route('/department/<org>/<account>', methods=['GET'])
 def departmentPortal(org=None,account=None):
+    currentUser = g.currentUser
     try:
         dept = Department.get(Department.ORG == org, Department.ACCOUNT == account)
-    except (NameError, DoesNotExist):
+    except DoesNotExist:
         dept = None
 
-    if g.currentUser.isLaborAdmin:
+    if currentUser.isLaborAdmin:
         departments = list(Department.select().order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
     else:
-        departments = list(getDepartmentsForSupervisor(g.currentUser).order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
-    
-    supervisorDepartments = (SupervisorDepartment.select().join(Supervisor).where(SupervisorDepartment.department == dept)
-        .order_by(fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name, Supervisor.LAST_NAME).asc()))
+        departments = list(getDepartmentsForSupervisor(currentUser).order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
     
     def buildSupervisorDisplay(supervisor):
         firstName = supervisor.preferred_name or supervisor.legal_name or ""
@@ -75,26 +73,32 @@ def departmentPortal(org=None,account=None):
         
     laborCoordinators = []
     supervisors = []
+    
+    # Avoid querying department members unless the selected department exists.
+    if dept is not None:
+        supervisorDepartments = (SupervisorDepartment.select().join(Supervisor).where(SupervisorDepartment.department == dept)
+            .order_by(fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name, Supervisor.LAST_NAME).asc()))
+        
 
-    for supervisorDepartment in supervisorDepartments:
-        supervisor = supervisorDepartment.supervisor
+        for supervisorDepartment in supervisorDepartments:
+            supervisor = supervisorDepartment.supervisor
 
-        if supervisor is None:
-            continue
+            if supervisor is None:
+                continue
 
-        supervisorDisplay= buildSupervisorDisplay(supervisor)
+            supervisorDisplay = buildSupervisorDisplay(supervisor)
 
-        if supervisorDepartment.isCoordinator:
-            laborCoordinators.append(supervisorDisplay)
-        else:
-            supervisors.append(supervisorDisplay)
+            if supervisorDepartment.isCoordinator:
+                laborCoordinators.append(supervisorDisplay)
+            else:
+                supervisors.append(supervisorDisplay)
 
     return render_template('main/departmentPortal.html', 
                            departments = departments,
                            department = dept,
                            supervisors = supervisors,
                            laborCoordinators=laborCoordinators,
-                           currentUser=g.currentUser,
+                           currentUser=currentUser,
                            )
 @main_bp.route('/supervisorPortal/addUserToDept', methods=['GET', 'POST'])
 def addUserToDept():

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -55,7 +55,7 @@ def departmentPortal(org=None,account=None):
     currentUser = g.currentUser
     try:
         dept = Department.get(Department.ORG == org, Department.ACCOUNT == account)
-    except DoesNotExist:
+    except (NameError, DoesNotExist):
         dept = None
 
     if currentUser.isLaborAdmin:

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -94,8 +94,8 @@ def departmentPortal(org=None,account=None):
                            supervisors = supervisors,
                            laborCoordinators=laborCoordinators,
                            currentUser=g.currentUser,
-                           positions = positionsList,
-                           posUrl = posUrl
+                        #    positions = positionsList,
+                        #    posUrl = posUrl
                            )
 @main_bp.route('/supervisorPortal/addUserToDept', methods=['GET', 'POST'])
 def addUserToDept():

--- a/app/controllers/main_routes/main_routes.py
+++ b/app/controllers/main_routes/main_routes.py
@@ -1,5 +1,5 @@
 from flask import render_template, request, json, redirect, url_for, send_file, g, flash, jsonify
-from peewee import JOIN, DoesNotExist
+from peewee import JOIN, DoesNotExist, fn
 from functools import reduce
 import operator
 from app.models.department import Department
@@ -56,17 +56,47 @@ def departmentPortal(org=None,account=None):
     except (NameError, DoesNotExist):
         dept = None
 
-
-
     if g.currentUser.isLaborAdmin:
         departments = list(Department.select().order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
     else:
         departments = list(getDepartmentsForSupervisor(g.currentUser).order_by(Department.isActive.desc(), Department.DEPT_NAME.asc()))
+    
+    supervisorDepartments = (SupervisorDepartment.select().join(Supervisor).where(SupervisorDepartment.department == dept)
+        .order_by(fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name, Supervisor.LAST_NAME).asc()))
+
+    laborCoordinators = []
+    supervisors = []
+
+    for supervisorDepartment in supervisorDepartments:
+        supervisor = supervisorDepartment.supervisor
+
+        if supervisor is None:
+            continue
+
+        firstName = supervisor.preferred_name or supervisor.legal_name or ""
+        lastName = supervisor.LAST_NAME or ""
+
+        supervisorName = f"{firstName} {lastName}".strip()
+
+        supervisorDisplay = {
+            "name": supervisorName,
+            "email": supervisor.EMAIL
+        }
+
+        if supervisorDepartment.isCoordinator:
+            laborCoordinators.append(supervisorDisplay)
+        else:
+            supervisors.append(supervisorDisplay)
 
     return render_template('main/departmentPortal.html', 
                            departments = departments,
-                           department = dept)
-
+                           department = dept,
+                           supervisors = supervisors,
+                           laborCoordinators=laborCoordinators,
+                           currentUser=g.currentUser,
+                           positions = positionsList,
+                           posUrl = posUrl
+                           )
 @main_bp.route('/supervisorPortal/addUserToDept', methods=['GET', 'POST'])
 def addUserToDept():
     userDeptData = request.form

--- a/app/logic/getSupervisors.py
+++ b/app/logic/getSupervisors.py
@@ -25,7 +25,7 @@ def getSupervisors(dept):
     # Avoid querying department members unless the selected department exists.
     if dept is not None:
         supervisorDepartments = (SupervisorDepartment.select().join(Supervisor).where(SupervisorDepartment.department == dept)
-            .order_by(fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name, Supervisor.LAST_NAME).asc()))
+            .order_by(Supervisor.LAST_NAME.asc()))
         for supervisorDepartment in supervisorDepartments:
             supervisor = supervisorDepartment.supervisor
             if supervisor is None:
@@ -39,5 +39,5 @@ def getSupervisors(dept):
                 laborCoordinators.append(supervisorDisplay)
             else:
                 supervisors.append(supervisorDisplay)
-                
+
     return supervisors, laborCoordinators

--- a/app/logic/getSupervisors.py
+++ b/app/logic/getSupervisors.py
@@ -39,4 +39,5 @@ def getSupervisors(dept):
                 laborCoordinators.append(supervisorDisplay)
             else:
                 supervisors.append(supervisorDisplay)
+                
     return supervisors, laborCoordinators

--- a/app/logic/getSupervisors.py
+++ b/app/logic/getSupervisors.py
@@ -26,16 +26,12 @@ def getSupervisors(dept):
     if dept is not None:
         supervisorDepartments = (SupervisorDepartment.select().join(Supervisor).where(SupervisorDepartment.department == dept)
             .order_by(fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name, Supervisor.LAST_NAME).asc()))
-        
-
         for supervisorDepartment in supervisorDepartments:
             supervisor = supervisorDepartment.supervisor
-
             if supervisor is None:
                 continue
 
             supervisorDisplay = buildSupervisorDisplay(supervisor)
-
             if not supervisorDisplay:
                 continue
 

--- a/app/logic/getSupervisors.py
+++ b/app/logic/getSupervisors.py
@@ -9,11 +9,9 @@ def buildSupervisorDisplay(supervisor):
         firstName = supervisor.FIRST_NAME 
         lastName = supervisor.LAST_NAME
         if not (firstName and lastName):
-            print("First name and last name are required////////////////////////////////////////////////////////////////////////////////////////////")
             raise NameError("First name and last name are required")
 
     except NameError as e:
-        print(e)
         return None
 
     return {

--- a/app/logic/getSupervisors.py
+++ b/app/logic/getSupervisors.py
@@ -1,0 +1,37 @@
+from app.models.supervisor import Supervisor
+from app.models.supervisorDepartment import SupervisorDepartment
+from peewee import fn
+
+
+
+def buildSupervisorDisplay(supervisor):
+    firstName = supervisor.preferred_name or supervisor.legal_name or ""
+    lastName = supervisor.LAST_NAME or ""
+
+    return {
+        "name": f"{firstName} {lastName}".strip(),
+        "email": supervisor.EMAIL
+    }
+def fuck(dept):    
+    laborCoordinators = []
+    supervisors = []
+    
+    # Avoid querying department members unless the selected department exists.
+    if dept is not None:
+        supervisorDepartments = (SupervisorDepartment.select().join(Supervisor).where(SupervisorDepartment.department == dept)
+            .order_by(fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name, Supervisor.LAST_NAME).asc()))
+        
+
+        for supervisorDepartment in supervisorDepartments:
+            supervisor = supervisorDepartment.supervisor
+
+            if supervisor is None:
+                continue
+
+            supervisorDisplay = buildSupervisorDisplay(supervisor)
+
+            if supervisorDepartment.isCoordinator:
+                laborCoordinators.append(supervisorDisplay)
+            else:
+                supervisors.append(supervisorDisplay)
+    return supervisors, laborCoordinators

--- a/app/logic/getSupervisors.py
+++ b/app/logic/getSupervisors.py
@@ -1,0 +1,37 @@
+from app.models.supervisor import Supervisor
+from app.models.supervisorDepartment import SupervisorDepartment
+from peewee import fn
+
+
+
+def buildSupervisorDisplay(supervisor):
+    firstName = supervisor.preferred_name or supervisor.legal_name or ""
+    lastName = supervisor.LAST_NAME or ""
+
+    return {
+        "name": f"{firstName} {lastName}".strip(),
+        "email": supervisor.EMAIL
+    }
+def getSupervisors(dept):    
+    laborCoordinators = []
+    supervisors = []
+    
+    # Avoid querying department members unless the selected department exists.
+    if dept is not None:
+        supervisorDepartments = (SupervisorDepartment.select().join(Supervisor).where(SupervisorDepartment.department == dept)
+            .order_by(fn.COALESCE(Supervisor.preferred_name, Supervisor.legal_name, Supervisor.LAST_NAME).asc()))
+        
+
+        for supervisorDepartment in supervisorDepartments:
+            supervisor = supervisorDepartment.supervisor
+
+            if supervisor is None:
+                continue
+
+            supervisorDisplay = buildSupervisorDisplay(supervisor)
+
+            if supervisorDepartment.isCoordinator:
+                laborCoordinators.append(supervisorDisplay)
+            else:
+                supervisors.append(supervisorDisplay)
+    return supervisors, laborCoordinators

--- a/app/logic/getSupervisors.py
+++ b/app/logic/getSupervisors.py
@@ -5,8 +5,16 @@ from peewee import fn
 
 
 def buildSupervisorDisplay(supervisor):
-    firstName = supervisor.preferred_name or supervisor.legal_name or ""
-    lastName = supervisor.LAST_NAME or ""
+    try:
+        firstName = supervisor.FIRST_NAME 
+        lastName = supervisor.LAST_NAME
+        if not (firstName and lastName):
+            print("First name and last name are required////////////////////////////////////////////////////////////////////////////////////////////")
+            raise NameError("First name and last name are required")
+
+    except NameError as e:
+        print(e)
+        return None
 
     return {
         "name": f"{firstName} {lastName}".strip(),
@@ -29,6 +37,9 @@ def getSupervisors(dept):
                 continue
 
             supervisorDisplay = buildSupervisorDisplay(supervisor)
+
+            if not supervisorDisplay:
+                continue
 
             if supervisorDepartment.isCoordinator:
                 laborCoordinators.append(supervisorDisplay)

--- a/app/static/css/base.css
+++ b/app/static/css/base.css
@@ -251,8 +251,7 @@ a {
   padding: 0.5rem 1rem;
   background-color: rgba(0, 0, 0, 0.03);
   border-top: 1px solid rgba(0, 0, 0, 0.125);
-  border-bottom-left-radius: 1rem;
-  border-bottom-right-radius: 1rem;
+  border-radius: 1rem;
   margin-top: auto;
 }
 

--- a/app/static/css/base.css
+++ b/app/static/css/base.css
@@ -253,7 +253,6 @@ a {
   border-top: 1px solid rgba(0, 0, 0, 0.125);
   border-bottom-left-radius: 1rem;
   border-bottom-right-radius: 1rem;
-  
   margin-top: auto;
 }
 

--- a/app/static/css/base.css
+++ b/app/static/css/base.css
@@ -207,6 +207,7 @@ a {
   background-clip: border-box;
   border: 1px solid rgba(0, 0, 0, 0.125);
   border-radius: 0.25rem;
+  overflow: hidden;
 }
 
 .card-body {
@@ -250,6 +251,10 @@ a {
   padding: 0.5rem 1rem;
   background-color: rgba(0, 0, 0, 0.03);
   border-top: 1px solid rgba(0, 0, 0, 0.125);
+  border-bottom-left-radius: 1rem;
+  border-bottom-right-radius: 1rem;
+  
+  margin-top: auto;
 }
 
 .card-footer:last-child {
@@ -263,4 +268,34 @@ a {
 .card-img-top {
   border-top-left-radius: calc(0.25rem - 1px);
   border-top-right-radius: calc(0.25rem - 1px);
+}
+
+.members-icon {
+  font-size: 36px;
+}
+.site-footer {
+  position: fixed;
+  left: 280px;
+  right: 0;
+  bottom: 0;
+
+  background-color: #e9ebec;
+  color: #1e2433;
+
+  padding: 8px 15px;
+  line-height: 1.4;
+  box-sizing: border-box;
+  z-index: 101;
+
+}
+
+.sidebar-push {
+  padding-bottom: 85px;
+}
+
+@media (max-width: 991px) {
+  .site-footer {
+    left: 0;
+    width: 100%;
+  }
 }

--- a/app/static/css/base.css
+++ b/app/static/css/base.css
@@ -269,33 +269,3 @@ a {
   border-top-left-radius: calc(0.25rem - 1px);
   border-top-right-radius: calc(0.25rem - 1px);
 }
-
-.members-icon {
-  font-size: 36px;
-}
-.site-footer {
-  position: fixed;
-  left: 280px;
-  right: 0;
-  bottom: 0;
-
-  background-color: #e9ebec;
-  color: #1e2433;
-
-  padding: 8px 15px;
-  line-height: 1.4;
-  box-sizing: border-box;
-  z-index: 101;
-
-}
-
-.sidebar-push {
-  padding-bottom: 85px;
-}
-
-@media (max-width: 991px) {
-  .site-footer {
-    left: 0;
-    width: 100%;
-  }
-}

--- a/app/static/css/departmentPortal.css
+++ b/app/static/css/departmentPortal.css
@@ -8,7 +8,7 @@
 }
 
 .card-body {
-  padding: 1rem 1rem;
+  padding: 1rem;
   min-width: 100%;
 }
 
@@ -16,7 +16,7 @@
   display: inline-block;
   border: 1px solid #c0c0c0;
   border-radius: 8px;
-  padding: 3px 3.5px 1.5px 3.5px;
+  padding: 3px 3.5px 1.5px;
   font-size: 36px;
   color: #6e6e6e;
 }

--- a/app/static/css/departmentPortal.css
+++ b/app/static/css/departmentPortal.css
@@ -6,13 +6,6 @@
   min-width: 100%;
   box-shadow: 2px 2px 4px rgba(100, 100, 100, 0.26);
 }
-.bi-suitcase-lg-fill {  /* Bootstrap Icon */
-  border: 1px solid #c0c0c0;
-  border-radius: 8px;
-  padding: 3px 3.5px 1.5px 3.5px;
-  font-size: 3rem;
-  color:#6e6e6e;
-}
 
 .bi-people-fill {  /* Bootstrap Icon for Members Card */
   border: 1px solid #c0c0c0;
@@ -22,19 +15,7 @@
   color:#6e6e6e;
 }
 
-.card-group {
-    gap: 1rem;
-}
-.form-group {
-    width: 50%;
-    margin-left: auto ;
-    margin-right:auto;
-}
 .card-body {
   padding: 1rem 1rem;
   min-width: 100%
-}
-.row {
-    display: flex;
-    flex-wrap: wrap;
 }

--- a/app/static/css/departmentPortal.css
+++ b/app/static/css/departmentPortal.css
@@ -1,0 +1,40 @@
+.card {
+  border-radius: 1rem;
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
+  min-width: 100%;
+  box-shadow: 2px 2px 4px rgba(100, 100, 100, 0.26);
+}
+.bi-suitcase-lg-fill {  /* Bootstrap Icon */
+  border: 1px solid #c0c0c0;
+  border-radius: 8px;
+  padding: 3px 3.5px 1.5px 3.5px;
+  font-size: 3rem;
+  color:#6e6e6e;
+}
+
+.bi-people-fill {  /* Bootstrap Icon for Members Card */
+  border: 1px solid #c0c0c0;
+  border-radius: 8px;
+  padding: 3px 3.5px 1.5px 3.5px;
+  font-size: 3rem;
+  color:#6e6e6e;
+}
+
+.card-group {
+    gap: 1rem;
+}
+.form-group {
+    width: 50%;
+    margin-left: auto ;
+    margin-right:auto;
+}
+.card-body {
+  padding: 1rem 1rem;
+  min-width: 100%
+}
+.row {
+    display: flex;
+    flex-wrap: wrap;
+}

--- a/app/static/css/departmentPortal.css
+++ b/app/static/css/departmentPortal.css
@@ -9,7 +9,7 @@
 
 .card-body {
   padding: 1rem 1rem;
-  min-width: 100%
+  min-width: 100%;
 }
 
 .members-icon {

--- a/app/static/css/departmentPortal.css
+++ b/app/static/css/departmentPortal.css
@@ -7,15 +7,16 @@
   box-shadow: 2px 2px 4px rgba(100, 100, 100, 0.26);
 }
 
-.bi-people-fill {  /* Bootstrap Icon for Members Card */
-  border: 1px solid #c0c0c0;
-  border-radius: 8px;
-  padding: 3px 3.5px 1.5px 3.5px;
-  font-size: 3rem;
-  color:#6e6e6e;
-}
-
 .card-body {
   padding: 1rem 1rem;
   min-width: 100%
+}
+
+.members-icon {
+  display: inline-block;
+  border: 1px solid #c0c0c0;
+  border-radius: 8px;
+  padding: 3px 3.5px 1.5px 3.5px;
+  font-size: 36px;
+  color: #6e6e6e;
 }

--- a/app/templates/main/departmentPortal.html
+++ b/app/templates/main/departmentPortal.html
@@ -81,7 +81,6 @@
 
       {% else %}
         <p>None assigned. <a href="#" >Add one?</a> </p> 
-        <!-- href will be the link same as view members because we already have the logci to add labor coordinator and supervisor there and we don't want the card to be clsutered -->
           
       {% endif %}
       

--- a/app/templates/main/departmentPortal.html
+++ b/app/templates/main/departmentPortal.html
@@ -33,7 +33,7 @@
         <section class="card" aria-labelledby="current_allocation-title">
           <p> Insert Allocations Card Here </p>
             <div class="card-footer text-center">
-              <a href="/department/{{ department.ORG }}/{{ department.ACCOUNT }}/REPLACEME" class="btn btn-primary">View Alloations<span class="glyphicon glyphicon-chevron-right"></span></a>
+              <a href="/department/{{ department.ORG }}/{{ department.ACCOUNT }}/REPLACEME" class="btn btn-primary">View Allocations<span class="glyphicon glyphicon-chevron-right"></span></a>
             </div>
         </section>
         
@@ -101,10 +101,9 @@
               <p>and {{ supervisors|length - 3 }} more...</p>
             {% endif %}
 
-      {% elif not laborCoordinators and currentUser.isLaborAdmin %}
-        <p>No active supervisors assigned. <a href="#" >Add one?</a>  </p>
+
       {% else  %}
-        <p>No active supervisors assigned.</p>
+       <p> None assigned. {% if currentUser.isLaborAdmin %} <a href="#">Add one?</a> {% endif %}</p>
       {% endif %}
 
     </div>

--- a/app/templates/main/departmentPortal.html
+++ b/app/templates/main/departmentPortal.html
@@ -1,4 +1,8 @@
 {% extends "base.html" %}
+{% block styles %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/departmentPortal.css') }}?u={{ lastStaticUpdate }}">
+{% endblock %}
 
 {% block scripts %}
 {{super()}}

--- a/app/templates/main/departmentPortal.html
+++ b/app/templates/main/departmentPortal.html
@@ -28,6 +28,7 @@
 =======
 
 
+
   {% if department %}
     <div class="row g-3">
       <div class="col-12 col-lg-4 ">

--- a/app/templates/main/departmentPortal.html
+++ b/app/templates/main/departmentPortal.html
@@ -29,6 +29,7 @@
 
 
 
+
   {% if department %}
     <div class="row g-3">
       <div class="col-12 col-lg-4 ">

--- a/app/templates/main/departmentPortal.html
+++ b/app/templates/main/departmentPortal.html
@@ -54,9 +54,9 @@
         </div>
 
         <div class="media-body media-middle">
-          <h1>
+          <h3>
             Members
-          </h1>
+          </h3>
         </div>
       </div>
       <h4> <b>{% if laborCoordinators|length <= 1 %} Labor Coordinator {% else %} Labor Coordinators{% endif %}</b></h4>

--- a/app/templates/main/departmentPortal.html
+++ b/app/templates/main/departmentPortal.html
@@ -4,9 +4,9 @@
 {{super()}}
     <script type="text/javascript" src="{{url_for('static', filename='js/departmentPortal.js') }}?u={{lastStaticUpdate}}"></script>
 {% endblock %}
-
 {% block app_content %}
 <h2 class="text-center">{% if department %} {{department.DEPT_NAME}} Portal {% else %} Choose a Department: {% endif %} </h2>
+
 
   <!--selectpicker for department-->
   <div class="form-group">
@@ -24,4 +24,141 @@
     </select>
 
   </div>
+<<<<<<< HEAD
+=======
+
+
+  {% if department %}
+    <div class="row g-3">
+      <div class="col-12 col-lg-4 ">
+
+        <section class="card" aria-labelledby="current_allocation-title">
+          <p> Insert Allocations Card Here </p>
+            <div class="card-footer text-center">
+              <a href="/department/{{ department.ORG }}/{{ department.ACCOUNT }}/REPLACEME" class="btn btn-primary">View Alloations<span class="glyphicon glyphicon-chevron-right"></span></a>
+            </div>
+        </section>
+        
+       </div>
+
+        <div class="col-12 col-lg-4">
+          <section class="card">
+    <div class="card-body">
+      <div class="media">
+         <div class="media-left media-middle">
+          <span class="members-icon">
+            <i class="bi bi-people-fill"></i>
+          </span>
+        </div>
+
+        <div class="media-body media-middle">
+          <h1>
+            Members
+          </h1>
+        </div>
+      </div>
+      <h4> <b>{% if laborCoordinators|length <= 1 %} Labor Coordinator {% else %} Labor Coordinators{% endif %}</b></h4>
+      {% if laborCoordinators %}
+        {% for coordinator in laborCoordinators %}
+          <p>
+            {{ coordinator.name }}
+
+            {% if coordinator.email %}
+                 <a href="mailto:{{ coordinator.email }}"
+                      data-toggle="tooltip"
+                      data-placement="bottom"
+                      title="{{ coordinator.email }}">
+                      <i class="bi bi-envelope-fill"></i>
+                  </a>
+            {% endif %}
+          </p>
+        {% endfor %}
+      {% else %}
+        <p>None assigned. <a href="#" >Add one?</a> </p> 
+        <!-- href will be the link same as view members because we already have the logci to add labor coordinator and supervisor there and we don't want the card to be clsutered -->
+          
+      {% endif %}
+
+    
+      <h4> <b>{% if supervisors|length <= 1 %} Supervisor{% else %} Supervisors{% endif %}</b></h4>
+
+      {% if supervisors %}
+        {% for s in supervisors[:3] %}
+            <p>
+              {{ s.name }}
+
+              {% if s.email %}
+                  <a href="mailto:{{ s.email }}"
+                      data-toggle="tooltip"
+                      data-placement="bottom"
+                      title="{{ s.email }}">
+                      <i class="bi bi-envelope-fill"></i>
+                  </a>
+                
+              {% endif %}
+            </p>
+            {% endfor %}
+
+            {% if supervisors|length > 3 %}
+              <p>and {{ supervisors|length - 3 }} more...</p>
+            {% endif %}
+
+      {% elif not laborCoordinators and currentUser.isLaborAdmin %}
+        <p>No active supervisors assigned. <a href="#" >Add one?</a>  </p>
+      {% else  %}
+        <p>No active supervisors assigned.</p>
+      {% endif %}
+
+    </div>
+
+    <div class="card-footer text-center">
+      <a href="#" class="btn btn-primary">View Members
+         <span class="glyphicon glyphicon-chevron-right"></span>
+      </a>
+    </div>
+  </section>
+
+        </div>
+
+        <div class=" col-12 col-lg-4">
+        <section class="card" aria-labelledby="positions-title">
+          <div class="card-body">
+              <div class="media">
+              <div class="media-left media-middle">
+                <span aria-hidden="true" style="color: #424242; font-size: 24px;">
+                  <i class="bi bi-suitcase-lg-fill"></i>
+                </span>
+              </div>
+              <div class="media-body media-middle">
+                <h1>Positions</h1>
+              </div>
+
+            </div>
+            <ul style="line-height:2;">
+            {% for p in positions[:7] %}
+                  {% if p == "No active positions in this department" %}
+                    <li class="card-text">
+                    <p> {{ p }} </p>
+                    </li>
+                  {% else %}
+                    <li class="card-text">
+                      <a href= "/department/{{ department.ORG }}/{{ department.ACCOUNT }}/positions/{{posUrl[loop.index0]}}">{{ p }}</a>
+                    </li>
+                  {% endif %}
+            {% endfor %}
+            {% if positions| length >7 %}
+                </ul><p class="card-text">and {{ (positions | length) - 7}} more...</p>
+              {% endif %}
+            
+          </div>
+              <div class="card-footer text-center">
+                <a href="/department/{{ department.ORG }}/{{ department.ACCOUNT }}/positions" class="btn btn-primary">View All Positions<span class="glyphicon glyphicon-chevron-right"></span></a>
+              </div>
+        </section>
+      </div>
+  </div>
+
+{% endif %}
+
+>>>>>>> parent of 78e87860 (Revert "Merge pull request #645 from BCStudentSoftwareDevTeam/MembersCard")
 {% endblock %}

--- a/app/templates/main/departmentPortal.html
+++ b/app/templates/main/departmentPortal.html
@@ -61,7 +61,7 @@
       </div>
       <h4> <b>{% if laborCoordinators|length <= 1 %} Labor Coordinator {% else %} Labor Coordinators{% endif %}</b></h4>
       {% if laborCoordinators %}
-        {% for coordinator in laborCoordinators %}
+        {% for coordinator in laborCoordinators[:3] %}
           <p>
             {{ coordinator.name }}
 
@@ -75,17 +75,22 @@
             {% endif %}
           </p>
         {% endfor %}
+        {% if laborCoordinators|length > 3 %}
+              <p>and {{ laborCoordinators|length - 3 }} more...</p>
+        {% endif %}
+
       {% else %}
         <p>None assigned. <a href="#" >Add one?</a> </p> 
         <!-- href will be the link same as view members because we already have the logci to add labor coordinator and supervisor there and we don't want the card to be clsutered -->
           
       {% endif %}
+      
 
     
       <h4> <b>{% if supervisors|length <= 1 %} Supervisor{% else %} Supervisors{% endif %}</b></h4>
 
       {% if supervisors %}
-        {% for s in supervisors[:3] %}
+        {% for s in supervisors[:5] %}
             <p>
               {{ s.name }}
 
@@ -101,8 +106,8 @@
             </p>
             {% endfor %}
 
-            {% if supervisors|length > 3 %}
-              <p>and {{ supervisors|length - 3 }} more...</p>
+            {% if supervisors|length > 5 %}
+              <p>and {{ supervisors|length - 5 }} more...</p>
             {% endif %}
 
 

--- a/app/templates/main/departmentPortal.html
+++ b/app/templates/main/departmentPortal.html
@@ -24,10 +24,6 @@
     </select>
 
   </div>
-<<<<<<< HEAD
-=======
-
-
 
 
   {% if department %}
@@ -121,46 +117,19 @@
   </section>
 
         </div>
+      <div class="col-12 col-lg-4 ">
 
-        <div class=" col-12 col-lg-4">
-        <section class="card" aria-labelledby="positions-title">
-          <div class="card-body">
-              <div class="media">
-              <div class="media-left media-middle">
-                <span aria-hidden="true" style="color: #424242; font-size: 24px;">
-                  <i class="bi bi-suitcase-lg-fill"></i>
-                </span>
-              </div>
-              <div class="media-body media-middle">
-                <h1>Positions</h1>
-              </div>
-
+        <section class="card" aria-labelledby="current_allocation-title">
+          <p> Insert Positions Card Here </p>
+            <div class="card-footer text-center">
+              <a href="/department/{{ department.ORG }}/{{ department.ACCOUNT }}/REPLACEME" class="btn btn-primary">View Positions<span class="glyphicon glyphicon-chevron-right"></span></a>
             </div>
-            <ul style="line-height:2;">
-            {% for p in positions[:7] %}
-                  {% if p == "No active positions in this department" %}
-                    <li class="card-text">
-                    <p> {{ p }} </p>
-                    </li>
-                  {% else %}
-                    <li class="card-text">
-                      <a href= "/department/{{ department.ORG }}/{{ department.ACCOUNT }}/positions/{{posUrl[loop.index0]}}">{{ p }}</a>
-                    </li>
-                  {% endif %}
-            {% endfor %}
-            {% if positions| length >7 %}
-                </ul><p class="card-text">and {{ (positions | length) - 7}} more...</p>
-              {% endif %}
-            
-          </div>
-              <div class="card-footer text-center">
-                <a href="/department/{{ department.ORG }}/{{ department.ACCOUNT }}/positions" class="btn btn-primary">View All Positions<span class="glyphicon glyphicon-chevron-right"></span></a>
-              </div>
         </section>
-      </div>
+        
+       </div>
+
   </div>
 
 {% endif %}
 
->>>>>>> parent of 78e87860 (Revert "Merge pull request #645 from BCStudentSoftwareDevTeam/MembersCard")
 {% endblock %}

--- a/database/demo_data.py
+++ b/database/demo_data.py
@@ -334,10 +334,10 @@ staffs = [
             {
             "ID": "B00939230",
             "PIDM":99,
-            "FIRST_NAME":"Mario",
+            "FIRST_NAME":"Wario",
             "LAST_NAME" : "Nakazawa",
-            "EMAIL"  :"nakazawam@berea.edu",
-            "CPO":"400",
+            "EMAIL"  :"nakazawaw@berea.edu",
+            "CPO":"666",
             "ORG":"2114",
             "DEPT_NAME": "Computer Science"
             },

--- a/database/demo_data.py
+++ b/database/demo_data.py
@@ -330,6 +330,56 @@ staffs = [
             "CPO":"420",
             "ORG":"2114",
             "DEPT_NAME": "Computer Science"
+            },
+            {
+            "ID": "B00939230",
+            "PIDM":99,
+            "FIRST_NAME":"Mario",
+            "LAST_NAME" : "Nakazawa",
+            "EMAIL"  :"nakazawam@berea.edu",
+            "CPO":"400",
+            "ORG":"2114",
+            "DEPT_NAME": "Computer Science"
+            },
+            {
+            "ID": "B00222888",
+            "PIDM":97,
+            "FIRST_NAME":"Test",
+            "LAST_NAME" : "Professor",
+            "EMAIL"  :"professort@berea.edu",
+            "CPO":"500",
+            "ORG":"2114",
+            "DEPT_NAME": "Computer Science"
+            },
+            {
+            "ID": "B00888222",
+            "PIDM":98,
+            "FIRST_NAME":"Demo",
+            "LAST_NAME" : "Z",
+            "EMAIL"  :"demoz@berea.edu",
+            "CPO":"999",
+            "ORG":"2114",
+            "DEPT_NAME": "Computer Science"
+            },
+            {
+            "ID": "B00123112",
+            "PIDM":92,
+            "FIRST_NAME":"Supervisor",
+            "LAST_NAME" : "Test",
+            "EMAIL"  :"tests@berea.edu",
+            "CPO":"888",
+            "ORG":"2114",
+            "DEPT_NAME": "Computer Science"
+            },
+            {
+            "ID": "B00012213",
+            "PIDM":91,
+            "FIRST_NAME":"Sib",
+            "LAST_NAME" : "Ztest",
+            "EMAIL"  :"ztests@berea.edu",
+            "CPO":"222",
+            "ORG":"2114",
+            "DEPT_NAME": "Computer Science"
             }
         ]
 
@@ -651,6 +701,31 @@ supervisorDepartmentMembers = [
 
     {
         "supervisor": "B00841417",
+        "department": 1,
+        "isCoordinator": True
+    },
+    {
+        "supervisor": "B00939230",
+        "department": 1,
+        "isCoordinator": False
+    },
+    {
+        "supervisor": "B00888222",
+        "department": 1,
+        "isCoordinator": False
+    },
+    {
+        "supervisor": "B00222888",
+        "department": 1,
+        "isCoordinator": False
+    },
+    {
+        "supervisor": "B00123112",
+        "department": 1,
+        "isCoordinator": True
+    },
+    {
+        "supervisor": "B00012213",
         "department": 1,
         "isCoordinator": True
     }

--- a/database/demo_data.py
+++ b/database/demo_data.py
@@ -825,7 +825,7 @@ print(" * allocation added")
 # Position History
 #############################
 
-positionhistory = [
+positionHistory = [
     {
         "positionTitle": "Student Programmer",
         "positionCode": "S61407",
@@ -939,5 +939,5 @@ positionhistory = [
     
 
 ]
-PositionHistory.insert_many(positionhistory).on_conflict_replace().execute()
+PositionHistory.insert_many(positionHistory).on_conflict_replace().execute()
 print(" * position history added")

--- a/database/demo_data.py
+++ b/database/demo_data.py
@@ -309,7 +309,7 @@ staffs = [
             "EMAIL"  :"jonesj@berea.edu",
             "CPO":"6301",
             "ORG":"2114",
-            "DEPT_NAME": "Computer Science",
+            "DEPT_NAME": "Computer Science"
             },
             {
             "ID": "B00763721",

--- a/database/demo_data.py
+++ b/database/demo_data.py
@@ -309,7 +309,7 @@ staffs = [
             "EMAIL"  :"jonesj@berea.edu",
             "CPO":"6301",
             "ORG":"2114",
-            "DEPT_NAME": "Computer Science"
+            "DEPT_NAME": "Computer Science",
             },
             {
             "ID": "B00763721",

--- a/tests/code/test_getSupervisor.py
+++ b/tests/code/test_getSupervisor.py
@@ -26,33 +26,33 @@ def test_buildSupervisorDisplay():
                                  isActive = 1)
         
         # has legal_name but no preferred_name
-        fella = buildSupervisorDisplay(staff)
-        assert fella["name"] == "Test Subject" 
-        assert fella["email"] == "test@berea.edu"
+        builtSupervisor = buildSupervisorDisplay(staff)
+        assert builtSupervisor["name"] == "Test Subject" 
+        assert builtSupervisor["email"] == "test@berea.edu"
         assert staff.preferred_name == None
         
         staff.EMAIL = None
-        fella = buildSupervisorDisplay(staff)
-        assert fella["email"] == None
+        builtSupervisor = buildSupervisorDisplay(staff)
+        assert builtSupervisor["email"] == None
 
         # no legal_name nor preferred_name
         staff.legal_name = None
-        fella = buildSupervisorDisplay(staff)
-        assert fella == None
+        builtSupervisor = buildSupervisorDisplay(staff)
+        assert builtSupervisor == None
 
         # no legal_name but has preferred_name
         staff.preferred_name = "Joey"
-        fella = buildSupervisorDisplay(staff)
-        assert fella["name"] == "Joey Subject"
+        builtSupervisor = buildSupervisorDisplay(staff)
+        assert builtSupervisor["name"] == "Joey Subject"
 
         # has both legal_name and preferred_name
         staff.legal_name = "Test"
-        fella = buildSupervisorDisplay(staff)
-        assert fella["name"] == "Joey Subject"
+        builtSupervisor = buildSupervisorDisplay(staff)
+        assert builtSupervisor["name"] == "Joey Subject"
 
         staff.LAST_NAME = None
-        fella = buildSupervisorDisplay(staff)
-        assert fella == None
+        builtSupervisor = buildSupervisorDisplay(staff)
+        assert builtSupervisor == None
 
         transaction.rollback()
 

--- a/tests/code/test_getSupervisor.py
+++ b/tests/code/test_getSupervisor.py
@@ -14,12 +14,6 @@ def test_getSupervisors():
                                  ORG = "1",
                                  departmentCoimpliance = 1,
                                  isActive = 1)
-        Department.create(departmentID = 10001,
-                          DEPT_NAME = "Test Labor Office",
-                          ACCOUNT = "4",
-                          ORG = "8",
-                          epartmentCoimpliance = 1,
-                          isActive = 1)
         
         staff = Supervisor.create(ID = "B0000000",
                                   PIDM = 10000,

--- a/tests/code/test_getSupervisor.py
+++ b/tests/code/test_getSupervisor.py
@@ -6,6 +6,41 @@ from app.models.supervisorDepartment import SupervisorDepartment
 from app.models.department import Department
 
 @pytest.mark.integration
+def test_buildSupervisorDisplay():
+    with mainDB.atomic() as transaction:
+        #creating test data
+        staff = Supervisor.create(ID = "B0000000",
+                                  PIDM = 10000,
+                                  LAST_NAME = "Subject",
+                                  legal_name = "Test",
+                                  EMAIL = "test@berea.edu",
+                                  CPO = "9000",
+                                  ORG = "1",
+                                  DEPT_NAME = "Test Computer Science")
+
+        dept = Department.create(departmentID = 10000,
+                                 DEPT_NAME = "Test Computer Science",
+                                 ACCOUNT = "4",
+                                 ORG = "1",
+                                 departmentCoimpliance = 1,
+                                 isActive = 1)
+        
+        fella = buildSupervisorDisplay(staff)
+        assert fella["name"] == "Test Subject" 
+        assert fella["email"] == "test@berea.edu"
+        
+        staff.EMAIL = None
+        fella = buildSupervisorDisplay(staff)
+        assert fella["email"] == None
+
+        staff.legal_name = None
+        fella = buildSupervisorDisplay(staff)
+        assert fella == None
+
+        transaction.rollback()
+
+
+@pytest.mark.integration
 def test_getSupervisors():
     with mainDB.atomic() as transaction:
         dept = Department.create(departmentID = 10000,

--- a/tests/code/test_getSupervisor.py
+++ b/tests/code/test_getSupervisor.py
@@ -8,28 +8,28 @@ from app.models.department import Department
 @pytest.mark.integration
 def test_getSupervisors():
     with mainDB.atomic() as transaction:
-        dept = Department.create(departmentID = 1000,
+        dept = Department.create(departmentID = 10000,
                                  DEPT_NAME = "Test Computer Science",
                                  ACCOUNT = "4",
                                  ORG = "1",
                                  departmentCoimpliance = 1,
                                  isActive = 1)
-        Department.create(departmentID = 1001,
+        Department.create(departmentID = 10001,
                           DEPT_NAME = "Test Labor Office",
                           ACCOUNT = "4",
                           ORG = "8",
                           epartmentCoimpliance = 1,
                           isActive = 1)
         
-        staff = Supervisor.create(ID = "B000000",
-                                  PIDM = 1000,
+        staff = Supervisor.create(ID = "B0000000",
+                                  PIDM = 10000,
                                   LAST_NAME = "Subject",
                                   legal_name = "Test",
                                   EMAIL = "test@berea.edu",
                                   CPO = "9000",
                                   ORG = "1",
                                   DEPT_NAME = "Test Computer Science")
-        staff2 = Supervisor.create(ID = "B200000",
+        staff2 = Supervisor.create(ID = "B2000000",
                                   PIDM = 1002,
                                   LAST_NAME = "Extra",
                                   legal_name = "Tester",
@@ -38,8 +38,8 @@ def test_getSupervisors():
                                   ORG = "1",
                                   DEPT_NAME = "Test Computer Science")
 
-        testCoordinator = Supervisor.create(ID = "B100000",
-                                      PIDM = 1000,
+        testCoordinator = Supervisor.create(ID = "B10000000",
+                                      PIDM = 10000,
                                       LAST_NAME = "Coordinator",
                                       legal_name = "Labor",
                                       EMAIL = "Coordinator@berea.edu",
@@ -47,23 +47,24 @@ def test_getSupervisors():
                                       ORG = "1",
                                       DEPT_NAME = "Test Computer Science")
             
-        SupervisorDepartment.create(supervisor = "B000000",
-                                    department = 1000,
+        SupervisorDepartment.create(supervisor = "B0000000",
+                                    department = 10000,
                                     isCoordinator = 0)
-        SupervisorDepartment.create(supervisor = "B100000",
-                                    department = 1000,
+        SupervisorDepartment.create(supervisor = "B10000000",
+                                    department = 10000,
                                     isCoordinator = 1)
-        SupervisorDepartment.create(supervisor = "B200000",
-                                    department = 1000,
+        SupervisorDepartment.create(supervisor = "B2000000",
+                                    department = 10000,
                                     isCoordinator = 0)
 
         checkDept = getSupervisors(dept)
         #checks whether not the supervisors Names are in the correct list, [supervisors, coordinators]
         #The checkDept returns a tuple(Supervisor, Coordinator) with a list with dictionaries with the information about each person.
-        assert staff.__data__["LAST_NAME"] == checkDept[0][0]['name'].split(' ')[1]
+        #The checkDept return is in order by LAST_NAME
+        assert staff.__data__["LAST_NAME"] == checkDept[0][1]['name'].split(' ')[1]
         assert staff.__data__["LAST_NAME"] != checkDept[1][0]['name'].split(' ')[1]
         assert testCoordinator.__data__["LAST_NAME"] == checkDept[1][0]['name'].split(' ')[1]
-        assert staff2.__data__["LAST_NAME"] == checkDept [0][1]['name'].split(' ')[1]
+        assert staff2.__data__["LAST_NAME"] == checkDept[0][0]['name'].split(' ')[1]
 
         transaction.rollback()
  

--- a/tests/code/test_getSupervisor.py
+++ b/tests/code/test_getSupervisor.py
@@ -25,15 +25,32 @@ def test_buildSupervisorDisplay():
                                  departmentCoimpliance = 1,
                                  isActive = 1)
         
+        # has legal_name but no preferred_name
         fella = buildSupervisorDisplay(staff)
         assert fella["name"] == "Test Subject" 
         assert fella["email"] == "test@berea.edu"
+        assert staff.preferred_name == None
         
         staff.EMAIL = None
         fella = buildSupervisorDisplay(staff)
         assert fella["email"] == None
 
+        # no legal_name nor preferred_name
         staff.legal_name = None
+        fella = buildSupervisorDisplay(staff)
+        assert fella == None
+
+        # no legal_name but has preferred_name
+        staff.preferred_name = "Joey"
+        fella = buildSupervisorDisplay(staff)
+        assert fella["name"] == "Joey Subject"
+
+        # has both legal_name and preferred_name
+        staff.legal_name = "Test"
+        fella = buildSupervisorDisplay(staff)
+        assert fella["name"] == "Joey Subject"
+
+        staff.LAST_NAME = None
         fella = buildSupervisorDisplay(staff)
         assert fella == None
 

--- a/tests/code/test_getSupervisor.py
+++ b/tests/code/test_getSupervisor.py
@@ -35,7 +35,7 @@ def test_buildSupervisorDisplay():
         builtSupervisor = buildSupervisorDisplay(staff)
         assert builtSupervisor["email"] == None
 
-        # no legal_name nor preferred_name
+        # no legal_name nor preferred_name, should error and return None
         staff.legal_name = None
         builtSupervisor = buildSupervisorDisplay(staff)
         assert builtSupervisor == None
@@ -50,6 +50,7 @@ def test_buildSupervisorDisplay():
         builtSupervisor = buildSupervisorDisplay(staff)
         assert builtSupervisor["name"] == "Joey Subject"
 
+        # test that it errors and returns None
         staff.LAST_NAME = None
         builtSupervisor = buildSupervisorDisplay(staff)
         assert builtSupervisor == None

--- a/tests/code/test_getSupervisor.py
+++ b/tests/code/test_getSupervisor.py
@@ -61,10 +61,10 @@ def test_getSupervisors():
         #checks whether not the supervisors Names are in the correct list, [supervisors, coordinators]
         #The checkDept returns a tuple(Supervisor, Coordinator) with a list with dictionaries with the information about each person.
         #The checkDept return is in order by LAST_NAME
-        assert staff.__data__["LAST_NAME"] == checkDept[0][1]['name'].split(' ')[1]
-        assert staff.__data__["LAST_NAME"] != checkDept[1][0]['name'].split(' ')[1]
-        assert testCoordinator.__data__["LAST_NAME"] == checkDept[1][0]['name'].split(' ')[1]
-        assert staff2.__data__["LAST_NAME"] == checkDept[0][0]['name'].split(' ')[1]
+        assert "Subject" == checkDept[0][1]['name'].split(' ')[1]
+        assert"Subject" != checkDept[1][0]['name'].split(' ')[1]
+        assert "Coordinator" == checkDept[1][0]['name'].split(' ')[1]
+        assert "Extra" == checkDept[0][0]['name'].split(' ')[1]
 
         transaction.rollback()
  

--- a/tests/code/test_getSupervisor.py
+++ b/tests/code/test_getSupervisor.py
@@ -1,0 +1,69 @@
+import pytest
+from app.models import mainDB
+from app.logic.getSupervisors import *
+from app.models.supervisor import Supervisor
+from app.models.supervisorDepartment import SupervisorDepartment
+from app.models.department import Department
+
+@pytest.mark.integration
+def test_getSupervisors():
+    with mainDB.atomic() as transaction:
+        dept = Department.create(departmentID = 1000,
+                                 DEPT_NAME = "Test Computer Science",
+                                 ACCOUNT = "4",
+                                 ORG = "1",
+                                 departmentCoimpliance = 1,
+                                 isActive = 1)
+        Department.create(departmentID = 1001,
+                          DEPT_NAME = "Test Labor Office",
+                          ACCOUNT = "4",
+                          ORG = "8",
+                          epartmentCoimpliance = 1,
+                          isActive = 1)
+        
+        staff = Supervisor.create(ID = "B000000",
+                                  PIDM = 1000,
+                                  LAST_NAME = "Subject",
+                                  legal_name = "Test",
+                                  EMAIL = "test@berea.edu",
+                                  CPO = "9000",
+                                  ORG = "1",
+                                  DEPT_NAME = "Test Computer Science")
+        staff2 = Supervisor.create(ID = "B200000",
+                                  PIDM = 1002,
+                                  LAST_NAME = "Extra",
+                                  legal_name = "Tester",
+                                  EMAIL = "Extra@berea.edu",
+                                  CPO = "9002",
+                                  ORG = "1",
+                                  DEPT_NAME = "Test Computer Science")
+
+        testCoordinator = Supervisor.create(ID = "B100000",
+                                      PIDM = 1000,
+                                      LAST_NAME = "Coordinator",
+                                      legal_name = "Labor",
+                                      EMAIL = "Coordinator@berea.edu",
+                                      CPO = "9001",
+                                      ORG = "1",
+                                      DEPT_NAME = "Test Computer Science")
+            
+        SupervisorDepartment.create(supervisor = "B000000",
+                                    department = 1000,
+                                    isCoordinator = 0)
+        SupervisorDepartment.create(supervisor = "B100000",
+                                    department = 1000,
+                                    isCoordinator = 1)
+        SupervisorDepartment.create(supervisor = "B200000",
+                                    department = 1000,
+                                    isCoordinator = 0)
+
+        checkDept = getSupervisors(dept)
+        #checks whether not the supervisors Names are in the correct list, [supervisors, coordinators]
+        #The checkDept returns a tuple(Supervisor, Coordinator) with a list with dictionaries with the information about each person.
+        assert staff.__data__["LAST_NAME"] == checkDept[0][0]['name'].split(' ')[1]
+        assert staff.__data__["LAST_NAME"] != checkDept[1][0]['name'].split(' ')[1]
+        assert testCoordinator.__data__["LAST_NAME"] == checkDept[1][0]['name'].split(' ')[1]
+        assert staff2.__data__["LAST_NAME"] == checkDept [0][1]['name'].split(' ')[1]
+
+        transaction.rollback()
+ 

--- a/tests/code/test_search.py
+++ b/tests/code/test_search.py
@@ -228,7 +228,7 @@ def test_getSupervisorsForDepartment():
         SupervisorDepartment.create(supervisor = 'B12361006', department = 1)
 
         supervisors = getSupervisorsForDepartment(1)
-        assert len(supervisors) == 7
+        assert len(supervisors) == 12
 
         testDept = Department.create(DEPT_NAME="supervisorDept", ACCOUNT="6740", ORG="2114", departmentCompliance = 1)
         supervisors = getSupervisorsForDepartment(testDept)

--- a/tests/code/test_tracy.py
+++ b/tests/code/test_tracy.py
@@ -57,8 +57,8 @@ class Test_Tracy:
             supervisors = tracy.getSupervisors()
 
             for s in supervisors:
-                assert s.FIRST_NAME in ['Alex','Brian','Jan','Jasmine','Mario','Megan','Scott','Madina']
-                assert s.CPO in ['420','6305','6301','6301','6302','6303','6300']
+                assert s.FIRST_NAME in ['Alex','Brian','Jan','Jasmine','Mario','Wario','Megan','Scott','Madina','Demo','Sib','Supervisor','Test']
+                assert s.CPO in ['666','999','420','6305','6301','6301','6302','6303','6300','222','888','500']
 
     @pytest.mark.integration
     def test_getSupervisorFromID(self, tracy):


### PR DESCRIPTION
## Description

This PR adds a Members card to the Department Portal homepage. The card gives users a quick overview of the people connected to a department by showing the assigned Labor Coordinator(s) and a preview of department members.

Fixes #603 
The card is meant to provide a simple summary on the homepage, while full personnel management will remain part of Issue #605.

## Changes

- Added a Members card to the Department Portal homepage.
- Displayed assigned Labor Coordinator(s) for the selected department.
- Displayed a preview of department members.
- Connected the card to real department/personnel data instead of hard-coded values.
- Added a View Details button for navigating to the Manage Personnel page.
- Refactored the member display logic to make the route easier to read and maintain.
- Added the `getSupervisors.py` logic file to handle getting the supervisors
- Added a test suite for the `getSupervisors` logic file

## Notes

- Full personnel management functionality belongs to Issue #605.

## Testing

- Verified that the Member's card displays on the Department Portal homepage.
- Verified that Labor Coordinator(s) and department members are separated correctly.
- Verified that the page still loads when no personnel is assigned.
- Checked that the View Members button is present.
- Verify that the `test_getSupervisors.py` file is passing when testing