### PR TITLE
Removed --skip-ssl from reset_database.sh

### DIFF
--- a/database/reset_database.sh
+++ b/database/reset_database.sh
@@ -22,12 +22,12 @@ if [ "$1" == "from-backup" ]; then
 fi
 
 echo "Dropping databases"
-mysql -u root -proot --skip-ssl --execute="DROP DATABASE \`lsf\`; DROP USER 'lsf_user';"
-mysql -u root -proot --skip-ssl --execute="DROP DATABASE \`UTE\`; DROP USER 'tracy_user';"
+mysql -u root -proot --execute="DROP DATABASE \`lsf\`; DROP USER 'lsf_user';"
+mysql -u root -proot --execute="DROP DATABASE \`UTE\`; DROP USER 'tracy_user';"
 
 echo "Recreating databases and users"
-mysql -u root -proot --skip-ssl --execute="CREATE DATABASE IF NOT EXISTS \`lsf\`; CREATE USER IF NOT EXISTS 'lsf_user'@'%' IDENTIFIED BY 'password'; GRANT ALL PRIVILEGES ON *.* TO 'lsf_user'@'%';"
-mysql -u root -proot --skip-ssl --execute="CREATE DATABASE IF NOT EXISTS \`UTE\`; CREATE USER IF NOT EXISTS 'tracy_user'@'%' IDENTIFIED BY 'password'; GRANT ALL PRIVILEGES ON *.* TO 'tracy_user'@'%';"
+mysql -u root -proot --execute="CREATE DATABASE IF NOT EXISTS \`lsf\`; CREATE USER IF NOT EXISTS 'lsf_user'@'%' IDENTIFIED BY 'password'; GRANT ALL PRIVILEGES ON *.* TO 'lsf_user'@'%';"
+mysql -u root -proot --execute="CREATE DATABASE IF NOT EXISTS \`UTE\`; CREATE USER IF NOT EXISTS 'tracy_user'@'%' IDENTIFIED BY 'password'; GRANT ALL PRIVILEGES ON *.* TO 'tracy_user'@'%';"
 
 cd database
 
@@ -38,7 +38,7 @@ rm -rf migrations.json
 echo "Creating database objects"
 if [ $BACKUP -eq 1 ]; then
     echo "  from backup"
-    mysql -u root -proot --skip-ssl lsf < prod-backup.sql
+    mysql -u root -proot lsf < prod-backup.sql
 else
     echo "  empty"
     ./migrate_db.sh


### PR DESCRIPTION
## Issue Description
`--skip-ssl` is present in department-portal-base, but no one is using dev containers anymore so `--skip-ssl` now causes an sql alchemy error. It's now deprecated in the newer mysql version that runs in the non-container WSL setup, and is entirely redundant.

Fixes #add issue number
Making the issue would take longer than fixing the problem. 

## Changes

- Removed every instance of `--skip-ssl` from `reset_database.sh`

## Testing

- Ensure no other files were changed and that the only change is in `reset_database.sh`
- Ensure that the non-container WSL setup does not require `--skip-ssl`