### PR TITLE
Create Logic to Notify Academic Advisors of Overloads

### DIFF
--- a/app/logic/emailHandler.py
+++ b/app/logic/emailHandler.py
@@ -175,7 +175,8 @@ class emailHandler():
         self.checkRecipient(
             studentEmailPurpose=studentTemplate.purpose,
             emailPurpose=supervisorTemplate.purpose,
-            secondaryEmailPurpose=None
+            secondaryEmailPurpose=None,
+            advisorEmailPurpose=None
         )
 
     def laborStatusFormApproved(self):

--- a/app/logic/emailHandler.py
+++ b/app/logic/emailHandler.py
@@ -259,10 +259,6 @@ class emailHandler():
                       "Labor Overload Form Approved For Supervisor",
                       "Labor Overload Form Approved For Financial Aid",
                       "Labor Overload Form Approved For Academic Advisor")
-    # Ignore and remove later.    
-    #def LaborOverLoadFormApprovedAdvisorEmail(self):
-        #""" This email is sent to the student's academic advisor when the overload form is approved by the labor office and is waiting for their approval. """
-       #self.checkRecipient(False, False, "Labor Overload Form Approved and sent to Advisor")
 
     def LaborOverLoadFormRejected(self):
         self.checkRecipient("Labor Overload Form Rejected For Student",

--- a/app/logic/emailHandler.py
+++ b/app/logic/emailHandler.py
@@ -29,7 +29,8 @@ class emailHandler():
         self.studentEmail = self.student.STU_EMAIL
         self.creatorEmail = self.formHistory.createdBy.email
         self.supervisorEmail = self.laborStatusForm.supervisor.EMAIL
-        self.advisorEmail = self.student.ADVISOR
+        self.advisorEmail =  self.student.ADVISOR
+        print ("self.advisorEmail: ", self.advisorEmail)
         self.date = self.laborStatusForm.startDate.strftime("%m/%d/%Y")
         self.weeklyHours = str(self.laborStatusForm.weeklyHours)
         self.contractHours = str(self.laborStatusForm.contractHours)
@@ -96,7 +97,8 @@ class emailHandler():
 
     def send(self, message: Message):
         if app.config['ENV'] == 'production' or app.config['ALWAYS_SEND_MAIL']:
-
+            print("LOOKING AT MESSAGE")
+            print(message.html)
             # If we have set an override address
             if app.config['MAIL_OVERRIDE_ALL']:
                 message.html = "<b>Original message intended for {}.</b><br>".format(", ".join(message.recipients)) + message.html

--- a/app/logic/emailHandler.py
+++ b/app/logic/emailHandler.py
@@ -413,6 +413,7 @@ class emailHandler():
         form = form.replace("@@WLS@@", self.laborStatusForm.WLS)
         form = form.replace("@@Term@@", self.term.termName)
         form = form.replace("@@Admin@@", self.adminName)
+        form = form.replace("@@Academic Advisor@@", self.advisorEmail)
 
         if self.formHistory.rejectReason:
             form = form.replace("@@RejectReason@@", self.formHistory.rejectReason)

--- a/app/logic/emailHandler.py
+++ b/app/logic/emailHandler.py
@@ -388,7 +388,7 @@ class emailHandler():
             recipient = 'Admin'
         elif sendTo == "Academic Advisor":
             message = Message(template.subject,
-                recipients=[self.advisorEmail]) # Change this to academic advisor email class once we have that set up.
+                recipients=[self.advisorEmail])
             recipient = 'Academic Advisor'
         message.html = formTemplate
 

--- a/app/logic/emailHandler.py
+++ b/app/logic/emailHandler.py
@@ -29,6 +29,7 @@ class emailHandler():
         self.studentEmail = self.student.STU_EMAIL
         self.creatorEmail = self.formHistory.createdBy.email
         self.supervisorEmail = self.laborStatusForm.supervisor.EMAIL
+        self.advisorEmail = self.student.ADVISOR
         self.date = self.laborStatusForm.startDate.strftime("%m/%d/%Y")
         self.weeklyHours = str(self.laborStatusForm.weeklyHours)
         self.contractHours = str(self.laborStatusForm.contractHours)
@@ -256,7 +257,12 @@ class emailHandler():
     def LaborOverLoadFormApproved(self):
         self.checkRecipient("Labor Overload Form Approved For Student",
                       "Labor Overload Form Approved For Supervisor",
-                      "Labor Overload Form Approved For Financial Aid")
+                      "Labor Overload Form Approved For Financial Aid",
+                      "Labor Overload Form Submitted For Academic Advisor")
+    # Ignore and remove later.    
+    def LaborOverLoadFormApprovedAdvisorEmail(self):
+        """ This email is sent to the student's academic advisor when the overload form is approved by the labor office and is waiting for their approval. """
+        self.checkRecipient(False, False, "Labor Overload Form Approved and sent to Advisor")
 
     def LaborOverLoadFormRejected(self):
         self.checkRecipient("Labor Overload Form Rejected For Student",
@@ -321,7 +327,7 @@ class emailHandler():
     #
     #     self.send(message)
 
-    def checkRecipient(self, studentEmailPurpose=False, emailPurpose=False, secondaryEmailPurpose=False):
+    def checkRecipient(self, studentEmailPurpose=False, emailPurpose=False, secondaryEmailPurpose=False, advisorEmailPurpose=False):
         """
         This method will take in two to three inputs of email purposes. An email to the student is always sent.
         The method then checks whether to send the email to only the primary or both the primary and secondary supervisors.
@@ -344,7 +350,9 @@ class emailHandler():
                     self.sendEmail(primaryEmail, "Labor Office")
                 else:
                     self.sendEmail(primaryEmail, "supervisor")
-
+        if advisorEmailPurpose:
+            advisorEmail = EmailTemplate.get(EmailTemplate.purpose == advisorEmailPurpose)
+            self.sendEmail(advisorEmail, "Academic Advisor")
     # Depending on the parameter 'sendTo', this method will send the email either to the Primary, Secondary, or the Student
     def sendEmail(self, template, sendTo):
         formTemplate = template.body
@@ -378,6 +386,11 @@ class emailHandler():
             message = Message(template.subject,
                 recipients=[self.adminEmail])
             recipient = 'Admin'
+        # Ignore and remove later.
+        elif sendTo == "Academic Advisor":
+            message = Message(template.subject,
+                recipients=[self.advisorEmail]) # Change this to academic advisor email class once we have that set up.
+            recipient = 'Academic Advisor'
         message.html = formTemplate
 
         newEmailTracker = EmailTracker.create(

--- a/app/logic/emailHandler.py
+++ b/app/logic/emailHandler.py
@@ -386,7 +386,6 @@ class emailHandler():
             message = Message(template.subject,
                 recipients=[self.adminEmail])
             recipient = 'Admin'
-        # Ignore and remove later.
         elif sendTo == "Academic Advisor":
             message = Message(template.subject,
                 recipients=[self.advisorEmail]) # Change this to academic advisor email class once we have that set up.

--- a/app/logic/emailHandler.py
+++ b/app/logic/emailHandler.py
@@ -258,7 +258,7 @@ class emailHandler():
         self.checkRecipient("Labor Overload Form Approved For Student",
                       "Labor Overload Form Approved For Supervisor",
                       "Labor Overload Form Approved For Financial Aid",
-                      "Labor Overload Form Submitted For Academic Advisor")
+                      "Labor Overload Form Approved For Academic Advisor")
     # Ignore and remove later.    
     #def LaborOverLoadFormApprovedAdvisorEmail(self):
         #""" This email is sent to the student's academic advisor when the overload form is approved by the labor office and is waiting for their approval. """

--- a/app/logic/emailHandler.py
+++ b/app/logic/emailHandler.py
@@ -260,9 +260,9 @@ class emailHandler():
                       "Labor Overload Form Approved For Financial Aid",
                       "Labor Overload Form Submitted For Academic Advisor")
     # Ignore and remove later.    
-    def LaborOverLoadFormApprovedAdvisorEmail(self):
-        """ This email is sent to the student's academic advisor when the overload form is approved by the labor office and is waiting for their approval. """
-        self.checkRecipient(False, False, "Labor Overload Form Approved and sent to Advisor")
+    #def LaborOverLoadFormApprovedAdvisorEmail(self):
+        #""" This email is sent to the student's academic advisor when the overload form is approved by the labor office and is waiting for their approval. """
+       #self.checkRecipient(False, False, "Labor Overload Form Approved and sent to Advisor")
 
     def LaborOverLoadFormRejected(self):
         self.checkRecipient("Labor Overload Form Rejected For Student",

--- a/app/models/emailTemplate.py
+++ b/app/models/emailTemplate.py
@@ -15,14 +15,14 @@ class EmailTemplate (baseModel):
 #Emails in labor status form:
 #LSF
 #1:When labor status form is submitted: send to student
-#2:When LSF is approved: send to supervisor and student
+#2:When LSF is approved: send to supervisor and student and academic advisor
 #3:When LSF is rejected: send to supervisor and student
 #4:When LSF is adjusted: send to supervisor and student (?)
 #Pending
 #5:When a pending form is modified: send to supervisor and student
 #LRF
 #6:When labor release form is submitted: Send to student
-#7:When lrf is approved: send to supervisor and student
+#7:When lrf is approved: send to supervisor and student and academic advisor
 #8:When lrf is rejected: send to supervisor and student
 #Overload
 #9: When labor overload form submitted (by student): send to supervisor(??? and advisor???)

--- a/database/base_data.py
+++ b/database/base_data.py
@@ -390,7 +390,8 @@ emailtemps= [
                 "formType":"Labor Overload Form",
                 "action":"Approved",
                 "subject":"Labor Overload Form Approved",
-                "body":''' <p> An overload for <strong>@@Student@@</strong>, <strong>@@StudB@@</strong> has been approved.
+                "body":''' 
+                <p> An overload for <strong>@@Student@@</strong>, <strong>@@StudB@@</strong> has been approved.
                             ''',
                 "audience":"Academic Advisor"
                 },

--- a/database/base_data.py
+++ b/database/base_data.py
@@ -391,7 +391,7 @@ emailtemps= [
                 "action":"Approved",
                 "subject":"Labor Overload Form Approved",
                 "body":''' 
-                <p> An overload for <strong>@@Student@@</strong>, <strong>@@StudB@@</strong> has been approved.
+                <p> An overload for <strong>@@Student@@</strong>, <strong>@@StudB@@</strong> has been approved. </p>
                             ''',
                 "audience":"Academic Advisor"
                 },

--- a/database/base_data.py
+++ b/database/base_data.py
@@ -368,15 +368,6 @@ emailtemps= [
                 "audience":"Supervisor"
                 },
                 {
-                "purpose":"Labor Overload Form Approved For Academic Advisor",
-                "formType":"Labor Overload Form",
-                "action":"Submitted",
-                "subject":"Labor Overload Form Approved",
-                "body":'''
-                            ''',
-                "audience":"Academic Advisor"
-                },
-                {
                 "purpose":"Labor Overload Form Approved For Student",
                 "formType":"Labor Overload Form",
                 "action":"Approved",
@@ -393,6 +384,15 @@ emailtemps= [
                 "body":'''
                             ''',
                 "audience":"Supervisor"
+                },
+                {
+                "purpose":"Labor Overload Form Approved For Academic Advisor",
+                "formType":"Labor Overload Form",
+                "action":"Approved",
+                "subject":"Labor Overload Form Approved",
+                "body":''' <p> An overload for <strong>@@Student@@</strong>, <strong>@@StudB@@</strong> has been approved.
+                            ''',
+                "audience":"Academic Advisor"
                 },
                 {
                 "purpose":"Labor Overload Form Rejected For Student",

--- a/database/base_data.py
+++ b/database/base_data.py
@@ -368,10 +368,10 @@ emailtemps= [
                 "audience":"Supervisor"
                 },
                 {
-                "purpose":"Labor Overload Form Submitted For Academic Advisor",
+                "purpose":"Labor Overload Form Approved For Academic Advisor",
                 "formType":"Labor Overload Form",
                 "action":"Submitted",
-                "subject":"Labor Overload Form Submitted",
+                "subject":"Labor Overload Form Approved",
                 "body":'''
                             ''',
                 "audience":"Academic Advisor"

--- a/database/base_data.py
+++ b/database/base_data.py
@@ -368,6 +368,15 @@ emailtemps= [
                 "audience":"Supervisor"
                 },
                 {
+                "purpose":"Labor Overload Form Submitted For Academic Advisor",
+                "formType":"Labor Overload Form",
+                "action":"Submitted",
+                "subject":"Labor Overload Form Submitted",
+                "body":'''
+                            ''',
+                "audience":"Academic Advisor"
+                },
+                {
                 "purpose":"Labor Overload Form Approved For Student",
                 "formType":"Labor Overload Form",
                 "action":"Approved",

--- a/database/demo_data.py
+++ b/database/demo_data.py
@@ -553,7 +553,7 @@ LaborStatusForm.insert([{
 FormHistory.insert([{
             "formHistoryID": 2,
             "formID_id": "2",
-            "historyType_id": "Labor Status Form",
+            "historyType_id": "Labor Overload Form",
             "createdBy_id": 1,
             "createdDate": f"{current_year}-04-14",
             "status_id": "Pending"


### PR DESCRIPTION
## IMPORTANT
The code currently lacks access to academic advisors' emails from the Tracy database and thus cannot be completed until Labor is contacted. The only information currently in Tracy is advisor names.

## Issue Description
When an overload form is approved, we should notify academic advisors.

Fixes issue #355 

## Changes
- Created a template for "Labor Overload Form Approved For Academic Advisor" in base_data.py
- Implemented "Labor Overload Form Approved For Academic Advisor" as an email purpose into emailHandler.py.
- Implemented logic to pull "Labor Overload Form Approved For Academic Advisor" Template into emailHandler.py.
- Implemented logic for sending an email using the advisorEmailPurpose.

## Testing
- Follow these steps to gain email access in Slack (These are also in the README.md.):
  - There are a couple of options to test email handling. By default, all emails will be logged to the slack channel #labor-emails in the bereacs workspace.

  - If you want to test with actual emails, use an email other than outlook to test email handler. This setup is specific to gmail, but should work with any other email that allows you to make app passwords

  1. Set up two factor authentication on your Gmail (Security Settings)
  2. Create an App Password through your Gmail. This 16 character password can only be viewed once, so make sure to save it. (NOTE: You won't have the option to create an app password unless step one is completed)
  3. Inside of your secret_config.yaml file set the MAIL_USERNAME and MAIL_DEFAULT_SENDER as your Gmail, set the MAIL_PASSWORD as your new app password as, and set ALWAYS_SEND_MAIL as True. If you want emails to go to their real recipients, remove MAIL_OVERRIDE_ALL from your config or set it to "".
  4. For testing purposes, change the email of the student and supervisor to match another email that can receive your test emails (or you can use MAIL_OVERRIDE_ALL to send everything to the address specified.

- Ensure you are on the development APP_ENV.
- Reset the database using the production backup information.
- Follow these steps in MySQL to add a fake overload form:
  - **MySQL access**: mysql -u root -proot lsf
  - **Insert Overload Form into Database**: INSERT INTO emailtemplate (purpose, formType, action, subject, body, audience) VALUES ('Labor Overload Form Approved For Academic Advisor', 'Labor Overload Form', 'Approved', 'Labor Overload Form Approved', '', 'Academic Advisor');
  - Type exit into the terminal.
- Flask run the program.
- On the sidebar, open the Administration accordion and click Pending Forms
- On the Pending Forms page:
  - Select the Pending Overload Forms tab.
  - Click on the action button of any form.
  - Select the manage button on the Actions dropdown.
  - Click the approve toggle, write a description, and click submit.
  - Wait and make sure the Labor Overload form closes. If it does not check the terminal for errors and return to the MySQL or setup steps for email access.
 - Check Slack to see if you have received the email. (It will come with two other emails).

## Issues with Current Code
- When the email is sent, nothing appears in the body.
- The previously noted academic advisor email issue.