### PR TITLE
Standardizing Allocation Logic

### DIFF
--- a/app/logic/allocationManager.py
+++ b/app/logic/allocationManager.py
@@ -7,21 +7,18 @@ from app.models.term import *
 from app.models.formHistory import FormHistory
 
 
-def getAllocation(termCode: int, dept: int):
-    academicYearCode = int(str(termCode)[:5] + "00")
+def getAllocation(termCode: int, dept: int, isFinal = True):
+    '''
+    This function returns a peewee object containing the selected allocation for given 
+    department and term. If you want the pending allocation, pass in False for isFinal.
+    '''
+    academicYearCode = int(str(termCode)[:4] + "00")
     allocationObject = Allocation.select().where(
         Allocation.termCode.in_([termCode,academicYearCode]),
         Allocation.department == dept, 
-        Allocation.isFinal == True).dicts().get()
-    return allocationObject # returns peewee object containing the current allocation for given department
+        Allocation.isFinal == isFinal).dicts().get()
+    return allocationObject 
 
-def getAllocationNonFinal(termCode: int, dept: int):
-    academicYearCode = int(str(termCode)[:5] + "00")
-    allocationObject = Allocation.select().where(
-        Allocation.termCode.in_([termCode,academicYearCode]),
-        Allocation.department == dept, 
-        Allocation.isFinal == False).dicts().get()
-    return allocationObject # returns peewee object containing the pending allocation for given department (I think?)
 
 def getTotalAllocations(termCode: int, dept: int):
     allocationObject = getAllocation(termCode, dept)
@@ -43,7 +40,7 @@ def countContracts(jobType: str, weeklyContractHours: int, termCode: int, dept: 
     For example, countContracts('secondary', 5, 202511, 1) returns the number of secondary 
     5-hour positions in the CS department for the 2025 Fall term.
     '''
-    academicYearCode = int(str(termCode)[:5] + "00") 
+    academicYearCode = int(str(termCode)[:4] + "00") 
     lsfCountPositions = FormHistory.select(
                             ).join(LaborStatusForm
                             ).join(Department
@@ -62,9 +59,9 @@ def getContractedAllocations(termCode: int, dept: int):
     This function returns a dictionary with a breakdown of all types of contracts 
     for the given department and term in the form of a dictionary.
     '''
-    academicYearCode = int(str(termCode)[:5] + "00")
+    academicYearCode = int(str(termCode)[:4] + "00")
     allocationObject = getAllocation(termCode, dept)
-    break_allocation = FormHistory.select(
+    breakAllocation = FormHistory.select(
         LaborStatusForm.department,
         LaborStatusForm.termCode,
         fn.SUM(LaborStatusForm.contractHours).alias('total_hours')
@@ -84,7 +81,7 @@ def getContractedAllocations(termCode: int, dept: int):
     
     breakSum = {"total_hours": 0}
     if dept:
-        for row in break_allocation:
+        for row in breakAllocation:
             if row["department"] == dept:
                 breakSum = row
                 break
@@ -97,8 +94,9 @@ def getContractedAllocations(termCode: int, dept: int):
     "used_20": countContracts("Primary", "20", termCode, dept),
     "used_5_sec": countContracts("Secondary", "5", termCode, dept),
     "used_10_sec": countContracts("Secondary", "10", termCode, dept),
-    "used_total": 0,  # all contracts with weekly hours, i.e. primaries + secondaries (not break contracts)
+    "used_primaries": sum(list(usedPositions.values())[:4]),
+    "used_secondaries": sum(list(usedPositions.values())[4:6]),
+    "used_total": sum(list(usedPositions.values())[:6]),  # all contracts with weekly hours, i.e. primaries + secondaries (not break contracts)
     "break_hours": breakSum["total_hours"]  # all break hours contracted (but not necessarily worked)
     }
-    usedPositions["used_total"] = sum(list(usedPositions.values())[:7])
     return usedPositions

--- a/app/logic/allocationManager.py
+++ b/app/logic/allocationManager.py
@@ -1,0 +1,104 @@
+from peewee import JOIN
+
+from app.models.allocation import Allocation
+from app.models.laborStatusForm import * 
+from app.models.department import *
+from app.models.term import *
+from app.models.formHistory import FormHistory
+
+
+def getAllocation(termCode: int, dept: int):
+    academicYearCode = int(str(termCode)[:5] + "00")
+    allocationObject = Allocation.select().where(
+        Allocation.termCode.in_([termCode,academicYearCode]),
+        Allocation.department == dept, 
+        Allocation.isFinal == True).dicts().get()
+    return allocationObject # returns peewee object containing the current allocation for given department
+
+def getAllocationNonFinal(termCode: int, dept: int):
+    academicYearCode = int(str(termCode)[:5] + "00")
+    allocationObject = Allocation.select().where(
+        Allocation.termCode.in_([termCode,academicYearCode]),
+        Allocation.department == dept, 
+        Allocation.isFinal == False).dicts().get()
+    return allocationObject # returns peewee object containing the pending allocation for given department (I think?)
+
+def getTotalAllocations(termCode: int, dept: int):
+    allocationObject = getAllocation(termCode, dept)
+    allocationDict = {"primary_10": allocationObject["primary_10"],
+                    "primary_12": allocationObject["primary_12"],
+                    "primary_15": allocationObject["primary_15"],
+                    "primary_20": allocationObject["primary_20"],
+                    "secondary_5": allocationObject["secondary_5"],
+                    "secondary_10": allocationObject["secondary_10"],
+                    "breakHours": allocationObject["breakHours"],
+                    "totalPrimaries": (allocationObject["primary_10"] + allocationObject["primary_12"] + allocationObject["primary_15"] + allocationObject["primary_20"]),
+                    "totalSecondaries": (allocationObject["secondary_5"] + allocationObject["secondary_10"]),
+                    "totalAllocations": (allocationObject["primary_10"] + allocationObject["primary_12"] + allocationObject["primary_15"] + allocationObject["primary_20"] + allocationObject["secondary_5"] + allocationObject["secondary_10"] )}
+    return allocationDict 
+
+def countContracts(jobType: str, weeklyContractHours: int, termCode: int, dept: int):
+    '''
+    This function counts the number of positions of a given type in a given department.
+    For example, countContracts('secondary', 5, 202511, 1) returns the number of secondary 
+    5-hour positions in the CS department for the 2025 Fall term.
+    '''
+    academicYearCode = int(str(termCode)[:5] + "00") 
+    lsfCountPositions = FormHistory.select(
+                            ).join(LaborStatusForm
+                            ).join(Department
+                            ).where(
+                                FormHistory.historyType == "Labor Status Form",
+                                FormHistory.status.in_(["Approved", "Pending", "Pre-Student Approval"]),
+                                LaborStatusForm.termCode.in_([termCode,academicYearCode]),
+                                LaborStatusForm.jobType == jobType, # 'primary' or 'secondary'
+                                LaborStatusForm.weeklyHours == weeklyContractHours, # 5, 10, 12, 15, or 20
+                                Department.departmentID == dept,
+                            ).count()
+    return lsfCountPositions 
+
+def getContractedAllocations(termCode: int, dept: int):
+    '''
+    This function returns a dictionary with a breakdown of all types of contracts 
+    for the given department and term in the form of a dictionary.
+    '''
+    academicYearCode = int(str(termCode)[:5] + "00")
+    allocationObject = getAllocation(termCode, dept)
+    break_allocation = FormHistory.select(
+        LaborStatusForm.department,
+        LaborStatusForm.termCode,
+        fn.SUM(LaborStatusForm.contractHours).alias('total_hours')
+    ).join(
+        LaborStatusForm,
+        on=(FormHistory.formID == LaborStatusForm.laborStatusFormID),
+    ).join(
+        Term,
+        on = (LaborStatusForm.termCode == Term.termCode )
+    ).where(
+        (FormHistory.historyType == "Labor Status Form") &
+        (FormHistory.status == "Approved") & 
+        (LaborStatusForm.termCode.in_([termCode,academicYearCode]))
+    ).group_by(
+        LaborStatusForm.department, 
+        LaborStatusForm.termCode).dicts()
+    
+    breakSum = {"total_hours": 0}
+    if dept:
+        for row in break_allocation:
+            if row["department"] == dept:
+                breakSum = row
+                break
+    
+    # dictionary definition:
+    usedPositions = {
+    "used_10": countContracts("Primary", "10", termCode, dept),
+    "used_12": countContracts("Primary", "12", termCode, dept),
+    "used_15": countContracts("Primary", "15", termCode, dept),
+    "used_20": countContracts("Primary", "20", termCode, dept),
+    "used_5_sec": countContracts("Secondary", "5", termCode, dept),
+    "used_10_sec": countContracts("Secondary", "10", termCode, dept),
+    "used_total": 0,  # all contracts with weekly hours, i.e. primaries + secondaries (not break contracts)
+    "break_hours": breakSum["total_hours"]  # all break hours contracted (but not necessarily worked)
+    }
+    usedPositions["used_total"] = sum(list(usedPositions.values())[:7])
+    return usedPositions

--- a/app/logic/allocationManager.py
+++ b/app/logic/allocationManager.py
@@ -21,6 +21,9 @@ def getAllocation(termCode: int, dept: int, isFinal = True):
 
 
 def getTotalAllocations(termCode: int, dept: int):
+    '''
+    This function returns a dictionary representation of the given department's allocation for the given term.
+    '''
     allocationObject = getAllocation(termCode, dept)
     allocationDict = {"primary_10": allocationObject["primary_10"],
                     "primary_12": allocationObject["primary_12"],
@@ -94,9 +97,12 @@ def getContractedAllocations(termCode: int, dept: int):
     "used_20": countContracts("Primary", "20", termCode, dept),
     "used_5_sec": countContracts("Secondary", "5", termCode, dept),
     "used_10_sec": countContracts("Secondary", "10", termCode, dept),
-    "used_primaries": sum(list(usedPositions.values())[:4]),
-    "used_secondaries": sum(list(usedPositions.values())[4:6]),
-    "used_total": sum(list(usedPositions.values())[:6]),  # all contracts with weekly hours, i.e. primaries + secondaries (not break contracts)
+    "used_primaries": 0,
+    "used_secondaries": 0,
+    "used_total": 0,  # all contracts with weekly hours, i.e. primaries + secondaries (not break contracts)
     "break_hours": breakSum["total_hours"]  # all break hours contracted (but not necessarily worked)
     }
+    usedPositions["used_primaries"] = sum(list(usedPositions.values())[:4])
+    usedPositions["used_secondaries"] = sum(list(usedPositions.values())[4:6])
+    usedPositions["used_total"] = sum(list(usedPositions.values())[:6])
     return usedPositions

--- a/tests/code/test_allocationManger.py
+++ b/tests/code/test_allocationManger.py
@@ -1,0 +1,178 @@
+import pytest
+
+from app.models import mainDB
+from app.models.allocation import Allocation
+from app.models.laborStatusForm import * 
+from app.models.department import *
+from app.models.term import *
+from app.models.formHistory import FormHistory
+from app.models.student import *
+from app.models.supervisor import * 
+from app.models.historyType import * 
+from app.models.user import User
+
+from app.logic.allocationManager import *
+
+
+@pytest.fixture
+def testUser():
+    user = User.create(
+        userID = "B12323435",
+        username="test"
+    )
+    yield user
+    user.delete_instance()
+
+@pytest.fixture
+def testDepartment():
+    #create
+    department = Department.create(
+        departmentID            = 9999,
+        DEPT_NAME               = "Testing Department of Tests",
+        ACCOUNT                 = 6740,
+        ORG                     = 9284,
+        departmentCompliance    = True,
+        isActive                = True)
+
+    yield department
+
+    #destroyLabor Status
+    department.delete_instance()
+
+@pytest.fixture
+def testTerm():
+    #create
+    term = Term.create(termCode = 200600)
+    yield term
+
+    #destroy
+    term.delete_instance()
+
+@pytest.fixture
+def testAllocation(testDepartment,testTerm):
+    #create
+    allocation = Allocation.create(
+        termCode       = testTerm.termCode,
+        department     = testDepartment.departmentID,
+        isFinal        = True,
+        approvedOn     = None,
+        approvedBy     = None,
+        justification  = "broski",
+        primary_10     = 3,
+        primary_12     = 7,
+        primary_15     = 6,
+        primary_20     = 1,
+        secondary_5    = 2,
+        secondary_10   = 0,
+        breakHours     = 556)
+
+    yield allocation
+
+    #destroy
+    allocation.delete_instance()
+
+@pytest.fixture
+def testStudent():
+    student_data = Student.create(
+    ID              = "B12323435"		        # B-number
+    )
+    yield student_data
+
+    #destroy
+    student_data.delete_instance()
+
+@pytest.fixture
+def testSupervisor():
+    supervisor_data = Supervisor.create(
+    ID              = "B12323435"		        # B-number
+    )
+    yield supervisor_data
+    #destroy
+    supervisor_data.delete_instance()
+
+@pytest.fixture
+def testHistoryType():
+    History_data = HistoryType.create(
+        historyTypeName = "Labor Status Form"
+    )
+    yield History_data
+    #destroy
+    History_data.delete_instance()
+
+@pytest.fixture
+def testLaborStatusForm(testStudent,testSupervisor,testDepartment,testTerm):
+    laborStatusForm = LaborStatusForm.create(
+    studentName                 = "John Doe",
+    laborStatusFormID           = 8989,
+    termCode                    = testTerm.termCode,      
+    studentSupervisee           = testStudent.ID,
+    supervisor_id               = testSupervisor.ID,
+    department                  = testDepartment.departmentID,
+    jobType                     = "Primary",
+    WLS                         = 1,
+    POSN_TITLE                  = "Break Worker",
+    POSN_CODE                   = "S61412",
+    contractHours               = 500,
+    weeklyHours                 = 15,
+    startDate                   = "2025-04-01",
+    endDate                     = "2025-09-01",
+    supervisorNotes             = None,
+    laborDepartmentNotes        = None,
+    studentConfirmation         = True,
+    confirmationToken           = None,
+    studentExpirationDate       = True,
+    studentResponseDate         = True,
+    )
+
+    yield laborStatusForm
+      #destroy
+    laborStatusForm.delete_instance()
+
+@pytest.fixture
+def testFormHistory(testLaborStatusForm,testUser):
+    formHistory = FormHistory.create(
+        formHistoryID = 8989,
+        formID        = testLaborStatusForm,      # pass the model instance
+        historyType   = "Labor Status Form", 
+        createdBy     = testUser.userID,
+        createdDate   = "2025-03-02",
+        status        = "Approved",
+    )
+    yield formHistory
+    formHistory.delete_instance()
+
+@pytest.mark.integration
+def test_getAllocation(testDepartment, testTerm, testAllocation):
+    
+    allocation = getAllocation(testTerm.termCode, testDepartment)
+    assert allocation["primary_10"] == 3
+    assert allocation["primary_12"] == 7
+    assert allocation["primary_15"] == 6
+    assert allocation["primary_20"] == 1
+    assert allocation["secondary_5"] == 2
+    assert allocation["secondary_10"] == 0
+    assert allocation["breakHours"] == 556
+
+@pytest.mark.integration
+def test_getTotalAllocations(testDepartment, testTerm, testAllocation):
+    totalAllocation = getTotalAllocations(testTerm.termCode,testDepartment)
+    assert totalAllocation['totalPrimaries'] == 17
+    assert totalAllocation['totalSecondaries'] == 2
+    assert totalAllocation['totalAllocations'] == 19
+
+@pytest.mark.integration
+def test_countContracts(testLaborStatusForm, testTerm, testDepartment, testFormHistory):
+    contractsCounts = countContracts(testLaborStatusForm.jobType,testLaborStatusForm.weeklyHours,testTerm.termCode,testDepartment.departmentID)
+    assert contractsCounts == 1
+
+@pytest.mark.integration
+def test_getContractedAllocations(testLaborStatusForm, testTerm, testDepartment, testFormHistory,testAllocation):
+    contractedAllocation = getContractedAllocations(testTerm.termCode,testDepartment.departmentID)
+    assert contractedAllocation['used_10'] == 0
+    assert contractedAllocation['used_12'] == 0
+    assert contractedAllocation['used_15'] == 1
+    assert contractedAllocation['used_20'] == 0
+    assert contractedAllocation['used_5_sec'] == 0
+    assert contractedAllocation['used_10_sec'] == 0
+    assert contractedAllocation['used_total'] == 1
+    assert contractedAllocation['break_hours'] == 500

--- a/tests/code/test_allocationManger.py
+++ b/tests/code/test_allocationManger.py
@@ -72,6 +72,29 @@ def testAllocation(testDepartment,testTerm):
     allocation.delete_instance()
 
 @pytest.fixture
+def testPendingAllocation(testDepartment,testTerm):
+    #create
+    allocation = Allocation.create(
+        termCode       = testTerm.termCode,
+        department     = testDepartment.departmentID,
+        isFinal        = False,
+        approvedOn     = None,
+        approvedBy     = None,
+        justification  = "pending broski",
+        primary_10     = 4,
+        primary_12     = 8,
+        primary_15     = 7,
+        primary_20     = 2,
+        secondary_5    = 3,
+        secondary_10   = 1,
+        breakHours     = 557)
+
+    yield allocation
+
+    #destroy
+    allocation.delete_instance()
+
+@pytest.fixture
 def testStudent():
     student_data = Student.create(
     ID              = "B12323435"		        # B-number
@@ -89,15 +112,6 @@ def testSupervisor():
     yield supervisor_data
     #destroy
     supervisor_data.delete_instance()
-
-@pytest.fixture
-def testHistoryType():
-    History_data = HistoryType.create(
-        historyTypeName = "Labor Status Form"
-    )
-    yield History_data
-    #destroy
-    History_data.delete_instance()
 
 @pytest.fixture
 def testLaborStatusForm(testStudent,testSupervisor,testDepartment,testTerm):
@@ -142,9 +156,10 @@ def testFormHistory(testLaborStatusForm,testUser):
     formHistory.delete_instance()
 
 @pytest.mark.integration
-def test_getAllocation(testDepartment, testTerm, testAllocation):
+def test_getAllocation(testDepartment, testTerm, testAllocation, testPendingAllocation):
     
     allocation = getAllocation(testTerm.termCode, testDepartment)
+    assert allocation["justification"] == "broski"
     assert allocation["primary_10"] == 3
     assert allocation["primary_12"] == 7
     assert allocation["primary_15"] == 6
@@ -152,6 +167,16 @@ def test_getAllocation(testDepartment, testTerm, testAllocation):
     assert allocation["secondary_5"] == 2
     assert allocation["secondary_10"] == 0
     assert allocation["breakHours"] == 556
+
+    allocation = getAllocation(testTerm.termCode, testDepartment, False)
+    assert allocation["justification"] == "pending broski"
+    assert allocation["primary_10"] == 4
+    assert allocation["primary_12"] == 8
+    assert allocation["primary_15"] == 7
+    assert allocation["primary_20"] == 2
+    assert allocation["secondary_5"] == 3
+    assert allocation["secondary_10"] == 1
+    assert allocation["breakHours"] == 557
 
 @pytest.mark.integration
 def test_getTotalAllocations(testDepartment, testTerm, testAllocation):
@@ -162,7 +187,7 @@ def test_getTotalAllocations(testDepartment, testTerm, testAllocation):
 
 @pytest.mark.integration
 def test_countContracts(testLaborStatusForm, testTerm, testDepartment, testFormHistory):
-    contractsCounts = countContracts(testLaborStatusForm.jobType,testLaborStatusForm.weeklyHours,testTerm.termCode,testDepartment.departmentID)
+    contractsCounts = countContracts(testLaborStatusForm.jobType, testLaborStatusForm.weeklyHours, testTerm.termCode, testDepartment.departmentID)
     assert contractsCounts == 1
 
 @pytest.mark.integration
@@ -174,5 +199,9 @@ def test_getContractedAllocations(testLaborStatusForm, testTerm, testDepartment,
     assert contractedAllocation['used_20'] == 0
     assert contractedAllocation['used_5_sec'] == 0
     assert contractedAllocation['used_10_sec'] == 0
+
+    assert contractedAllocation['used_primaries'] == 1
+    assert contractedAllocation['used_secondaries'] == 0
     assert contractedAllocation['used_total'] == 1
+
     assert contractedAllocation['break_hours'] == 500


### PR DESCRIPTION
## Issue Description

There were a few different implementations that all performed very similar functions, namely accessing the Allocation of a department, as well as accessing how much the department has "used" of their allocation.

## Changes

- Added `allocationManager.py` logic file 
- Added `test_allocationManger.py` testing file

## Testing

- Run the testing file with `tests/run_tests.sh tests/code/test_allocationManger.py`